### PR TITLE
Zorg dat de gebruiker een reset van de Theme Wizard moet bevestigen

### DIFF
--- a/packages/theme-wizard-app/index.ts
+++ b/packages/theme-wizard-app/index.ts
@@ -12,3 +12,4 @@ import './src/components/wizard-scraper';
 import './src/components/wizard-story-react';
 import './src/components/wizard-react-element';
 import './src/components/wizard-story-preview';
+import './src/components/wizard-theme-reset-button';

--- a/packages/theme-wizard-app/src/components/wizard-style-guide/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide/index.ts
@@ -1,4 +1,3 @@
-import type { ClippyModal } from '@nl-design-system-community/clippy-components/clippy-modal';
 import type { DesignToken } from 'style-dictionary/types';
 import { consume } from '@lit/context';
 import '@nl-design-system-community/clippy-components/clippy-html-image';
@@ -31,6 +30,7 @@ import { html as staticHtml } from 'lit/static-html.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
+import { isClippyModal } from '../../utils/assertions';
 import { resolveColorValue } from '../wizard-colorscale-input';
 import styles from './styles';
 
@@ -193,7 +193,8 @@ export class WizardStyleGuide extends LitElement {
 
     if (token !== undefined) {
       this.requestUpdate();
-      const dialog = this.renderRoot.querySelector('#token-dialog')! as ClippyModal;
+      const dialog = this.renderRoot.querySelector('#token-dialog');
+      if (!isClippyModal(dialog)) return;
 
       dialog.addEventListener(
         'close',

--- a/packages/theme-wizard-app/src/components/wizard-theme-reset-button/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-theme-reset-button/index.ts
@@ -1,0 +1,62 @@
+import { consume } from '@lit/context';
+import '@nl-design-system-community/clippy-components/clippy-button';
+import { ClippyModal } from '@nl-design-system-community/clippy-components/clippy-modal';
+import { LitElement, html } from 'lit';
+import { customElement, query } from 'lit/decorators.js';
+import type Theme from '../../lib/Theme';
+import { themeContext } from '../../contexts/theme';
+import { t } from '../../i18n';
+
+const tag = 'wizard-theme-reset-button';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: WizardThemeResetButton;
+  }
+}
+
+@customElement(tag)
+export class WizardThemeResetButton extends LitElement {
+  @consume({ context: themeContext, subscribe: true })
+  private readonly theme!: Theme;
+
+  @query('clippy-modal')
+  private readonly modalDialog!: ClippyModal;
+
+  readonly #handleClick = () => {
+    this.modalDialog?.open();
+  };
+
+  readonly #handleDialogClose = (event: Event) => {
+    const dialog = event.currentTarget as ClippyModal;
+    if (dialog.returnValue === 'confirm') {
+      this.dispatchEvent(new Event('reset', { bubbles: true, composed: true }));
+    }
+  };
+
+  override render() {
+    if (!this.theme) {
+      return html``;
+    }
+
+    return html`
+      <clippy-modal
+        .title=${t('themeResetDialog.title')}
+        actions="both"
+        .confirmLabel=${t('themeResetDialog.confirm')}
+        .cancelLabel=${t('themeResetDialog.cancel')}
+        @close=${this.#handleDialogClose}
+      >
+        <p>${t('themeResetDialog.body')}</p>
+      </clippy-modal>
+
+      <div @click=${this.#handleClick} style="display:contents">
+        <slot>
+          <clippy-button purpose="subtle" hint="negative" type="button" ?disabled=${!this.theme.modified}>
+            ${t('themeResetDialog.triggerText')}
+          </clippy-button>
+        </slot>
+      </div>
+    `;
+  }
+}

--- a/packages/theme-wizard-app/src/components/wizard-theme-reset-button/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-theme-reset-button/index.ts
@@ -6,6 +6,7 @@ import { customElement, query } from 'lit/decorators.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
+import { isClippyModal } from '../../utils/assertions';
 
 const tag = 'wizard-theme-reset-button';
 
@@ -28,17 +29,14 @@ export class WizardThemeResetButton extends LitElement {
   };
 
   readonly #handleDialogClose = (event: Event) => {
