### PR TITLE
fix(wizard-font-input): maintain font family token value type

### DIFF
--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -49,7 +49,7 @@ export class WizardFontInput extends WizardTokenInput {
   readonly #handleChange = (event: Event) => {
     const target = event.target;
     if (!(target instanceof ClippyFontCombobox)) return;
-    this.value = `${target.value}`;
+    this.value = target.value ?? '';
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   };
 


### PR DESCRIPTION
Make sure that the type (`string | string[]`) of font family design token value is maintained when updating it via the input and not flattened to a string