### PR TITLE
ci: automatically add GitHub Issues to project

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add issues project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    environment: issues
+    steps:
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          project-url: https://github.com/orgs/nl-design-system/projects/70
+          github-token: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}


### PR DESCRIPTION
Experiment. Ik moet nog de environment tokens instellen, maar ik denk dat we deze moeten mergen om te testen.

De werking is er van afhankelijk dat de environment bestaat en dat de token is ingesteld

- [x] Terraform PR maken voor environment https://github.com/nl-design-system/terraform/pull/521
- [ ] Terraform wijziging uitrollen
- [ ] personal access token maken
- [ ] De `ADD_TO_PROJECT_GITHUB_TOKEN` instellen in de project
- [ ] Deze PR mergen
- [ ] Testen of een nieuwe issue maken een github workflow triggert, toegang heeft tot de environment en de issue automatisch toevoegt aan het project