### PR TITLE
build: add npm keyword for expertteam-digitale-toegankelijkheid

### DIFF
--- a/.changeset/long-paws-ring.md
+++ b/.changeset/long-paws-ring.md
@@ -1,0 +1,10 @@
+---
+'@nl-design-system-community/theme-wizard-templates': patch
+'@nl-design-system-community/design-tokens-schema': patch
+'@nl-design-system-community/theme-wizard-server': patch
+'@nl-design-system-community/css-scraper': patch
+'@nl-design-system-community/theme-wizard-lit-components': patch
+'@nl-design-system-community/theme-wizard-website': patch
+---
+
+Add `expertteam-digitale-toegankelijkheid` keyword to npm packages.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Design system based on the NL Design System architecture",
   "license": "EUPL-1.2",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/packages/css-scraper/package.json
+++ b/packages/css-scraper/package.json
@@ -5,6 +5,7 @@
   "description": "CSS Scraper",
   "license": "EUPL-1.2",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/packages/design-tokens-schema/package.json
+++ b/packages/design-tokens-schema/package.json
@@ -5,6 +5,7 @@
   "description": "Zod schema's for Design Tokens JSON format",
   "license": "EUPL-1.2",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "type": "module",

--- a/packages/theme-wizard-server/package.json
+++ b/packages/theme-wizard-server/package.json
@@ -5,6 +5,7 @@
   "description": "Web server with REST API for scraping websites to extract design tokens",
   "license": "EUPL-1.2",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/packages/theme-wizard-templates/package.json
+++ b/packages/theme-wizard-templates/package.json
@@ -5,6 +5,7 @@
   "description": "Templates",
   "license": "EUPL-1.2",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "files": [

--- a/proprietary/assets/package.json
+++ b/proprietary/assets/package.json
@@ -5,6 +5,7 @@
   "description": "Assets",
   "license": "SEE LICENSE IN LICENSE.md",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/proprietary/design-tokens/package.json
+++ b/proprietary/design-tokens/package.json
@@ -5,6 +5,7 @@
   "description": "Example design tokens",
   "license": "SEE LICENSE IN LICENSE.md",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,

--- a/proprietary/font/package.json
+++ b/proprietary/font/package.json
@@ -6,6 +6,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "dist/index.css",
   "keywords": [
+    "expertteam-digitale-toegankelijkheid",
     "nl-design-system"
   ],
   "private": true,


### PR DESCRIPTION
Even een keyword toegevoegd zodat we makkelijk een overzicht van onze packages maken op npmjs.com:

https://www.npmjs.com/search?q=keywords%3Aexpertteam-digitale-toegankelijkheid