### PR TITLE
chore(design): remove font inputs && color gradients from UI

### DIFF
--- a/packages/theme-wizard-app/src/components/app/app.ts
+++ b/packages/theme-wizard-app/src/components/app/app.ts
@@ -19,15 +19,13 @@ import '../wizard-validation-issues-alert';
 import { WizardTokenInput } from '../wizard-token-input';
 import appStyles from './app.css';
 
-const BODY_FONT_TOKEN_REF = 'basis.text.font-family.default';
-const HEADING_FONT_TOKEN_REF = 'basis.heading.font-family';
 /**
  * Main application component - Orchestrator coordinator
  */
 @customElement('theme-wizard-app')
 export class App extends LitElement {
-  #storage = new PersistentStorage({ prefix: 'theme-wizard' });
-  #theme = new Theme();
+  readonly #storage = new PersistentStorage({ prefix: 'theme-wizard' });
+  readonly #theme = new Theme();
   private readonly scraper: Scraper = new Scraper(
     document.querySelector('meta[name=scraper-api]')?.getAttribute('content') || '',
   );
@@ -158,8 +156,6 @@ export class App extends LitElement {
   };
 
   override render() {
-    const bodyFontToken = this.#theme.at(BODY_FONT_TOKEN_REF);
-    const headingFontToken = this.#theme.at(HEADING_FONT_TOKEN_REF);
     return html`
       <div class="theme-app ma-theme">
         <wizard-download-confirmation
@@ -172,22 +168,6 @@ export class App extends LitElement {
           @config-change=${this.#handleSourceUrlChange}
         >
           <form @change=${this.#handleTokenChange} @reset=${this.#handleReset}>
-            <fieldset>
-              <legend>Lettertypes</legend>
-              <wizard-token-field
-                .errors=${this.#theme.issues}
-                .token=${headingFontToken}
-                label="Koppen"
-                path=${HEADING_FONT_TOKEN_REF}
-              ></wizard-token-field>
-              <wizard-token-field
-                .errors=${this.#theme.issues}
-                .token=${bodyFontToken}
-                label="Lopende tekst"
-                path=${BODY_FONT_TOKEN_REF}
-              ></wizard-token-field>
-            </fieldset>
-
             <details>
               <summary>Alle tokens</summary>
               <wizard-token-field

--- a/packages/theme-wizard-app/src/components/sidebar/sidebar.ts
+++ b/packages/theme-wizard-app/src/components/sidebar/sidebar.ts
@@ -17,8 +17,6 @@ import '../color-scale-picker';
 @customElement('theme-wizard-sidebar')
 export class LitSidebar extends LitElement {
   @property() sourceUrl = DEFAULT_CONFIG.sourceUrl;
-  @property() headingFont = DEFAULT_CONFIG.headingFont;
-  @property() bodyFont = DEFAULT_CONFIG.bodyFont;
   @property({ attribute: false }) onResetTheme?: () => void;
 
   @state() brandColors: ColorToken[] = [];
@@ -58,8 +56,6 @@ export class LitSidebar extends LitElement {
 
     const form = event.currentTarget as HTMLFormElement;
     const formData = new FormData(form);
-    const headingFont = formData.get('heading-font');
-    const bodyFont = formData.get('body-font');
     const brandColors = formData.get('brand-colors');
     // @TODO: Use defined color scales
     // const colorScales = formData.getAll('color-scale');
@@ -67,25 +63,7 @@ export class LitSidebar extends LitElement {
     this.brandColors = this.colorOptions
       .filter(({ value }) => (typeof brandColors === 'string' ? brandColors : '').split(',').includes(value))
       .map(({ token }) => token);
-
-    this.notifyConfigChange({
-      bodyFont: typeof bodyFont === 'string' ? bodyFont : '',
-      headingFont: typeof headingFont === 'string' ? headingFont : '',
-    });
   };
-
-  get fontOptions() {
-    return this.scrapedTokens
-      .filter((token) => token.$type === 'fontFamily')
-      .map((token) => {
-        const { $extensions, $value } = token;
-        const value = $value.join(', ');
-        return {
-          label: $extensions[EXTENSION_AUTHORED_AS],
-          value,
-        };
-      });
-  }
 
   get colorOptions() {
     return this.scrapedTokens
@@ -119,32 +97,18 @@ export class LitSidebar extends LitElement {
                 placeholder="https://example.com"
                 .value=${this.sourceUrl || ''}
               />
-
               <utrecht-button appearance="primary-action-button" type="submit">Analyseer</utrecht-button>
             </div>
           </section>
         </form>
 
         <form class="theme-sidebar__form" @change=${this.handleThemeForm} @submit=${this.handleThemeForm}>
-          <fieldset>
-            <legend>Kleuren</legend>
-            <color-select
-              id="color-select"
-              name="brand-colors"
-              label="Basiskleuren"
-              .options=${this.colorOptions}
-            ></color-select>
-
-            <fieldset>
-              <legend>Kleurverlopen</legend>
-              <color-scale-picker name="color-scale"></color-scale-picker>
-              <output for="color-select">
-                ${this.brandColors.map(
-                  (token) => html` <color-scale-picker .from=${token} name="color-scale"></color-scale-picker>`,
-                )}
-              </output>
-            </fieldset>
-          </fieldset>
+          <color-select
+            id="color-select"
+            name="brand-colors"
+            label="Basiskleuren"
+            .options=${this.colorOptions}
+          ></color-select>
         </form>
 
         <slot></slot>

--- a/packages/theme-wizard-website/e2e/fixtures/fixtures.ts
+++ b/packages/theme-wizard-website/e2e/fixtures/fixtures.ts
@@ -1,5 +1,4 @@
-import { test as base, type Locator } from '@playwright/test';
-import { expect as baseExpect } from '@playwright/test';
+import { test as base } from '@playwright/test';
 import { ThemeWizardPage } from '../pages/ThemeWizardPage';
 
 type ThemeWizardFixture = {
@@ -7,16 +6,6 @@ type ThemeWizardFixture = {
   previewPage: ThemeWizardPage;
   collagePage: ThemeWizardPage;
 };
-
-type MatcherResult =
-  | {
-      actual?: string;
-      expected: string;
-      name: string;
-      message?: string;
-      pass: boolean;
-    }
-  | undefined;
 
 export const test = base.extend<ThemeWizardFixture>({
   collagePage: async ({ page }, use) => {
@@ -40,51 +29,4 @@ export const test = base.extend<ThemeWizardFixture>({
   },
 });
 
-export const expect = baseExpect.extend({
-  async toHaveFont(locator: Locator, expectedFont: string, options?: { timeout?: number }) {
-    const assertionName = 'toHaveFont';
-    let pass: boolean;
-    let matcherResult: MatcherResult = undefined;
-
-    try {
-      const expectation = this.isNot ? baseExpect(locator).not : baseExpect(locator);
-      await expectation.toHaveCSS('font-family', new RegExp(expectedFont), options);
-      pass = true;
-    } catch (error: unknown) {
-      if (error instanceof Error && 'matcherResult' in error) {
-        matcherResult = error.matcherResult as MatcherResult;
-      } else {
-        throw new Error('Failed to get font family');
-      }
-      pass = false;
-    }
-
-    if (this.isNot) {
-      pass = !pass;
-    }
-
-    const locatorString = (locator as { toString(): string }).toString();
-
-    const message = pass
-      ? () =>
-          this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
-          '\n\n' +
-          `Locator: ${locatorString}\n` +
-          `Expected: not ${this.utils.printExpected(expectedFont)}\n` +
-          (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '')
-      : () =>
-          this.utils.matcherHint(assertionName, undefined, undefined, { isNot: this.isNot }) +
-          '\n\n' +
-          `Locator: ${locatorString}\n` +
-          `Expected: ${this.utils.printExpected(expectedFont)}\n` +
-          (matcherResult ? `Received: ${this.utils.printReceived(matcherResult.actual)}` : '');
-
-    return {
-      name: assertionName,
-      actual: matcherResult?.actual,
-      expected: expectedFont,
-      message,
-      pass,
-    };
-  },
-});
+export { expect } from '@playwright/test';

--- a/packages/theme-wizard-website/e2e/pages/ThemeWizardPage.ts
+++ b/packages/theme-wizard-website/e2e/pages/ThemeWizardPage.ts
@@ -33,14 +33,6 @@ export class ThemeWizardPage {
     await this.templateSelect.selectOption({ label: templateName });
   }
 
-  async changeHeadingFont(fontName: string) {
-    await this.page.getByLabel('Koppen').selectOption({ label: fontName });
-  }
-
-  async changeBodyFont(fontName: string) {
-    await this.page.getByLabel('Lopende tekst').selectOption({ label: fontName });
-  }
-
   /** @param colorHexValue A 6-digit hex value */
   async changeColor(label: string, colorHexValue: string) {
     const input = this.page.getByLabel(label);

--- a/packages/theme-wizard-website/e2e/wizard.spec.ts
+++ b/packages/theme-wizard-website/e2e/wizard.spec.ts
@@ -14,24 +14,6 @@ test.describe('scraping css design tokens', () => {
   });
 });
 
-test.describe('change fonts', () => {
-  test('can change heading font to Courier New on preview', async ({ previewPage }) => {
-    const heading = previewPage.getHeading(2);
-
-    await expect(heading).not.toHaveFont('Courier New');
-    await previewPage.changeHeadingFont('Courier New');
-    await expect(heading).toHaveFont('Courier New');
-  });
-
-  test('can change body font to Arial', async ({ previewPage }) => {
-    const paragraph = previewPage.getParagraph();
-
-    await expect(paragraph).not.toHaveFont('Arial');
-    await previewPage.changeBodyFont('Arial');
-    await expect(paragraph).toHaveFont('Arial');
-  });
-});
-
 test.describe('Download tokens as JSON', () => {
   test('initial button state is correct', async ({ themeWizard }) => {
     await expect(themeWizard.downloadButton).toBeVisible();
@@ -39,7 +21,8 @@ test.describe('Download tokens as JSON', () => {
   });
 
   test('does not show confirmation modal when there are no validation errors', async ({ page, themeWizard }) => {
-    await themeWizard.changeBodyFont('Arial');
+    await themeWizard.sidebar.locator('summary').click();
+    await themeWizard.changeColor('{basis.color.accent-1.bg-active}', '#cccccc');
     await expect(themeWizard.downloadButton).toBeEnabled();
 
     const downloadPromise = page.waitForEvent('download');
@@ -94,7 +77,8 @@ test.describe('Download tokens as JSON', () => {
 
   test.describe('after changing a token', () => {
     test.beforeEach(async ({ themeWizard }) => {
-      await themeWizard.changeBodyFont('Arial');
+      await themeWizard.sidebar.locator('summary').click();
+      await themeWizard.changeColor('{basis.color.accent-1.bg-active}', '#f1f1f1');
     });
 
     test('Button becomes active after changes made', async ({ themeWizard }) => {
@@ -114,8 +98,6 @@ test.describe('Download tokens as JSON', () => {
     });
 
     test('Button remains enabled when validation errors are found', async ({ themeWizard }) => {
-      // Make sure the color inputs are visible so we can interact with them
-      await themeWizard.sidebar.locator('summary').click();
       // Trigger a contrast warning
       await themeWizard.changeColor('{basis.color.accent-1.bg-active}', '#000000');
 


### PR DESCRIPTION
Schoont de UI op zodat het makkelijker is om zometeen een betere UI te implementeren.

- verwijder font inputs (+ bijbehorende tests). Deze komen later terug nadat #221 is gedaan
- verwijder kleurverlopen, deze komen later mogelijk in andere vorm, mogelijk nadat #222 is gedaan

refs #219