### PR TITLE
feat: add /api/docs Swagger docs

### DIFF
--- a/packages/theme-wizard-server/package.json
+++ b/packages/theme-wizard-server/package.json
@@ -36,6 +36,7 @@
     "vitest": "3.2.4"
   },
   "dependencies": {
+    "@hono/swagger-ui": "0.5.2",
     "@hono/zod-openapi": "1.1.3",
     "@nl-design-system-community/css-scraper": "workspace:*",
     "hono": "4.9.9",

--- a/packages/theme-wizard-server/src/schemas/client-error.ts
+++ b/packages/theme-wizard-server/src/schemas/client-error.ts
@@ -2,28 +2,25 @@ import { z } from '@hono/zod-openapi';
 
 export const clientErrorSchema = z
   .object({
-    error: z.object({
-      name: z.string(),
-      message: z.string(),
-    }),
-    issues: z.optional(
-      z.array(
-        z.object({
-          name: z.string(),
-          message: z.string(),
-          path: z.optional(z.string()),
-        }),
-      ),
+    errors: z.array(
+      z.object({
+        name: z.string(),
+        message: z.string(),
+      }),
     ),
     ok: false,
   })
   .openapi({
     example: {
-      error: {
-        name: 'InvalidUrlError',
-        message: 'This URL is not valid',
-      },
+      errors: [
+        {
+          name: 'InvalidUrlError',
+          message: 'This URL is not valid',
+        },
+      ],
       ok: false,
     },
     type: 'object',
   });
+
+export type ClientError = z.infer<typeof clientErrorSchema>;

--- a/packages/theme-wizard-server/src/schemas/server-error.ts
+++ b/packages/theme-wizard-server/src/schemas/server-error.ts
@@ -2,14 +2,20 @@ import { z } from '@hono/zod-openapi';
 
 export const serverErrorSchema = z
   .object({
-    name: z.optional(z.string()),
-    message: z.string(),
+    error: z.object({
+      name: z.optional(z.string()),
+      message: z.string(),
+    }),
     ok: z.literal(false),
   })
   .openapi({
     example: {
-      message: 'Something went wrong',
+      error: {
+        message: 'Something went wrong',
+      },
       ok: false,
     },
     type: 'object',
   });
+
+export type ServerError = z.infer<typeof serverErrorSchema>;

--- a/packages/theme-wizard-server/src/scraping-error-handler.test.ts
+++ b/packages/theme-wizard-server/src/scraping-error-handler.test.ts
@@ -15,7 +15,15 @@ describe('withScrapingErrorHandler', () => {
     const response = await app.request('/test');
 
     expect(response.status).toBe(400);
-    expect(await response.text()).toBe('Scraping Error');
+    expect(await response.json()).toEqual({
+      errors: [
+        {
+          name: 'ScrapingError',
+          message: 'Scraping Error',
+        },
+      ],
+      ok: false,
+    });
   });
 
   test('converts unknown errors to 500', async () => {
@@ -29,7 +37,12 @@ describe('withScrapingErrorHandler', () => {
     const response = await app.request('/test');
 
     expect(response.status).toBe(500);
-    expect(await response.text()).toBe('encountered a scraping error');
+    expect(await response.json()).toEqual({
+      error: {
+        message: 'encountered a scraping error',
+      },
+      ok: false,
+    });
   });
 
   test('returns response when no error', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
 
   packages/theme-wizard-server:
     dependencies:
+      '@hono/swagger-ui':
+        specifier: 0.5.2
+        version: 0.5.2(hono@4.9.9)
       '@hono/zod-openapi':
         specifier: 1.1.3
         version: 1.1.3(hono@4.9.9)(zod@4.1.12)
@@ -716,6 +719,11 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hono/swagger-ui@0.5.2':
+    resolution: {integrity: sha512-7wxLKdb8h7JTdZ+K8DJNE3KXQMIpJejkBTQjrYlUWF28Z1PGOKw6kUykARe5NTfueIN37jbyG/sBYsbzXzG53A==}
+    peerDependencies:
+      hono: '*'
 
   '@hono/vite-dev-server@0.21.1':
     resolution: {integrity: sha512-HRqwsgbbTJ4a0Jiq7aB5aWb12upHtXGSU6nh+LuokTaB6VzFfiIkUBRUdAtRbGV7a3EWehoGhAbVZZjfKgR3uw==}
@@ -6482,6 +6490,10 @@ snapshots:
   '@fastify/busboy@2.1.1': {}
 
   '@hono/node-server@1.19.5(hono@4.9.9)':
+    dependencies:
+      hono: 4.9.9
+
+  '@hono/swagger-ui@0.5.2(hono@4.9.9)':
     dependencies:
       hono: 4.9.9
 


### PR DESCRIPTION
closes #57

- API Docs op `/api/docs`
- Server (500) en client (400) errors zijn nu JSON volgens een vast schema

<img width="1643" height="1293" alt="De swagger docs pagina met een van de endpoints getest" src="https://github.com/user-attachments/assets/4a718fbb-1d18-42db-88ca-b28263f4f038" />