-    const dialog = event.currentTarget as ClippyModal;
+    const dialog = event.currentTarget;
+    if (!isClippyModal(dialog)) return;
     if (dialog.returnValue === 'confirm') {
       this.dispatchEvent(new Event('reset', { bubbles: true, composed: true }));
     }
   };
 
   override render() {
-    if (!this.theme) {
-      return html``;
-    }
-
     return html`
       <clippy-modal
         .title=${t('themeResetDialog.title')}

--- a/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
@@ -33,10 +33,6 @@ export class WizardTokensForm extends LitElement {
   @consume({ context: themeContext, subscribe: true })
   private readonly theme!: Theme;
 
-  readonly #handleReset = () => {
-    this.dispatchEvent(new Event('reset', { bubbles: true, composed: true }));
-  };
-
   override render() {
     if (!this.theme) {
       return html`<div>Loading...</div>`;
@@ -56,9 +52,7 @@ export class WizardTokensForm extends LitElement {
     ];
 
     return html`
-      <form @reset=${this.#handleReset}>
-        <button class="utrecht-link-button utrecht-link-button--html-button" type="reset">Reset tokens</button>
-
+      <form>
         <ul class="wizard-app__basis-tokens">
           ${fonts.map(
             ({ label, path, token }) =>

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -96,6 +96,13 @@ export const en = {
     unusedTokenWarning: 'This token is defined but never used in acomponent.',
     value: 'Value',
   },
+  themeResetDialog: {
+    body: 'Are you sure you want to reset all token values to their defaults? This cannot be undone.',
+    cancel: () => t('cancel'),
+    confirm: 'Reset theme',
+    title: 'Reset theme',
+    triggerText: 'Reset theme',
+  },
   tokenDownloadDialog: {
     body: 'There are still errors in your theme. This may lead to issues with readability, contrast, or consistency. Do you still want to download the tokens?',
     cancel: () => t('cancel'),
@@ -366,6 +373,13 @@ export const nl = {
     tokenName: 'Naam',
     unusedTokenWarning: 'Token is gedefinieerd maar wordt nooit toegepast op een component.',
     value: 'Waarde',
+  },
+  themeResetDialog: {
+    body: 'Weet je zeker dat je alle tokenwaarden wilt terugzetten naar de standaardwaarden? Dit kan niet ongedaan worden gemaakt.',
+    cancel: () => t('cancel'),
+    confirm: 'Thema resetten',
+    title: 'Thema resetten',
+    triggerText: 'Thema resetten',
   },
   tokenDownloadDialog: {
     body: 'Er zijn nog fouten gevonden in je thema. Dit kan leiden tot problemen met leesbaarheid, contrast of consistentie. Wil je de tokens toch downloaden?',

--- a/packages/theme-wizard-app/src/utils/assertions.ts
+++ b/packages/theme-wizard-app/src/utils/assertions.ts
@@ -1,0 +1,5 @@
+import { ClippyModal } from '@nl-design-system-community/clippy-components/clippy-modal';
+
+export const isClippyModal = (element: unknown): element is ClippyModal => {
+  return element instanceof ClippyModal;
+};

--- a/packages/theme-wizard-website/e2e/pages/ThemeWizardPage.ts
+++ b/packages/theme-wizard-website/e2e/pages/ThemeWizardPage.ts
@@ -70,6 +70,7 @@ export class ThemeWizardPage {
   }
 
   async reset() {
-    await this.page.getByRole('button', { name: 'Reset tokens' }).click();
+    await this.page.getByRole('button', { name: 'Thema resetten' }).click();
+    await this.page.getByRole('dialog').getByRole('button', { name: 'Thema resetten ' }).click();
   }
 }

--- a/packages/theme-wizard-website/e2e/pages/ThemeWizardPage.ts
+++ b/packages/theme-wizard-website/e2e/pages/ThemeWizardPage.ts
@@ -71,6 +71,6 @@ export class ThemeWizardPage {
 
   async reset() {
     await this.page.getByRole('button', { name: 'Thema resetten' }).click();
-    await this.page.getByRole('dialog').getByRole('button', { name: 'Thema resetten ' }).click();
+    await this.page.getByRole('dialog').getByRole('button', { name: 'Thema resetten' }).click();
   }
 }

--- a/packages/theme-wizard-website/src/pages/index.astro
+++ b/packages/theme-wizard-website/src/pages/index.astro
@@ -41,6 +41,7 @@ if (!currentTemplate) {
         <section>
           <h2>Download thema</h2>
           <wizard-tokens-download></wizard-tokens-download>
+          <wizard-theme-reset-button></wizard-theme-reset-button>
         </section>
       </div>
 


### PR DESCRIPTION
refs #578

- verplaats reset button naar beneden, ver weg van de initial view
- toon dialog voordat we thema resetten voor bevestiging
- toon hint=negative purpose=subtle button als default
- Sta toe dat consumer van deze web component een andere button rendert
- Update Page Object Model om deze reset dialog te approven 😍 
- implementatie geinspireerd op de tokens json download button

<img width="1700" height="1197" alt="Screenshot 2026-02-27 at 13 40 31" src="https://github.com/user-attachments/assets/45cc335d-e2d3-4dba-90c2-0343365f61e0" />
