### PR TITLE
fix: avoid nesting `<p>` inside `<p>`

### DIFF
--- a/packages/theme-wizard-templates/src/pages/gemeentevoorbeeld/components/OpeningHoursCard/index.tsx
+++ b/packages/theme-wizard-templates/src/pages/gemeentevoorbeeld/components/OpeningHoursCard/index.tsx
@@ -34,7 +34,7 @@ const OpeningHoursCard = ({ openingHoursSummary = [] }: OpeningHoursCardProps) =
           <div className="opening-hours-summary">
             {openingHoursSummary.map((item) => (
               <Fragment key={item.label}>
-                <p className="opening-hours-item">
+                <div className="opening-hours-item">
                   <strong>{item.label}:</strong>{' '}
                   <p>
                     {item.hours ? (
@@ -50,7 +50,7 @@ const OpeningHoursCard = ({ openingHoursSummary = [] }: OpeningHoursCardProps) =
                       <span>gesloten</span>
                     )}
                   </p>
-                </p>
+                </div>
 
                 <br />
               </Fragment>


### PR DESCRIPTION
Deze error kreeg ik steeds lokaal en is hiermee verholpen.

```
In HTML, <p> cannot be a descendant of <p>.
This will cause a hydration error.

  ...
    <div className="utrecht-pa...">
      <main id="main">
        <MainIntroSection openingHoursSummary={[...]}>
          <PageContent>
            <div ref={null} className="utrecht-pa...">
              <Heading2>
              <section>
                <Heading2>
                <Row align="stretch" columnGap="var(--basi..." rowGap="var(--basi..." justify="space-between" ...>
                  <div className="clippy-row..." style={{...}}>
                    <Column>
                    <Column cols={3}>
                      <div className="clippy-col...">
                        <OpeningHoursCard openingHoursSummary={[...]}>
                          <div className="clippy-voo...">
                            <Icon>
                            <section aria-labelledby="openingsti...">
                              <Heading2>
                              <div className="opening-ho...">
>                               <p className="opening-hours-item">
                                  <strong>
>                                 <p>
```