### PR TITLE
perf: make StrictThemeSchema ~22x faster

### DIFF
--- a/packages/design-tokens-schema/src/token-reference.ts
+++ b/packages/design-tokens-schema/src/token-reference.ts
@@ -33,13 +33,10 @@ type TokenLike = {
 };
 
 const isTokenLike = (obj: unknown): obj is TokenLike => {
-  // First check if it's a valid value object
   if (!isValueObject(obj)) return false;
-
-  // Check for required $type property (must be a string)
+  // Must have a `$type: string`
   if (!('$type' in obj) || typeof obj['$type'] !== 'string') return false;
-
-  // Check for required $value property (must be string or object)
+  // Must have a `$value`
   return '$value' in obj;
 };
 
@@ -77,7 +74,6 @@ export const isTokenWithRef = (
     throw new Error(`Invalid token reference: can not find "${refPath}"`);
   }
 
-  // Check that we're dealing with a token-like object
   if (!isTokenLike(referencedToken)) {
     throw new Error(
       `Invalid token reference: expected "{${refPath}}" to have a "$value" and "$type" property (referenced from "${path.join('.')}")`,


### PR DESCRIPTION
`isTokenWithRef` is a _hot path_: it's called very many times. And for each call we check against 1 or 2 Zod schemas which is very expensive to do. Since this validation needs to run a lot in the frontend it makes sense to optimise it. 

Before

<img width="396" height="386" alt="Screenshot 2025-11-13 at 10 08 03" src="https://github.com/user-attachments/assets/3cd80f0f-df14-4421-9858-322946d9a707" />

After

<img width="405" height="319" alt="Screenshot 2025-11-13 at 10 07 52" src="https://github.com/user-attachments/assets/ee235d76-518b-4635-a261-f2ca7e095e60" />
