### PR TITLE
fix: ignore generated astro files in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import tseslint from 'typescript-eslint';
 
 export default defineConfig([
   // use the built-in globalIgnores utility to globally ignore files in the project
-  globalIgnores(['**/dist/', '**/build/', '**/coverage/']),
+  globalIgnores(['**/dist/', '**/build/', '**/coverage/', '**/.astro/']),
   {
     // Use the Perfectionist recommended/natural configuration for all possible JavaScript, TypeScript and JSX files
     name: 'perfectionist/recommended/natural',


### PR DESCRIPTION
Fixes the errors shown in the image. Somehow these only occur locally, not in CI.

<img width="1059" height="1207" alt="Terminal output of a `pnpm run lint` command. It shows 5 problems, all originating from various .astro files. Errors include 'Unexpected any' and 'no-empty-object-type'" src="https://github.com/user-attachments/assets/13e0b90b-e24a-4705-b4cd-9cc9fcda1e11" />
