### PR TITLE
chore(lint): add @eslint/plugin-eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import eslint from '@eslint/js';
 import json from '@eslint/json';
 import nlDesignSystemConfig from '@nl-design-system/eslint-config/configs/nl-design-system.config.mjs';
+import vitest from '@vitest/eslint-plugin';
 import prettier from 'eslint-config-prettier';
 import perfectionist from 'eslint-plugin-perfectionist';
 import react from 'eslint-plugin-react';
@@ -85,5 +86,29 @@ export default defineConfig([
   {
     name: 'eslint-plugin-zod-x',
     ...eslintPluginZodX.configs.recommended,
+  },
+  {
+    name: '@vitest',
+    files: ['**/*.test.ts'],
+    plugins: {
+      vitest,
+    },
+    rules: {
+      ...vitest.configs.recommended.rules,
+      'vitest/consistent-test-filename': 'error',
+      'vitest/consistent-test-it': [
+        'error',
+        {
+          fn: 'it',
+          withinDescribe: 'it',
+        },
+      ],
+      'vitest/consistent-vitest-vi': 'error', // error when calling `vitest.mock()` instead of `vi.mock()`
+      'vitest/no-focused-tests': ['warn', { fixable: false }], // Warn when using it.only(), do not auto-fix
+      'vitest/prefer-each': 'error', // prefer it.each([a, b])('test %s', (thing) => {})
+      'vitest/prefer-todo': 'warn', // warn when test has empty or no body
+      'vitest/valid-title': ['error', { allowArguments: true }],
+      'vitest/warn-todo': ['warn'],
+    },
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@eslint/json": "0.14.0",
     "@nl-design-system/eslint-config": "2.1.2",
     "@types/node": "22.19.0",
+    "@vitest/eslint-plugin": "1.4.3",
     "eslint": "9.39.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-perfectionist": "4.15.1",

--- a/packages/css-scraper/src/get-css.test.ts
+++ b/packages/css-scraper/src/get-css.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, vi, beforeEach, type Mock } from 'vitest';
+import { expect, describe, vi, beforeEach, Mock, it } from 'vitest';
 import { ForbiddenError, NotFoundError, ConnectionRefusedError, InvalidUrlError, TimeoutError } from './errors';
 import { getCssFromHtml, getImportUrls, getCssFile, getCssResources, getCss, getDesignTokens } from './get-css';
 
@@ -16,7 +16,7 @@ describe('getCssResources', () => {
     vi.clearAllMocks();
   });
 
-  test('get a CSS file directly (no further scraping', async () => {
+  it('get a CSS file directly (no further scraping', async () => {
     (fetch as Mock).mockResolvedValueOnce(CSS_FILE_REPONSE_MOCK);
     const result = await getCssResources('https://example.com/style.css');
     expect(result).toEqual([
@@ -28,7 +28,7 @@ describe('getCssResources', () => {
     ]);
   });
 
-  test('get remote CSS referenced in a <link> tag', async () => {
+  it('get remote CSS referenced in a <link> tag', async () => {
     // Mock the HTML request
     const mockHtml = `
       <html>
@@ -61,7 +61,7 @@ describe('getCssResources', () => {
     ]);
   });
 
-  test('get embedded CSS from a <style> tag', async () => {
+  it('get embedded CSS from a <style> tag', async () => {
     // Mock the HTML request
     const mockCss = 'a { color: blue; }';
     const mockHtml = `
@@ -88,7 +88,7 @@ describe('getCssResources', () => {
     ]);
   });
 
-  test('deep-fetch CSS from an @import rule', async () => {
+  it('deep-fetch CSS from an @import rule', async () => {
     // Mock the HTML request
     const mockCss = '@import url("./fonts.css");';
     const mockHtml = `
@@ -124,7 +124,7 @@ describe('getCssResources', () => {
     ]);
   });
 
-  test('fetch CSS from a remote source with relative path and <base> element in the HTML', async () => {
+  it('fetch CSS from a remote source with relative path and <base> element in the HTML', async () => {
     // Mock the HTML request
     const mockHtml = `
       <html>
@@ -158,7 +158,7 @@ describe('getCssResources', () => {
     ]);
   });
 
-  test('strips wyback machine toolbar', async () => {
+  it('strips wyback machine toolbar', async () => {
     // Mock the HTML request
     const mockCss = 'html { color: green; }';
     const mockHtml = `
@@ -206,11 +206,11 @@ describe('getCssResources', () => {
   });
 
   describe('errors', () => {
-    test('InvalidUrlError', async () => {
+    it('InvalidUrlError', async () => {
       await expect(getCssResources('')).rejects.toThrowError(InvalidUrlError);
     });
 
-    test('NotFoundError', async () => {
+    it('NotFoundError', async () => {
       (fetch as Mock).mockResolvedValueOnce({
         ok: false,
         status: 404,
@@ -219,7 +219,7 @@ describe('getCssResources', () => {
       await expect(getCssResources('http://example.com')).rejects.toThrowError(NotFoundError);
     });
 
-    test('ForbiddenError', async () => {
+    it('ForbiddenError', async () => {
       (fetch as Mock).mockResolvedValueOnce({
         ok: false,
         status: 403,
@@ -228,7 +228,7 @@ describe('getCssResources', () => {
       await expect(getCssResources('http://example.com')).rejects.toThrowError(ForbiddenError);
     });
 
-    test('ConnectionRefusedError', async () => {
+    it('ConnectionRefusedError', async () => {
       (fetch as Mock).mockResolvedValueOnce({
         ok: false,
         status: 400,
@@ -237,7 +237,7 @@ describe('getCssResources', () => {
       await expect(getCssResources('http://example.com')).rejects.toThrowError(ConnectionRefusedError);
     });
 
-    test('ConnectionRefusedError (localhost)', async () => {
+    it('ConnectionRefusedError (localhost)', async () => {
       (fetch as Mock).mockResolvedValueOnce({
         ok: false,
         status: 400,
@@ -246,7 +246,7 @@ describe('getCssResources', () => {
       await expect(getCssResources('http://localhost:8080')).rejects.toThrowError(ConnectionRefusedError);
     });
 
-    test('TimeoutError', async () => {
+    it('TimeoutError', async () => {
       (fetch as Mock).mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
       await expect(getCssResources('http://example.com/style.css', { timeout: 0 })).rejects.toThrowError(TimeoutError);
     });
@@ -254,7 +254,7 @@ describe('getCssResources', () => {
 });
 
 describe('getCss', () => {
-  test('concatenates resources', async () => {
+  it('concatenates resources', async () => {
     const mockCss = 'a { color: blue; }';
     (fetch as Mock).mockResolvedValueOnce(CSS_FILE_REPONSE_MOCK);
     const result = await getCss('example.com/style.css');
@@ -264,7 +264,7 @@ describe('getCss', () => {
 
 describe('getCssFromHtml', () => {
   describe('<style> tags', () => {
-    test('single style element', () => {
+    it('single style element', () => {
       const html = `
         <style>.my-css { color: red; }</style>
       `;
@@ -277,7 +277,7 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('multiple style elements', () => {
+    it('multiple style elements', () => {
       const html = `
         <style>.my-css { color: red; }</style>
         <p>Hello world</p>
@@ -297,12 +297,12 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('empty style tag', () => {
+    it('empty style tag', () => {
       const html = `<style></style>`;
       expect(getCssFromHtml(html, 'example.com')).toEqual([]);
     });
 
-    test('empty style tag with whitespace', () => {
+    it('empty style tag with whitespace', () => {
       const html = `<style> </style>`;
       expect(getCssFromHtml(html, 'example.com')).toEqual([]);
     });
@@ -314,7 +314,7 @@ describe('getCssFromHtml', () => {
     // - <base> element present: yes | no
     // - media: null | string
     // - rel: stylesheet | alternate stylesheet | etc
-    test('rel=stylesheet href=absolute', () => {
+    it('rel=stylesheet href=absolute', () => {
       expect(
         getCssFromHtml('<link rel="stylesheet" href="https://example.com/style.css">', 'https://example.com'),
       ).toEqual([
@@ -329,7 +329,7 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('rel="stylesheet alternate"', () => {
+    it('rel="stylesheet alternate"', () => {
       expect(
         getCssFromHtml('<link rel="stylesheet alternate" href="https://example.com/style.css">', 'https://example.com'),
       ).toEqual([
@@ -344,7 +344,7 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('rel="stylesheet media=(prefers-color-scheme: dark)"', () => {
+    it('rel="stylesheet media=(prefers-color-scheme: dark)"', () => {
       expect(
         getCssFromHtml(
           '<link rel="stylesheet" href="https://example.com/style.css" media="(prefers-color-scheme: dark)">',
@@ -363,7 +363,7 @@ describe('getCssFromHtml', () => {
     });
 
     describe('relative URLs', () => {
-      test('rel=stylesheet href=./style.css', () => {
+      it('rel=stylesheet href=./style.css', () => {
         expect(getCssFromHtml('<link rel="stylesheet" href="./style.css">', 'https://example.com')).toEqual([
           {
             css: undefined,
@@ -376,7 +376,7 @@ describe('getCssFromHtml', () => {
         ]);
       });
 
-      test('rel=stylesheet href=./style.css', () => {
+      it('rel=stylesheet href=../../style.css', () => {
         expect(
           getCssFromHtml('<link rel="stylesheet" href="../../style.css">', 'https://example.com/blog/post'),
         ).toEqual([
@@ -392,7 +392,7 @@ describe('getCssFromHtml', () => {
       });
     });
 
-    test('handles base64 encoded hrefs', () => {
+    it('handles base64 encoded hrefs', () => {
       const expectedCss = 'test {}';
       const href = `data:text/css;base64,${btoa(expectedCss)}`;
       const html = `<link rel="stylesheet" href="${href}">`;
@@ -410,7 +410,7 @@ describe('getCssFromHtml', () => {
   });
 
   describe('inline `style=".." attributes', () => {
-    test('a single element with a style attribute', () => {
+    it('a single element with a style attribute', () => {
       const html = `<p style="font-size: 20px; font-weight: bold;">I am h1</p>`;
       expect(getCssFromHtml(html, 'example.com')).toEqual([
         {
@@ -421,7 +421,7 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('multiple elements with a style attribute', () => {
+    it('multiple elements with a style attribute', () => {
       const html = `
         <p style="font-size: 20px;">I am h1</p>
         <marquee style="animation-duration: 60s;">WHIEEEEE</marquee>
@@ -435,7 +435,7 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('missing trailing ;', () => {
+    it('missing trailing ;', () => {
       const html = `
         <p style="font-size: 20px">I am h1</p>
         <marquee style="animation-duration: 60s;">WHIEEEEE</marquee>
@@ -449,12 +449,12 @@ describe('getCssFromHtml', () => {
       ]);
     });
 
-    test('empty attribute', () => {
+    it('empty attribute', () => {
       const html = '<p style="">test</p>';
       expect(getCssFromHtml(html, 'example.com')).toEqual([]);
     });
 
-    test('attribute with whitespace only', () => {
+    it('attribute with whitespace only', () => {
       const html = '<p style="  ">test</p>';
       expect(getCssFromHtml(html, 'example.com')).toEqual([]);
     });
@@ -463,28 +463,28 @@ describe('getCssFromHtml', () => {
 
 describe('getImportUrls', () => {
   describe('1 @import', () => {
-    test('no url(), single quotes', () => {
+    it('no url(), single quotes', () => {
       expect(getImportUrls(`@import 'test.css';`)).toEqual(['test.css']);
     });
 
-    test('no url(), double quotes', () => {
+    it('no url(), double quotes', () => {
       expect(getImportUrls(`@import "test.css";`)).toEqual(['test.css']);
     });
 
-    test('url() w/o quotes', () => {
+    it('url() w/o quotes', () => {
       expect(getImportUrls('@import url(test.css);')).toEqual(['test.css']);
     });
 
-    test('url() w/ single quotes', () => {
+    it('url() w/ single quotes', () => {
       expect(getImportUrls(`@import url('test.css');`)).toEqual(['test.css']);
     });
 
-    test('url() w/ double quotes', () => {
+    it('url() w/ double quotes', () => {
       expect(getImportUrls(`@import url("test.css");`)).toEqual(['test.css']);
     });
   });
 
-  test('multiple @imports', () => {
+  it('multiple @imports', () => {
     // examples from https://developer.mozilla.org/en-US/docs/Web/CSS/@import#examples
     const css = `
       @import "custom.css";
@@ -504,33 +504,33 @@ describe('getImportUrls', () => {
     ]);
   });
 
-  test('multiple consecutive (minified) @imports', () => {
+  it('multiple consecutive (minified) @imports', () => {
     const css = '@import "custom1.css";@import "custom2.css";';
     expect(getImportUrls(css)).toEqual(['custom1.css', 'custom2.css']);
   });
 
   describe('with layer()', () => {
-    test('@import with layer', () => {
+    it('@import with layer', () => {
       expect(getImportUrls(`@import url("test.css") layer;`)).toEqual(['test.css']);
     });
 
-    test('@import url() layer(test)', () => {
+    it('@import url() layer(test)', () => {
       expect(getImportUrls(`@import url("test.css") layer(test);`)).toEqual(['test.css']);
     });
 
-    test('@import url() layer(test.me.nested)', () => {
+    it('@import url() layer(test.me.nested)', () => {
       expect(getImportUrls(`@import url("test.css") layer(test.me.nested);`)).toEqual(['test.css']);
     });
   });
 
   describe('with supports()', () => {
-    test('@import url("test.css") supports(display: grid);', () => {
+    it('@import url("test.css") supports(display: grid);', () => {
       expect(getImportUrls(`@import url("test.css") supports(display: grid);`)).toEqual(['test.css']);
     });
   });
 
   describe('with @media', () => {
-    test('@import url("test.css") (min-width: 1000px);', () => {
+    it('@import url("test.css") (min-width: 1000px);', () => {
       expect(getImportUrls('@import url("test.css") (min-width: 1000px);')).toEqual(['test.css']);
     });
   });
@@ -546,15 +546,14 @@ describe('getImportUrls', () => {
       '@import "test.css" supports((not (display: grid)) and (display: flex)) screen and (width <= 400px);',
       '@import "test.css" supports((selector(h2 > p)) and (font-tech(color-COLRv1)));',
     ];
-    for (const imprt of imports) {
-      test(imprt, () => {
-        expect(getImportUrls(imprt)).toEqual(['test.css']);
-      });
-    }
+
+    it.each(imports)('%s', (imprt) => {
+      expect(getImportUrls(imprt)).toEqual(['test.css']);
+    });
   });
 
   describe('invalid CSS cases that we do not care about', () => {
-    test('@import declared after a ruleset', () => {
+    it('@import declared after a ruleset', () => {
       const css = `
         * {
           margin: 0;
@@ -566,7 +565,7 @@ describe('getImportUrls', () => {
       expect(getImportUrls(css)).toEqual(['my-imported-styles.css']);
     });
 
-    test('nested @import in a conditional at-rule', () => {
+    it('nested @import in a conditional at-rule', () => {
       const css = `
         @media (max-width: 0) {
           @import url('test1.css');
@@ -593,7 +592,7 @@ describe('getCssFile', () => {
     'User-Agent': 'NL Design System CSS Scraper/1.0',
   };
 
-  test('it fetches CSS content successfully', async () => {
+  it('fetches CSS content successfully', async () => {
     const mockResponse = 'body { margin: 0; }';
     (fetch as Mock).mockResolvedValueOnce({
       ok: true,
@@ -609,7 +608,7 @@ describe('getCssFile', () => {
     expect(result).toEqual(mockResponse);
   });
 
-  test('it returns an empty string when the request fails', async () => {
+  it('returns an empty string when the request fails', async () => {
     (fetch as Mock).mockResolvedValueOnce({
       ok: false,
     });
@@ -619,7 +618,7 @@ describe('getCssFile', () => {
     expect(result).toEqual('');
   });
 
-  test('it returns an empty string when the request is aborted', async () => {
+  it('returns an empty string when the request is aborted', async () => {
     (fetch as Mock).mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
 
     const controller = new AbortController();
@@ -631,7 +630,7 @@ describe('getCssFile', () => {
 });
 
 describe('getDesignTokens', () => {
-  test('formats css into design tokens', () => {
+  it('formats css into design tokens', () => {
     const mockCss = `
       a {
         color: blue;

--- a/packages/css-scraper/src/is-localhost.test.ts
+++ b/packages/css-scraper/src/is-localhost.test.ts
@@ -1,32 +1,32 @@
-import { test, expect } from 'vitest';
+import { it, expect } from 'vitest';
 import { isLocalhostUrl } from './is-localhost';
 
-test('localhost', () => {
+it('localhost', () => {
   expect(isLocalhostUrl('http://localhost')).toBeTruthy();
   expect(isLocalhostUrl('http://localhost:8080')).toBeTruthy();
   expect(isLocalhostUrl('HTTP://LOCALHOST:8080')).toBeTruthy();
 });
 
-test('127.0.0.1', () => {
+it('127.0.0.1', () => {
   expect(isLocalhostUrl('http://127.0.0.1/')).toBeTruthy();
   expect(isLocalhostUrl('http://127.0.0.1/hello-world')).toBeTruthy();
   expect(isLocalhostUrl('http://127.0.0.1:8080')).toBeTruthy();
 });
 
-test('192.168.*.*', () => {
+it('192.168.*.*', () => {
   expect(isLocalhostUrl('http://192.168.0.0')).toBeTruthy();
   expect(isLocalhostUrl('http://192.168.1.1')).toBeTruthy();
 });
 
-test('allows a URL object', () => {
+it('allows a URL object', () => {
   expect(isLocalhostUrl(new URL('http://localhost'))).toBeTruthy();
 });
 
-test('example.com', () => {
+it('example.com', () => {
   expect(isLocalhostUrl('https://example.com')).toBeFalsy();
 });
 
-test('does not throw on <empty string>', () => {
+it('does not throw on <empty string>', () => {
   expect(() => isLocalhostUrl('')).not.toThrow();
   expect(isLocalhostUrl('')).toBeFalsy();
 });

--- a/packages/css-scraper/src/resolve-url.test.ts
+++ b/packages/css-scraper/src/resolve-url.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from 'vitest';
+import { it, expect, describe } from 'vitest';
 import { resolveUrl } from './resolve-url';
 
 describe('valid urls', () => {
@@ -14,25 +14,24 @@ describe('valid urls', () => {
     ['example.com/path', new URL('https://example.com/path')],
     ['example.com/path?query=1#fragment', new URL('https://example.com/path?query=1#fragment')],
   ];
-  fixtures.forEach(([input, expected]) => {
-    test(`${input} => ${expected.toString()}`, () => {
-      expect(resolveUrl(input)).toEqual(expected);
-    });
+
+  it.each(fixtures)(`%s => %s}`, (input, expected) => {
+    expect(resolveUrl(input)).toEqual(expected);
   });
 
-  test('handles base64 encoded data URLs', () => {
+  it('handles base64 encoded data URLs', () => {
     const input = `data:text/css;charset=utf-8,${encodeURIComponent('h1 { color: red; }')}`;
     expect(resolveUrl(input)?.toString()).toEqual(input);
   });
 
-  test('paths with base url', () => {
+  it('paths with base url', () => {
     expect.soft(resolveUrl('/path', 'https://example.com')).toEqual(new URL('https://example.com/path'));
     expect.soft(resolveUrl('path', 'https://example.com')).toEqual(new URL('https://example.com/path'));
     expect.soft(resolveUrl('path?query=1', 'https://example.com')).toEqual(new URL('https://example.com/path?query=1'));
     expect.soft(resolveUrl('//other.com/path', 'https://example.com')).toEqual(new URL('https://other.com/path'));
   });
 
-  test('parent paths with base url', () => {
+  it('parent paths with base url', () => {
     expect
       .soft(resolveUrl('./style.css', 'https://example.com/lots/of/nested/folders'))
       .toEqual(new URL('https://example.com/lots/of/nested/style.css'));
@@ -50,9 +49,7 @@ describe('valid urls', () => {
 
 describe('invalid urls', () => {
   const fixtures: string[] = ['', 'example', '//example.com', 'a { color: red; } b { font-size: 12px; }'];
-  fixtures.forEach((input) => {
-    test(input, () => {
-      expect(resolveUrl(input)).toBeUndefined();
-    });
+  it.each(fixtures)(`%s`, (input) => {
+    expect(resolveUrl(input)).toBeUndefined();
   });
 });

--- a/packages/css-scraper/src/strip-wayback.test.ts
+++ b/packages/css-scraper/src/strip-wayback.test.ts
@@ -1,8 +1,8 @@
-import { test, expect, describe } from 'vitest';
+import { it, expect, describe } from 'vitest';
 import { isWaybackUrl, removeWaybackToolbar } from './strip-wayback';
 
 describe('isWaybackUrl', () => {
-  test('valid cases', () => {
+  it('valid cases', () => {
     const urls = [
       'https://web.archive.org/web/20250311183954/x', // invalid URL but not our concern
       'https://web.archive.org/web/20250311183954/https://www.projectwallace.com/',
@@ -14,7 +14,7 @@ describe('isWaybackUrl', () => {
     }
   });
 
-  test('invalid cases', () => {
+  it('invalid cases', () => {
     const urls = [
       '',
       'https://example.com',
@@ -30,7 +30,7 @@ describe('isWaybackUrl', () => {
 });
 
 describe(`removeWaybackInsertions`, () => {
-  test('removes toolbar html', () => {
+  it('removes toolbar html', () => {
     const html = `
       <!doctype>
       <html>
@@ -72,7 +72,7 @@ describe(`removeWaybackInsertions`, () => {
   });
 
   describe('leaves everything else intact', () => {
-    test('no toolbar present', () => {
+    it('no toolbar present', () => {
       const html = `
       <!doctype>
       <html>
@@ -87,7 +87,7 @@ describe(`removeWaybackInsertions`, () => {
       expect(removeWaybackToolbar(html)).toEqual(html);
     });
 
-    test('does not remove just any comment', () => {
+    it('does not remove just any comment', () => {
       const html = `
       <p>Hello</p>
       <!-- this is my comment -->

--- a/packages/design-tokens-schema/src/base-token.test.ts
+++ b/packages/design-tokens-schema/src/base-token.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, expectTypeOf } from 'vitest';
+import { it, expect, describe, expectTypeOf } from 'vitest';
 import {
   BaseDesignTokenIdentifierSchema,
   type BaseDesignTokenIdentifier,
@@ -8,7 +8,7 @@ import {
 } from './index';
 
 describe('BaseDesignTokenNameSchema', () => {
-  test('accepts simple strings', () => {
+  it('accepts simple strings', () => {
     for (const fixture of ['a', 'abc', '1', 'dashed-ident', 'snake_ident', '123abc']) {
       const result = BaseDesignTokenIdentifierSchema.safeParse(fixture);
       expect.soft(result.success).toBeTruthy();
@@ -16,13 +16,13 @@ describe('BaseDesignTokenNameSchema', () => {
     }
   });
 
-  test('rejects invalid types', () => {
+  it('rejects invalid types', () => {
     for (const fixture of [1, {}]) {
       expect.soft(BaseDesignTokenIdentifierSchema.safeParse(fixture).success).toBeFalsy();
     }
   });
 
-  test('rejects forbidden characters', () => {
+  it('rejects forbidden characters', () => {
     for (const fixture of ['', '$test', '{ref}', 'test.123']) {
       expect.soft(BaseDesignTokenIdentifierSchema.safeParse(fixture).success).toBeFalsy();
     }
@@ -30,7 +30,7 @@ describe('BaseDesignTokenNameSchema', () => {
 });
 
 describe('BaseDesignTokenSchema', () => {
-  test('accepts objects with only valid properties', () => {
+  it('accepts objects with only valid properties', () => {
     const fixture = {
       'my-token-id': {
         $description: 'This is an unknown token',
@@ -49,12 +49,12 @@ describe('BaseDesignTokenSchema', () => {
       $value: 'value',
     };
 
-    test('MUST be a string', () => {
+    it('MUST be a string', () => {
       const token = { ...fixture, $description: 'test' };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(true);
     });
 
-    test('MUST not be null', () => {
+    it('MUST not be null', () => {
       const token = { ...fixture, $description: null };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(false);
     });
@@ -66,22 +66,22 @@ describe('BaseDesignTokenSchema', () => {
       $value: 'value',
     };
 
-    test('MAY be true', () => {
+    it('MAY be true', () => {
       const token = { ...fixture, $deprecated: true };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(true);
     });
 
-    test('MAY be false', () => {
+    it('MAY be false', () => {
       const token = { ...fixture, $deprecated: false };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(true);
     });
 
-    test('MAY be a string', () => {
+    it('MAY be a string', () => {
       const token = { ...fixture, $deprecated: 'Use X or Y instead' };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(true);
     });
 
-    test('MUST not be null', () => {
+    it('MUST not be null', () => {
       const token = { ...fixture, $deprecated: null };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(false);
     });
@@ -93,23 +93,23 @@ describe('BaseDesignTokenSchema', () => {
       $value: 'value',
     };
 
-    test('MAY be an empty record', () => {
+    it('MAY be an empty record', () => {
       const token = { ...fixture, $extensions: {} };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(true);
     });
 
-    test('MAY be an simple record', () => {
+    it('MAY be an simple record', () => {
       const token = { ...fixture, $extensions: { test: 1 } };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(true);
     });
 
-    test('MUST not be null', () => {
+    it('MUST not be null', () => {
       const token = { ...fixture, $extensions: null };
       expect(BaseDesignTokenValueSchema.safeParse(token).success).toEqual(false);
     });
   });
 
-  test('accepts a bare minimum token', () => {
+  it('accepts a bare minimum token', () => {
     const fixture = {
       'my-token-id': {
         $type: 'unknown',
@@ -121,7 +121,7 @@ describe('BaseDesignTokenSchema', () => {
     expectTypeOf(result.data!).toEqualTypeOf<BaseDesignToken>();
   });
 
-  test('rejects objects with unknown properties', () => {
+  it('rejects objects with unknown properties', () => {
     const fixture = {
       'my-token-id': {
         $type: 'my-token-type',
@@ -134,7 +134,7 @@ describe('BaseDesignTokenSchema', () => {
     expectTypeOf(result.data).not.toEqualTypeOf<BaseDesignToken>();
   });
 
-  test('rejects tokens without a $value', () => {
+  it('rejects tokens without a $value', () => {
     const fixture = {
       'my-token-id': {
         $type: 'my-token-type',
@@ -145,7 +145,7 @@ describe('BaseDesignTokenSchema', () => {
     expectTypeOf(result.data).not.toEqualTypeOf<BaseDesignToken>();
   });
 
-  test('rejects tokens with an invalid ID', () => {
+  it('rejects tokens with an invalid ID', () => {
     const fixture = {
       $tokenName: {
         $type: 'my-token-type',

--- a/packages/design-tokens-schema/src/basis-tokens.test.ts
+++ b/packages/design-tokens-schema/src/basis-tokens.test.ts
@@ -1,7 +1,7 @@
 import maTokens from '@nl-design-system-community/ma-design-tokens/dist/tokens';
 import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tokens';
 import voorbeeldTokens from '@nl-design-system-unstable/voorbeeld-design-tokens/dist/tokens';
-import { describe, test, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import * as z from 'zod';
 import {
   BrandsSchema,
@@ -18,11 +18,11 @@ import {
 import { ColorToken, parseColor } from './color-token';
 
 describe('brand', () => {
-  test('no brands present', () => {
+  it('no brands present', () => {
     expect(BrandsSchema.safeParse({}).success).toBeTruthy();
   });
 
-  test('valid brand name', () => {
+  it('valid brand name', () => {
     const config = {
       ma: {
         name: {
@@ -34,7 +34,7 @@ describe('brand', () => {
     expect(BrandsSchema.safeParse(config).success).toBeTruthy();
   });
 
-  test('brand name should be a valid Design Token', () => {
+  it('brand name should be a valid Design Token', () => {
     const config = {
       // invalid identifier
       '$my-brand': {
@@ -48,7 +48,7 @@ describe('brand', () => {
   });
 
   describe('single brand', () => {
-    test('empty color config', () => {
+    it('empty color config', () => {
       const config = {
         name: {
           $type: 'text',
@@ -59,7 +59,7 @@ describe('brand', () => {
       expect(BrandSchema.safeParse(config).success).toBeTruthy();
     });
 
-    test('missing color config', () => {
+    it('missing color config', () => {
       const config = {
         name: {
           $type: 'text',
@@ -70,14 +70,14 @@ describe('brand', () => {
       expect(BrandSchema.safeParse(config).success).toBeTruthy();
     });
 
-    test('missing name', () => {
+    it('missing name', () => {
       const config = {
         color: {},
       };
       expect(BrandSchema.safeParse(config).success).toBeFalsy();
     });
 
-    test('incorrect name type', () => {
+    it('incorrect name type', () => {
       const config = {
         name: {
           $type: 'string', // instead of 'text'
@@ -98,7 +98,7 @@ describe('brand', () => {
       },
     };
 
-    test('top-level colors with legacy color', () => {
+    it('top-level colors with legacy color', () => {
       const config = {
         name: {
           $type: 'text',
@@ -116,7 +116,7 @@ describe('brand', () => {
       expect.soft(result.data?.color?.['white']).toEqual(modernWhite);
     });
 
-    test('top-level colors with modern color', () => {
+    it('top-level colors with modern color', () => {
       const config = {
         name: {
           $type: 'text',
@@ -132,7 +132,7 @@ describe('brand', () => {
       expect.soft(result.data).toEqual(config);
     });
 
-    test('nested colors with legacy color format', () => {
+    it('nested colors with legacy color format', () => {
       const config = {
         name: {
           $type: 'text',
@@ -152,7 +152,7 @@ describe('brand', () => {
       expect.soft(result.data?.color?.['indigo']).toEqual({ 1: modernWhite });
     });
 
-    test('nested colors with modern color format', () => {
+    it('nested colors with modern color format', () => {
       const config = {
         name: {
           $type: 'text',
@@ -169,7 +169,7 @@ describe('brand', () => {
       expect.soft(result.data).toEqual(config);
     });
 
-    test('fails on invalid top-level colors', () => {
+    it('fails on invalid top-level colors', () => {
       const config = {
         name: {
           $type: 'text',
@@ -186,7 +186,7 @@ describe('brand', () => {
       expect.soft(result.success).toBeFalsy();
     });
 
-    test('fails on invalid nested colors', () => {
+    it('fails on invalid nested colors', () => {
       const config = {
         name: {
           $type: 'text',
@@ -205,7 +205,7 @@ describe('brand', () => {
       expect.soft(result.success).toBeFalsy();
     });
 
-    test('fails on invalid color name', () => {
+    it('fails on invalid color name', () => {
       const config = {
         name: {
           $type: 'text',
@@ -226,20 +226,20 @@ describe('brand', () => {
 });
 
 describe('basis', () => {
-  test('basis config allows unknown properties', () => {
+  it('basis config allows unknown properties', () => {
     expect(BasisTokensSchema.safeParse({ unknownField: {} }).success).toBeTruthy();
   });
 
   describe('color', () => {
-    test('allows known color names', () => {
+    it('allows known color names', () => {
       expect(BasisColorSchema.safeParse({ 'accent-1': {} }).success).toBeTruthy();
     });
 
-    test('does not allow unknown properties', () => {
+    it('does not allow unknown properties', () => {
       expect(BasisColorSchema.safeParse({ unknownField: {} }).success).toBeFalsy();
     });
 
-    test('allows references to other tokens in the schema', () => {
+    it('allows references to other tokens in the schema', () => {
       const config = {
         default: {
           'bg-document': {
@@ -285,7 +285,7 @@ describe('theme', () => {
   };
 
   describe('adding contrast-with extensions', () => {
-    test('adds contrast-with extensions for tokens that we know', () => {
+    it('adds contrast-with extensions for tokens that we know', () => {
       const config = {
         basis: {
           color: {
@@ -322,7 +322,7 @@ describe('theme', () => {
       });
     });
 
-    test('contrast-with extensions do not mess with existing extensions', () => {
+    it('contrast-with extensions do not mess with existing extensions', () => {
       const config = {
         basis: {
           color: {
@@ -359,7 +359,7 @@ describe('theme', () => {
       ).toHaveLength(2);
     });
 
-    test('does not add extension when corresponding token does not exist', () => {
+    it('does not add extension when corresponding token does not exist', () => {
       const config = {
         basis: {
           color: {
@@ -398,7 +398,7 @@ describe('theme', () => {
         brand: brandConfig,
       };
 
-      test('does not mutate the input config', () => {
+      it('does not mutate the input config', () => {
         const originalConfig = structuredClone(config);
         StrictThemeSchema.safeParse(config);
         const originalBg = originalConfig.basis.color.default['bg-document'].$value;
@@ -406,13 +406,13 @@ describe('theme', () => {
         expect.soft(originalBg).toEqual(bgAfterValidation);
       });
 
-      test('validates the input', () => {
+      it('validates the input', () => {
         const result = StrictThemeSchema.safeParse(config);
         expect.soft(BrandSchema.safeParse(config.brand.ma).success).toBeTruthy();
         expect.soft(result.success).toBeTruthy();
       });
 
-      test('returns the schema with the ref value added to an extension and the $value left intact', () => {
+      it('returns the schema with the ref value added to an extension and the $value left intact', () => {
         const result = StrictThemeSchema.safeParse(config);
         const expectedColor = brandConfig.ma.color.indigo[5];
         expect.soft(result.data?.basis?.color?.default?.['bg-document']).toEqual({
@@ -424,7 +424,7 @@ describe('theme', () => {
       });
     });
 
-    test('marks as invalid if resolving to an nonexistent object', () => {
+    it('marks as invalid if resolving to an nonexistent object', () => {
       const config = {
         basis: {
           color: {
@@ -448,7 +448,7 @@ describe('theme', () => {
       expect.soft(result.success).toBeFalsy();
     });
 
-    test('marks as invalid if resolving to an existing object without a $value property', () => {
+    it('marks as invalid if resolving to an existing object without a $value property', () => {
       const config = {
         basis: {
           color: {
@@ -473,7 +473,7 @@ describe('theme', () => {
       });
     });
 
-    test('marks as invalid when a font-family token reference points to an existing non-font-family token', () => {
+    it('marks as invalid when a font-family token reference points to an existing non-font-family token', () => {
       const config = {
         basis: {
           heading: {
@@ -526,7 +526,7 @@ describe('theme', () => {
       },
     } satisfies Theme;
 
-    test('passes when contrast is sufficient', () => {
+    it('passes when contrast is sufficient', () => {
       const testConfig = structuredClone(config);
       testConfig.basis.color.default['border-default'] = {
         $type: 'color',
@@ -540,7 +540,7 @@ describe('theme', () => {
       expect(result.success).toEqual(true);
     });
 
-    test('fails when color-document vs bg-subtle do not have enough contrast', () => {
+    it('fails when color-document vs bg-subtle do not have enough contrast', () => {
       const testConfig = structuredClone(config);
       testConfig.basis.color.default['bg-subtle'] = {
         $type: 'color',
@@ -572,7 +572,7 @@ describe('theme', () => {
       ]);
     });
 
-    test('passes when legacy tokens are used with proper contrast', () => {
+    it('passes when legacy tokens are used with proper contrast', () => {
       const testConfig = structuredClone(config);
       testConfig.basis.color.default['bg-subtle'] = {
         $type: 'color',
@@ -586,7 +586,7 @@ describe('theme', () => {
       expect(result.success).toEqual(true);
     });
 
-    test('fails when legacy tokens are used with improper contrast', () => {
+    it('fails when legacy tokens are used with improper contrast', () => {
       const testConfig = structuredClone(config);
       testConfig.basis.color.default['bg-subtle'] = {
         $type: 'color',
@@ -619,7 +619,7 @@ describe('theme', () => {
     });
   });
 
-  test('finding both ref and contrast issues at once', () => {
+  it('finding both ref and contrast issues at once', () => {
     // This test case exists because previous versions would bail out after the validation found an invalid ref and skipped checking contrast
     const white = parseColor('#ffffff');
     const lightGray = parseColor('#cccccc');
@@ -673,17 +673,17 @@ describe('theme', () => {
 });
 
 describe('strictly validate known basis themes', () => {
-  test('Mooi & Anders theme', () => {
+  it('Mooi & Anders theme', () => {
     const result = StrictThemeSchema.safeParse(maTokens);
     expect(result.success).toEqual(true);
   });
 
-  test('Voorbeeld theme', () => {
+  it('Voorbeeld theme', () => {
     const result = StrictThemeSchema.safeParse(voorbeeldTokens);
     expect(result.success).toEqual(true);
   });
 
-  test('Start theme', () => {
+  it('Start theme', () => {
     const result = StrictThemeSchema.safeParse(startTokens);
     expect(result.success).toEqual(true);
   });

--- a/packages/design-tokens-schema/src/color-token.test.ts
+++ b/packages/design-tokens-schema/src/color-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, expectTypeOf } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import {
   ColorAlphaSchema,
   type ColorAlpha,
@@ -12,7 +12,7 @@ import {
 } from './color-token';
 
 describe('Alpha', () => {
-  test('accepts valid ranges', () => {
+  it('accepts valid ranges', () => {
     for (const alpha of [0, 1, 0.5]) {
       const result = ColorAlphaSchema.safeParse(alpha);
       expect(result.success).toBeTruthy();
@@ -20,7 +20,7 @@ describe('Alpha', () => {
     }
   });
 
-  test('rejects invalid ranges', () => {
+  it('rejects invalid ranges', () => {
     for (const alpha of ['0', -1, 2]) {
       const result = ColorAlphaSchema.safeParse(alpha);
       expect(result.success).toBeFalsy();
@@ -30,7 +30,7 @@ describe('Alpha', () => {
 });
 
 describe('Hex fallback', () => {
-  test('accepts valid ranges', () => {
+  it('accepts valid ranges', () => {
     for (const hex of ['#000000', '#ffffff', '#bada55', '#FFFFFF', '#ffFFff']) {
       const result = ColorHexFallbackSchema.safeParse(hex);
       expect(result.success).toBeTruthy();
@@ -38,7 +38,7 @@ describe('Hex fallback', () => {
     }
   });
 
-  test('rejects invalid ranges', () => {
+  it('rejects invalid ranges', () => {
     for (const hex of ['000000', '#000', '#aabbccdd', '#az09AZ']) {
       const result = ColorHexFallbackSchema.safeParse(hex);
       expect(result.success).toBeFalsy();
@@ -48,7 +48,7 @@ describe('Hex fallback', () => {
 });
 
 describe('color token validation', () => {
-  test('leave valid modern tokens intact', () => {
+  it('leave valid modern tokens intact', () => {
     const token = {
       $type: 'color',
       $value: {
@@ -62,7 +62,7 @@ describe('color token validation', () => {
     expect(result.data).toEqual(token);
   });
 
-  test('upgrade legacy color to modern', () => {
+  it('upgrade legacy color to modern', () => {
     const legacyColor = {
       $type: 'color',
       $value: '#f00',
@@ -90,7 +90,7 @@ describe('color token validation', () => {
       },
     } satisfies ColorToken;
 
-    test('convert `transparent` to fully transparent black, modern syntax', () => {
+    it('convert `transparent` to fully transparent black, modern syntax', () => {
       const transparentColor = {
         $type: 'color',
         $value: 'transparent',
@@ -100,7 +100,7 @@ describe('color token validation', () => {
       expect(result.data).toEqual(expected_color);
     });
 
-    test('convert `rgba(0, 0, 0, 0)` to fully transparent black, modern syntax', () => {
+    it('convert `rgba(0, 0, 0, 0)` to fully transparent black, modern syntax', () => {
       const transparentColor = {
         $type: 'color',
         $value: 'rgba(0, 0, 0, 0)',
@@ -111,7 +111,7 @@ describe('color token validation', () => {
     });
   });
 
-  test('invalid colors are rejected', () => {
+  it('invalid colors are rejected', () => {
     const legacyColor = {
       $type: 'color',
       $value: '__not_a_color__',
@@ -122,7 +122,7 @@ describe('color token validation', () => {
 });
 
 describe('stringify token to string', () => {
-  test('stringify a color value to an srgb string', () => {
+  it('stringify a color value to an srgb string', () => {
     const tokenValue = {
       alpha: 1,
       colorSpace: 'srgb',
@@ -133,7 +133,7 @@ describe('stringify token to string', () => {
   });
 
   // https://www.designtokens.org/tr/drafts/color/#using-the-none-keyword
-  test('stringifies colors that use "none" in their components', () => {
+  it('stringifies colors that use "none" in their components', () => {
     const tokenValue = {
       alpha: 1,
       colorSpace: 'hsl',
@@ -144,7 +144,7 @@ describe('stringify token to string', () => {
     expect(result).toBe('#ffffff');
   });
 
-  test('using the zod legacyToModernColor codec', () => {
+  it('using the zod legacyToModernColor codec', () => {
     expect(
       legacyToModernColor.encode({
         alpha: 1,

--- a/packages/design-tokens-schema/src/fontfamily-token.test.ts
+++ b/packages/design-tokens-schema/src/fontfamily-token.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, expectTypeOf } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import {
   type FontFamilyValue,
   ModernFontFamilyValueSchema,
@@ -9,7 +9,7 @@ import {
 } from './fontfamily-token';
 
 describe('parsing values', () => {
-  test('accepts valid font-families', () => {
+  it('accepts valid font-families', () => {
     const fixtures = ['serif', '💪', 'Arial Black', '-apple-system'];
     for (const fontFamily of fixtures) {
       const result = ModernFontFamilyValueSchema.safeParse(fontFamily);
@@ -18,14 +18,14 @@ describe('parsing values', () => {
     }
   });
 
-  test('upgrades legacy format with a single comma-separated string', () => {
+  it('upgrades legacy format with a single comma-separated string', () => {
     const result = LegacyFontFamilyValueSchema.safeParse('serif, sans-serif');
     expect(result.success).toBeTruthy();
     expect(result.data).toEqual(['serif', 'sans-serif']);
     expectTypeOf(result.data!).toEqualTypeOf<LegacyFontFamilyValue>();
   });
 
-  test('rejects invalid "families"', () => {
+  it('rejects invalid "families"', () => {
     for (const nonFamily of [16, true, ' ', ',', ' , ']) {
       const result = ModernFontFamilyValueSchema.safeParse(nonFamily);
       expect(result.success).toBeFalsy();
@@ -34,7 +34,7 @@ describe('parsing values', () => {
   });
 });
 
-test('accepts modern token', () => {
+it('accepts modern token', () => {
   const token = {
     $type: 'fontFamily',
     $value: ['sans-serif'],
@@ -51,13 +51,13 @@ describe('legacy token format', () => {
     $value: 'Source Sans Pro, Helvetica, Arial, sans-serif',
   };
 
-  test('accepts legacy token', () => {
+  it('accepts legacy token', () => {
     const result = FontFamilyTokenSchema.safeParse(token);
     expect.soft(result.success).toBeTruthy();
     expectTypeOf(result.data!).toEqualTypeOf<FontFamilyToken>();
   });
 
-  test('upgrades legacy token', () => {
+  it('upgrades legacy token', () => {
     const result = FontFamilyTokenSchema.safeParse(token);
     expect.soft(result.data?.$type).toEqual('fontFamily');
     expect.soft(result.data?.$value).toEqual(['Source Sans Pro', 'Helvetica', 'Arial', 'sans-serif']);

--- a/packages/design-tokens-schema/src/token-reference.test.ts
+++ b/packages/design-tokens-schema/src/token-reference.test.ts
@@ -1,19 +1,19 @@
-import { test, expect } from 'vitest';
+import { it, expect } from 'vitest';
 import { TokenReferenceSchema } from './token-reference';
 
-test('allows valid ref with a single path', () => {
+it('allows valid ref with a single path', () => {
   const result = TokenReferenceSchema.safeParse('{ma}');
   expect.soft(result.success).toBeTruthy();
   expect.soft(result.data).toEqual('{ma}');
 });
 
-test('allows valid ref with nested paths', () => {
+it('allows valid ref with nested paths', () => {
   const result = TokenReferenceSchema.safeParse('{ma.color.white}');
   expect.soft(result.success).toBeTruthy();
   expect.soft(result.data).toEqual('{ma.color.white}');
 });
 
-test('disallows non-ref-like items', () => {
+it('disallows non-ref-like items', () => {
   expect.soft(TokenReferenceSchema.safeParse('{}').success).toBeFalsy();
   expect.soft(TokenReferenceSchema.safeParse('{.}').success).toBeFalsy();
   expect.soft(TokenReferenceSchema.safeParse('ma.color').success).toBeFalsy();

--- a/packages/lit/src/components/color-scale-picker/index.test.ts
+++ b/packages/lit/src/components/color-scale-picker/index.test.ts
@@ -1,5 +1,5 @@
 import { BrandSchema } from '@nl-design-system-community/design-tokens-schema';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 import './index';
 
@@ -10,25 +10,25 @@ describe(`<${tag}>`, () => {
     document.body.innerHTML = `<${tag}></${tag}>`;
   });
 
-  test('shows a color element', () => {
+  it('shows a color element', () => {
     const element = document.querySelector(tag);
     const color = element?.shadowRoot?.querySelector('input[type=color]') || undefined;
     expect(color).toBeDefined();
   });
 
-  test('shows a list of colors', () => {
+  it('shows a list of colors', () => {
     const element = document.querySelector(tag);
     const output = element?.shadowRoot?.querySelector('output');
     expect(output?.childNodes.length).toBeGreaterThan(1);
   });
 
-  test('value corresponds to valid token schema', () => {
+  it('value corresponds to valid token schema', () => {
     const element = document.querySelector(tag);
     const value = element?.value;
     expect(BrandSchema.safeParse(value)).toBeTruthy();
   });
 
-  test('value updates when color changes', async () => {
+  it('value updates when color changes', async () => {
     const element = document.querySelector(tag);
     /* @ts-expect-error element/shadowroot could be undefined, but it is fine if it would throw */
     const color = page.elementLocator(element?.shadowRoot?.querySelector('input[type=color]'));

--- a/packages/lit/src/components/dropdown/index.test.ts
+++ b/packages/lit/src/components/dropdown/index.test.ts
@@ -1,5 +1,5 @@
 import '.';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { Dropdown } from '.';
 
 const tag = 'wiz-dropdown';
@@ -25,7 +25,7 @@ describe(`<${tag}> integration tests`, () => {
     document.body.innerHTML = `<${tag}></${tag}>`;
   });
 
-  test('renders a select element', async () => {
+  it('renders a select element', async () => {
     const element = document.querySelector(tag) as Dropdown;
     element.isOptgroup = true;
     element.options = OPTIONS;
@@ -36,7 +36,7 @@ describe(`<${tag}> integration tests`, () => {
     expect(select?.tagName.toLowerCase()).toBe('select');
   });
 
-  test('renders optgroups with options', async () => {
+  it('renders optgroups with options', async () => {
     const element = document.querySelector(tag) as Dropdown;
     element.isOptgroup = true;
     element.options = OPTIONS;
@@ -53,7 +53,7 @@ describe(`<${tag}> integration tests`, () => {
     expect(somePathGroup).toBeDefined();
   });
 
-  test('dispatches change event on select change', async () => {
+  it('dispatches change event on select change', async () => {
     const element = document.querySelector(tag) as Dropdown;
     element.isOptgroup = true;
     element.options = OPTIONS;

--- a/packages/lit/src/components/preview-picker/index.test.ts
+++ b/packages/lit/src/components/preview-picker/index.test.ts
@@ -1,6 +1,6 @@
 import '.';
 import type { Category, TemplateGroup } from '@nl-design-system-community/theme-wizard-templates';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import type { PreviewPicker } from '.';
 
 const tag = 'preview-picker';
@@ -36,7 +36,7 @@ describe(`<${tag}>`, () => {
     document.body.innerHTML = '';
   });
 
-  test('renders a form with wiz-dropdown', async () => {
+  it('renders a form with wiz-dropdown', async () => {
     const el = await mount();
     const form = el.shadowRoot?.querySelector('form');
     const dropdown = el.shadowRoot?.querySelector('wiz-dropdown');
@@ -45,7 +45,7 @@ describe(`<${tag}>`, () => {
     expect(dropdown).toBeTruthy();
   });
 
-  test('builds optgroup options with full template paths', async () => {
+  it('builds optgroup options with full template paths', async () => {
     const el = await mount();
     const dropdown = el.shadowRoot?.querySelector('wiz-dropdown');
     const options = dropdown?.options;
@@ -55,14 +55,14 @@ describe(`<${tag}>`, () => {
     expect(allValues).toContain('/another-beautiful-thing/another-beautiful-page');
   });
 
-  test('defaults to first option when no templatePath param', async () => {
+  it('defaults to first option when no templatePath param', async () => {
     const el = await mount();
     const dropdown = el.shadowRoot?.querySelector('wiz-dropdown');
 
     expect(dropdown?.value).toBe('/something-beautiful/some-beautiful-page');
   });
 
-  test('reads current value from ?templatePath query param', async () => {
+  it('reads current value from ?templatePath query param', async () => {
     const origin = globalThis.location.origin;
     globalThis.history.pushState({}, '', `${origin}/?templatePath=/something-beautiful/some-beautiful-page`);
     const el = await mount();

--- a/packages/lit/src/components/wizard-font-input/index.test.ts
+++ b/packages/lit/src/components/wizard-font-input/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import './index';
 
 const tag = 'wizard-font-input';
@@ -8,13 +8,13 @@ describe(`<${tag}>`, () => {
     document.body.innerHTML = `<${tag}></${tag}>`;
   });
 
-  test('shows a select element', () => {
+  it('shows a select element', () => {
     const element = document.querySelector(tag);
     const select = element?.shadowRoot?.querySelector('select');
     expect(select).toBeDefined();
   });
 
-  test('shows a list of common fonts', () => {
+  it('shows a list of common fonts', () => {
     const element = document.querySelector(tag);
     const options = element?.shadowRoot?.querySelectorAll('option');
     expect(options?.length).toBeGreaterThan(1);

--- a/packages/lit/src/components/wizard-token-input/index.test.ts
+++ b/packages/lit/src/components/wizard-token-input/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import './index';
 
@@ -9,12 +9,12 @@ describe(`<${tag}>`, () => {
     document.body.innerHTML = `<${tag}></${tag}><button>hoi</button>`;
   });
 
-  test('shows a form control', () => {
+  it('shows a form control', () => {
     const formElement = page.getByRole('textbox');
     expect(formElement).toBeDefined();
   });
 
-  test('emits a changeEvent a form control', async () => {
+  it('emits a changeEvent a form control', async () => {
     const mockEventHandler = vi.fn();
     document.addEventListener('change', mockEventHandler);
     const textboxElement = page.getByRole('textbox');

--- a/packages/lit/src/lib/ColorScale/index.test.ts
+++ b/packages/lit/src/lib/ColorScale/index.test.ts
@@ -1,5 +1,5 @@
 import { COLOR_SPACES } from '@nl-design-system-community/design-tokens-schema';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import ColorToken from '../ColorToken';
 import ColorScale from './index';
 
@@ -36,41 +36,41 @@ const orangeOKLCH = new ColorToken({
 });
 
 describe('ColorScale', () => {
-  test('can be initialized with a token', () => {
+  it('can be initialized with a token', () => {
     const colorScale = new ColorScale(greenOKLCH);
     expect(colorScale.from.toObject()).toMatchObject(greenOKLCH.toObject());
   });
 
-  test('converts srgb to oklch on initialization', () => {
+  it('converts srgb to oklch on initialization', () => {
     const colorScale = new ColorScale(greenSRGB);
     expect(colorScale.fromOKLCH.toObject()).toMatchObject(greenOKLCH.toObject());
   });
 
-  test('can be updated after initialization', () => {
+  it('can be updated after initialization', () => {
     const colorScale = new ColorScale(greenSRGB);
     colorScale.from = orangeOKLCH;
     expect(colorScale.from.toObject()).toMatchObject(orangeOKLCH.toObject());
   });
 
-  test('converts after update', () => {
+  it('converts after update', () => {
     const colorScale = new ColorScale(greenSRGB);
     colorScale.from = orangeSRGB;
     expect(colorScale.fromOKLCH.toObject()).toMatchObject(orangeOKLCH.toObject());
   });
 
-  test('returns a list of derived colors', () => {
+  it('returns a list of derived colors', () => {
     const colorScale = new ColorScale(greenSRGB);
     expect(colorScale.list().length).toBe(colorScale.size);
   });
 
-  test('get token in color scale by position', () => {
+  it('get token in color scale by position', () => {
     const colorScale = new ColorScale(greenSRGB);
     for (let index = 0; index++; index < colorScale.size) {
       expect(colorScale.get(index)).toBeDefined();
     }
   });
 
-  test('list of derived colors contains base color exactly once, when lightness is in the mask', () => {
+  it('list of derived colors contains base color exactly once, when lightness is in the mask', () => {
     const lightnessMatchedGreenOKLCH = new ColorToken({
       $value: {
         ...greenOKLCH.$value,
@@ -86,7 +86,7 @@ describe('ColorScale', () => {
     expect(matches.length).toBe(1);
   });
 
-  test('list of derived colors contains base color exactly once, even if lightness is not in the mask', () => {
+  it('list of derived colors contains base color exactly once, even if lightness is not in the mask', () => {
     const colorScale = new ColorScale(greenSRGB);
     const matches = colorScale
       .list()
@@ -94,7 +94,7 @@ describe('ColorScale', () => {
     expect(matches.length).toBe(1);
   });
 
-  test('exports scale to an object defining design tokens', () => {
+  it('exports scale to an object defining design tokens', () => {
     const colorScale = new ColorScale(greenSRGB);
     expect(colorScale.toObject()).toMatchSnapshot();
   });

--- a/packages/lit/src/lib/ColorToken/index.test.ts
+++ b/packages/lit/src/lib/ColorToken/index.test.ts
@@ -1,5 +1,5 @@
 import { COLOR_SPACES, type ColorToken as ColorTokenType } from '@nl-design-system-community/design-tokens-schema';
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import ColorToken, { ColorComponents } from './index';
 
 const greenSRGB: ColorTokenType = {
@@ -56,23 +56,23 @@ const removeSwatchElements = () => {
  * and the resulting computed style will be `rgba(0, 0, 0, 0)`.
  */
 describe('ColorToken', () => {
-  test('can be initialized with a scraped color token', () => {
+  it('can be initialized with a scraped color token', () => {
     const colorToken = new ColorToken(greenSRGB);
     expect(colorToken).toBeDefined();
   });
 
-  test('matches initialization token', () => {
+  it('matches initialization token', () => {
     const colorToken = new ColorToken(greenSRGB);
     expect(colorToken.toObject()).toMatchObject(greenSRGB);
   });
 
   describe('toCSSColorFunction()', () => {
-    test('returns correct value for example srgb token', () => {
+    it('returns correct value for example srgb token', () => {
       const colorToken = new ColorToken(greenSRGB);
       const colorFunction = colorToken.toCSSColorFunction();
       expect(colorFunction).toBe('color(srgb 0 0.5058823529411764 0.12156862745098039)');
     });
-    test('returns correct value for example oklch token', () => {
+    it('returns correct value for example oklch token', () => {
       const colorToken = new ColorToken(greenOKLCH);
       const colorFunction = colorToken.toCSSColorFunction();
       expect(colorFunction).toBe('oklch(0.524144 0.165652 144.827)');
@@ -81,14 +81,14 @@ describe('ColorToken', () => {
 
   describe('toColorSpace()', () => {
     Object.values(COLOR_SPACES).forEach((destination) => {
-      test(`returns new ColorToken in ${destination} color space`, () => {
+      it(`returns new ColorToken in ${destination} color space`, () => {
         const token = new ColorToken(greenSRGB);
         const newToken = token.toColorSpace(destination);
         expect(newToken.$value.colorSpace).toBe(destination);
       });
     });
 
-    test('returns new ColorToken if destination color space is same as source', () => {
+    it('returns new ColorToken if destination color space is same as source', () => {
       const token = new ColorToken(greenSRGB);
       const newToken = token.toColorSpace(token.$value.colorSpace);
       // Values are the same
@@ -99,7 +99,7 @@ describe('ColorToken', () => {
 
     const token = new ColorToken(greenSRGB);
     Object.values(COLOR_SPACES).forEach((destination) => {
-      test(`ColorToken converted to ${destination} and back returns closely matching values`, () => {
+      it(`ColorToken converted to ${destination} and back returns closely matching values`, () => {
         const roundTripToken = new ColorToken(greenSRGB).toColorSpace(destination).toColorSpace('srgb');
         token.$value.components.every((value, index) =>
           // transformation is inherently lossy so therefore the precision is quite low
@@ -116,7 +116,7 @@ describe('ColorToken', () => {
     const components: ColorComponents = [1, 1, 1];
 
     Object.values(COLOR_SPACES).forEach((colorSpace) => {
-      test(`supports ${colorSpace}`, () => {
+      it(`supports ${colorSpace}`, () => {
         const colorFunction = ColorToken.getCSSColorFunction({ colorSpace, components });
         setSwatch(`rgb(from ${colorFunction} r g b`);
         expect(getSwatch()).not.toBe(invalidColor);
@@ -131,7 +131,7 @@ describe('ColorToken', () => {
     const components: ColorComponents = [1, 1, 1];
     Object.values(COLOR_SPACES).forEach((destination) => {
       Object.values(COLOR_SPACES).forEach((colorSpace) => {
-        test(`supports from ${colorSpace} to ${destination}`, () => {
+        it(`supports from ${colorSpace} to ${destination}`, () => {
           const colorFunction = ColorToken.getRelativeColorFunction(destination, { colorSpace, components });
           setSwatch(colorFunction);
           expect(getSwatch()).not.toBe(invalidColor);

--- a/packages/lit/src/lib/ColorToken/lib.test.ts
+++ b/packages/lit/src/lib/ColorToken/lib.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, test } from 'vitest';
+/* eslint-disable vitest/prefer-each */
+import { afterEach, describe, expect, it } from 'vitest';
 import { createHelperElement, getCSSColorComponents, getHue, toHSL, toHWB } from './lib';
 
 describe('ColorToken/createHelperElement', () => {
@@ -8,14 +9,14 @@ describe('ColorToken/createHelperElement', () => {
     }
   });
 
-  test('creates a div', () => {
+  it('creates a div', () => {
     const helper = createHelperElement();
     helper?.setAttribute('data-test-id', 'helper');
     const createdElement = document.querySelector('[data-test-id=helper]');
     expect(createdElement).toBeDefined();
   });
 
-  test('created div has display:none', () => {
+  it('created div has display:none', () => {
     const helper = createHelperElement();
     helper?.setAttribute('data-test-id', 'helper');
     const createdElement = document.querySelector('[data-test-id=helper]');
@@ -54,7 +55,7 @@ describe('ColorToken/getCSSColorComponents', () => {
   ];
 
   for (const { name, input, result } of testScenarios) {
-    test(name, () => {
+    it(`${name}`, () => {
       const components = getCSSColorComponents(input);
       expect(components.toString()).toBe(result);
     });
@@ -79,7 +80,7 @@ describe('ColorToken/getHue', () => {
     hsl: [hue],
     rgb: [r, g, b],
   } of colorScenarios) {
-    test(`can get hue degree of ${name}`, () => {
+    it(`can get hue degree of ${name}`, () => {
       const value = getHue([r, g, b]);
       expect(value.toFixed(1)).toBe(hue.toFixed(1));
     });
@@ -92,7 +93,7 @@ describe('ColorToken/toHSL', () => {
     hsl,
     rgb: [r, g, b],
   } of colorScenarios) {
-    test(`can convert RGB ${name} to HSL `, () => {
+    it(`can convert RGB ${name} to HSL `, () => {
       const value = toHSL([r, g, b]);
       expect(value).toStrictEqual(hsl);
     });
@@ -105,7 +106,7 @@ describe('ColorToken/toHWB', () => {
     hwb,
     rgb: [r, g, b],
   } of colorScenarios) {
-    test(`can convert RGB ${name} to HWB `, () => {
+    it(`can convert RGB ${name} to HWB `, () => {
       const value = toHWB([r, g, b]);
       expect(value).toStrictEqual(hwb);
     });

--- a/packages/lit/src/lib/PersistentStorage/index.test.ts
+++ b/packages/lit/src/lib/PersistentStorage/index.test.ts
@@ -92,7 +92,7 @@ describe('PersistentStorage', () => {
     expect(storage.getItem(key)).toBe(value);
   });
 
-  it('should remove items', () => {
+  it('should remove string items', () => {
     const storage = new PersistentStorage();
     const key = 'testKey';
     const value = 'testValue';
@@ -121,7 +121,7 @@ describe('PersistentStorage', () => {
     expect(storage.getJSON(key)).toMatchObject(object);
   });
 
-  it('should remove items', () => {
+  it('should remove object items', () => {
     const storage = new PersistentStorage();
     const key = 'testKey';
     const object = { a: 'b' };

--- a/packages/lit/src/lib/Scraper/index.test.ts
+++ b/packages/lit/src/lib/Scraper/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import Scraper from './index';
 
 describe('Scraper', () => {
@@ -6,7 +6,7 @@ describe('Scraper', () => {
     return new Response('', { status: 200 });
   });
 
-  test('tries to fetch css for given url', () => {
+  it('tries to fetch css for given url', () => {
     const scraperURL = 'https://example.com/';
     const targetURL = 'https://example.com/target';
     const scraper = new Scraper(scraperURL);
@@ -16,7 +16,7 @@ describe('Scraper', () => {
     expect(fetchSpy).toBeCalledWith(new URL(`${scraperURL}api/v1/css?url=${encodeURIComponent(targetURL)}`));
   });
 
-  test('can be invoked multiple times', () => {
+  it('can be invoked multiple times', () => {
     const scraperURL = 'https://example.com/';
     const targetURL = 'https://example.com/test';
     const scraper = new Scraper(scraperURL);

--- a/packages/lit/src/lib/Theme/index.test.ts
+++ b/packages/lit/src/lib/Theme/index.test.ts
@@ -1,19 +1,19 @@
 import tokens from '@nl-design-system-community/ma-design-tokens/src/tokens.json';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import Theme from './index';
 
 describe('Theme', () => {
-  test('instantiates with default values', () => {
+  it('instantiates with default values', () => {
     const theme = new Theme();
     expect(theme.defaults).toMatchObject(Theme.defaults);
   });
 
-  test('can instantiate with custom defaults', () => {
+  it('can instantiate with custom defaults', () => {
     const theme = new Theme(tokens);
     expect(theme.defaults).toMatchObject(tokens);
   });
 
-  test('can update tokens', async () => {
+  it('can update tokens', async () => {
     const theme = new Theme();
     const initialTokens = structuredClone(theme.tokens);
     theme.tokens = tokens;
@@ -21,7 +21,7 @@ describe('Theme', () => {
     return expect(updatedTokens).not.toMatchObject(initialTokens);
   });
 
-  test('can reset tokens', async () => {
+  it('can reset tokens', async () => {
     const theme = new Theme();
     theme.tokens = tokens;
     const updatedTokens = structuredClone(theme.tokens);
@@ -30,13 +30,13 @@ describe('Theme', () => {
     return expect(resettedTokens).not.toMatchObject(updatedTokens);
   });
 
-  test('can export to css custom properties', async () => {
+  it('can export to css custom properties', async () => {
     const theme = new Theme();
     const css = await theme.toCSS();
     return expect(css).toMatchSnapshot();
   });
 
-  test('can export to resolved css custom properties', async () => {
+  it('can export to resolved css custom properties', async () => {
     const theme = new Theme();
     const css = await theme.toCSS({ resolved: true });
     expect(css).toMatchSnapshot();

--- a/packages/theme-wizard-server/src/index.test.ts
+++ b/packages/theme-wizard-server/src/index.test.ts
@@ -1,5 +1,5 @@
 import * as cssScraper from '@nl-design-system-community/css-scraper';
-import { test, expect, describe, vi, beforeEach } from 'vitest';
+import { it, expect, describe, vi, beforeEach } from 'vitest';
 
 vi.mock('@vercel/related-projects', () => ({
   withRelatedProject: vi.fn(),
@@ -15,12 +15,12 @@ describe('cors', () => {
     vi.resetModules();
   });
 
-  test('allows request without origin', async () => {
+  it('allows request without origin', async () => {
     const response = await app.request('/');
     expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
   });
 
-  test('allows theme wizard website origin', async () => {
+  it('allows theme wizard website origin', async () => {
     const origin = 'http://localhost:8080';
     vi.mocked(withRelatedProject).mockReturnValue(origin);
     // Re-import app so it has withRelatedProject correctly mocked
@@ -31,7 +31,7 @@ describe('cors', () => {
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe(origin);
   });
 
-  test('disallows foreign origins', async () => {
+  it('disallows foreign origins', async () => {
     vi.mocked(withRelatedProject).mockReturnValue('https://example.com');
     // Re-import app so it has withRelatedProject correctly mocked
     const { default: app } = await import('./index');
@@ -43,33 +43,33 @@ describe('cors', () => {
 });
 
 describe('health check', () => {
-  test('returns correct response', async () => {
+  it('returns correct response', async () => {
     const response = await app.request('/healthz');
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({});
   });
 
-  test('does not send server timing header', async () => {
+  it('does not send server timing header', async () => {
     const response = await app.request('/healthz');
     expect(response.headers.get('server-timing')).toBeNull();
   });
 });
 
 describe('/api/v1', () => {
-  test('/ redirects to openapi', async () => {
+  it('/ redirects to openapi', async () => {
     const response = await app.request('/');
     expect.soft(response.status).toBe(302);
     expect.soft(response.headers.get('Location')).toBe('/api/v1/openapi.json');
   });
 
   describe('openapi.json', () => {
-    test('exists', async () => {
+    it('exists', async () => {
       const response = await app.request('/api/v1/openapi.json');
       expect.soft(response.status).toBe(200);
       expect.soft(response.headers.get('Content-Type')).toBe('application/json');
     });
 
-    test('lists all endpoints', async () => {
+    it('lists all endpoints', async () => {
       const response = await app.request('/api/v1/openapi.json');
       const data = await response.json();
       const endpoints = Object.keys(data.paths);
@@ -78,7 +78,7 @@ describe('/api/v1', () => {
   });
 
   describe('swagger docs', () => {
-    test('shows the UI', async () => {
+    it('shows the UI', async () => {
       const response = await app.request('/api/docs');
 
       expect.soft(response.status).toBe(200);
@@ -90,44 +90,43 @@ describe('/api/v1', () => {
   const mockedGetCssData = 'a { color: blue; }';
 
   describe('shared /css & /css-design-tokens', () => {
-    for (const url of ['/api/v1/css', '/api/v1/css-design-tokens']) {
-      test(`missing "url" query param (${url})`, async () => {
-        const response = await app.request(url);
-        expect.soft(response.status).toBe(400);
-        expect.soft(await response.json()).toEqual({
-          errors: [
-            {
-              name: 'invalid_type',
-              message: 'Invalid input: expected string, received undefined',
-              path: 'url',
-            },
-          ],
-          ok: false,
-        });
+    const endpoints = ['/api/v1/css', '/api/v1/css-design-tokens'];
+    it.each(endpoints)('missing "url" query param (%s)', async (url) => {
+      const response = await app.request(url);
+      expect.soft(response.status).toBe(400);
+      expect.soft(await response.json()).toEqual({
+        errors: [
+          {
+            name: 'invalid_type',
+            message: 'Invalid input: expected string, received undefined',
+            path: 'url',
+          },
+        ],
+        ok: false,
       });
+    });
 
-      test(`contains server-timing (${url})`, async () => {
-        vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
-        const response = await app.request(`${url}?url=example.com`);
-        const timingHeader = response.headers.get('server-timing');
-        expect.soft(timingHeader).toMatch(/scraping;dur=\d+(:?\.\d+);desc="Scraping CSS"/);
-      });
+    it.each(endpoints)(`contains server-timing (%s)`, async (url) => {
+      vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
+      const response = await app.request(`${url}?url=example.com`);
+      const timingHeader = response.headers.get('server-timing');
+      expect.soft(timingHeader).toMatch(/scraping;dur=\d+(:?\.\d+);desc="Scraping CSS"/);
+    });
 
-      test('contain security headers', async () => {
-        vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
-        const response = await app.request(`${url}?url=example.com`);
+    it.each(endpoints)('contain security headers (%s)', async (url) => {
+      vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
+      const response = await app.request(`${url}?url=example.com`);
 
-        const hsts = response.headers.get('Strict-Transport-Security');
-        expect.soft(hsts).toBe('max-age=15552000; includeSubDomains');
+      const hsts = response.headers.get('Strict-Transport-Security');
+      expect.soft(hsts).toBe('max-age=15552000; includeSubDomains');
 
-        const poweredBy = response.headers.get('X-Powered-By');
-        expect.soft(poweredBy).toBeNull();
-      });
-    }
+      const poweredBy = response.headers.get('X-Powered-By');
+      expect.soft(poweredBy).toBeNull();
+    });
   });
 
   describe('/css', () => {
-    test('returns a string of css', async () => {
+    it('returns a string of css', async () => {
       vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
       const response = await app.request('/api/v1/css?url=example.com');
 
@@ -135,7 +134,7 @@ describe('/api/v1', () => {
       expect.soft(response.headers.get('content-type')).toContain('text/css');
     });
 
-    test('server error', async () => {
+    it('server error', async () => {
       vi.spyOn(cssScraper, 'getCss').mockRejectedValueOnce(new Error('Generic error'));
       const response = await app.request('/api/v1/css?url=example.com');
 
@@ -158,7 +157,7 @@ describe('/api/v1', () => {
       }
     `;
 
-    test('returns tokens', async () => {
+    it('returns tokens', async () => {
       vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockCss);
       const response = await app.request('/api/v1/css-design-tokens?url=example.com');
 

--- a/packages/theme-wizard-server/src/scraping-error-handler.test.ts
+++ b/packages/theme-wizard-server/src/scraping-error-handler.test.ts
@@ -1,10 +1,10 @@
 import { ScrapingError } from '@nl-design-system-community/css-scraper';
 import { Hono } from 'hono';
-import { describe, test, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { withScrapingErrorHandler } from './scraping-error-handler';
 
 describe('withScrapingErrorHandler', () => {
-  test('converts scraping errors with statusCode to 400', async () => {
+  it('converts scraping errors with statusCode to 400', async () => {
     const app = new Hono();
     app.get(
       '/test',
@@ -26,7 +26,7 @@ describe('withScrapingErrorHandler', () => {
     });
   });
 
-  test('converts unknown errors to 500', async () => {
+  it('converts unknown errors to 500', async () => {
     const app = new Hono();
     app.get(
       '/test',
@@ -45,7 +45,7 @@ describe('withScrapingErrorHandler', () => {
     });
   });
 
-  test('returns response when no error', async () => {
+  it('returns response when no error', async () => {
     const app = new Hono();
     app.get(
       '/test',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: 22.19.0
         version: 22.19.0
+      '@vitest/eslint-plugin':
+        specifier: 1.4.3
+        version: 1.4.3(eslint@9.39.1)(typescript@5.9.3)(vitest@4.0.8)
       eslint:
         specifier: 9.39.1
         version: 9.39.1
@@ -2343,6 +2346,19 @@ packages:
       vitest: 4.0.8
     peerDependenciesMeta:
       '@vitest/browser':
+        optional: true
+
+  '@vitest/eslint-plugin@1.4.3':
+    resolution: {integrity: sha512-ba+YDKyZdViNAOg8P86a9tIEawPA/O+nLbwhg8g7nkqsLOAVum6GoZhkNxgwX621oqWAbB8N2xb+G5kkpXehcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: '>=8.57.0'
+      typescript: '>=5.0.0'
+      vitest: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vitest:
         optional: true
 
   '@vitest/expect@2.0.5':
@@ -8809,6 +8825,17 @@ snapshots:
       vitest: 4.0.8(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.19.0)(@vitest/browser-playwright@4.0.8)(tsx@4.19.2)(yaml@2.8.1)
     optionalDependencies:
       '@vitest/browser': 4.0.8(vite@7.2.2(@types/node@22.19.0)(tsx@4.19.2)(yaml@2.8.1))(vitest@4.0.8)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/eslint-plugin@1.4.3(eslint@9.39.1)(typescript@5.9.3)(vitest@4.0.8)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.46.3
+      '@typescript-eslint/utils': 8.46.3(eslint@9.39.1)(typescript@5.9.3)
+      eslint: 9.39.1
+    optionalDependencies:
+      typescript: 5.9.3
+      vitest: 4.0.8(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.19.0)(@vitest/browser-playwright@4.0.8)(tsx@4.19.2)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
closes #179 

- convert `test()` to `it()`
- convert some `for ... of()` to `it.each(list)('test name - %s', (item => {})`
- fixes some duplicate test titles