### PR TITLE
chore: provide all coverage data to codecov in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,8 @@ jobs:
       - name: Test
         run: |
           pnpm run test-coverage
-          pnpm build
-          pnpm test-build
+          pnpm run build
+          pnpm run test-build
 
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1


### PR DESCRIPTION
closes #36

- [x] Vergelijkt huidige coverage met `main` -> https://github.com/nl-design-system/theme-wizard/pull/70#issuecomment-3415199620