### PR TITLE
chore: locally also retry playwright test once

### DIFF
--- a/packages/theme-wizard-website/playwright.config.ts
+++ b/packages/theme-wizard-website/playwright.config.ts
@@ -33,8 +33,7 @@ const config: PlaywrightTestConfig = {
   ],
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? [['github'], ['list']] : 'list',
-  /* Retry on CI only */
-  retries: process.env.CI ? 1 : 0,
+  retries: 1,
   testDir: './e2e',
   testMatch: '**/*spec.ts',
   /* Maximum time one test can run for. */


### PR DESCRIPTION
Retry playwright test locally so it is easy to obtain a trace locally.