### PR TITLE
chore(theme-wizard-app): restore live reload

### DIFF
--- a/packages/theme-wizard-app/package.json
+++ b/packages/theme-wizard-app/package.json
@@ -9,7 +9,10 @@
     "directory": "packages/theme-wizard-app"
   },
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./theme.css": "./theme.css"
   },
   "files": [
@@ -17,7 +20,7 @@
     "theme.css"
   ],
   "scripts": {
-    "dev": "vite",
+    "dev": "vite build --watch",
     "types": "tsc -p tsconfig.json --emitDeclarationOnly",
     "type-check": "tsc --noEmit --project tsconfig.json",
     "build": "pnpm run type-check && pnpm run types && vite build",

--- a/packages/theme-wizard-app/tsconfig.json
+++ b/packages/theme-wizard-app/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["ES2024", "DOM"],
     "strict": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": false,
     "outDir": "dist",
     "types": ["vite/client"],


### PR DESCRIPTION
Instead of running vite in dev mode in the `theme-wizard-app`, it should run a watcher on the build. That way the dependency in the `theme-wizard-website` is always using the latest version and we have live reloading when working on components further downstream