### PR TITLE
Fix de kleur preview in de Color Combobox

### DIFF
--- a/packages/clippy-components/src/clippy-color-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-color-combobox/styles.ts
@@ -4,5 +4,6 @@ export default css`
   .clippy-color-combobox__option {
     align-items: center;
     display: flex;
+    gap: var(--clippy-color-combobox-option-gap, var(--basis-space-inline-md));
   }
 `;

--- a/packages/clippy-components/src/clippy-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-combobox/styles.ts
@@ -5,21 +5,24 @@ export default css`
     inline-size: 100%;
     position: relative;
   }
+
   .clippy-combobox__current-option {
     pointer-events: none;
     position: absolute;
     display: flex;
-    // Clip contents when current option exceeds input size
+    /* Clip contents when current option exceeds input size */
     inline-size: 100%;
     white-space: nowrap;
-    overflow: hidden;
+    overflow: clip;
     align-items: center;
   }
+
   .clippy-combobox__current-option:has(+ input:focus) {
     display: none;
   }
+
   /* added specificity to override the align-items now that the flex direction changes */
-  .clippy-combobox__option.utrecht-listbox__option {
+  .clippy-combobox__option[class] {
     display: flex;
     flex-direction: column;
     align-items: unset;

--- a/packages/clippy-components/src/clippy-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-combobox/styles.ts
@@ -5,24 +5,21 @@ export default css`
     inline-size: 100%;
     position: relative;
   }
-
   .clippy-combobox__current-option {
     pointer-events: none;
     position: absolute;
     display: flex;
-    /* Clip contents when current option exceeds input size */
+    // Clip contents when current option exceeds input size
     inline-size: 100%;
     white-space: nowrap;
-    overflow: clip;
+    overflow: hidden;
     align-items: center;
   }
-
   .clippy-combobox__current-option:has(+ input:focus) {
     display: none;
   }
-
   /* added specificity to override the align-items now that the flex direction changes */
-  .clippy-combobox__option[class] {
+  .clippy-combobox__option.utrecht-listbox__option {
     display: flex;
     flex-direction: column;
     align-items: unset;

--- a/packages/design-tokens-schema/src/index.ts
+++ b/packages/design-tokens-schema/src/index.ts
@@ -6,6 +6,7 @@ export * from './tokens/token-reference';
 export * from './validation-issue';
 export * from './basis-tokens';
 export * from './theme';
+export * from './extensions';
 export * from './resolve-refs';
 export * from './remove-non-token-properties';
 export * from './upgrade-legacy-tokens';

--- a/packages/design-tokens-schema/src/resolve-refs.ts
+++ b/packages/design-tokens-schema/src/resolve-refs.ts
@@ -42,6 +42,10 @@ export const resolveRefs = (config: unknown, root: Record<string, unknown>): voi
     // Ensure ref is a token object with $value and $type
     if (!isTokenLike(ref)) return;
 
+    // Clear any previously resolved value before setting to avoid array concatenation
+    // when resolveRefs is called multiple times on the same token object.
+    delete token.$extensions?.[EXTENSION_RESOLVED_AS];
+
     // Add an extension with the resolved ref's value
     setExtension(token, EXTENSION_RESOLVED_AS, structuredClone(ref.$value));
   });

--- a/packages/theme-wizard-app/src/components/app/app.ts
+++ b/packages/theme-wizard-app/src/components/app/app.ts
@@ -7,7 +7,7 @@ import { themeContext } from '../../contexts/theme';
 import PersistentStorage from '../../lib/PersistentStorage';
 import Theme from '../../lib/Theme';
 import { EXTENSION_TOKEN_STAGED, StagedDesignToken } from '../../utils/types';
-import { WizardColorscaleInput } from '../wizard-colorscale-input';
+import { WizardColorscaleInput, EXTENSION_COLORSCALE_SEED } from '../wizard-colorscale-input';
 import { WizardScraper } from '../wizard-scraper';
 import { WizardTokenCombobox } from '../wizard-token-combobox';
 import { WizardTokenInput } from '../wizard-token-input';
@@ -125,6 +125,7 @@ export class App extends LitElement {
         ];
       });
       this.theme.updateMany(updates);
+      this.theme.setGroupExtension(target.name, EXTENSION_COLORSCALE_SEED, target.seedColor);
     } else if (target instanceof WizardTokenCombobox) {
       this.theme.updateAt(target.name, target.value?.$value);
     } else if (target instanceof WizardTokenInput) {

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/index.ts
@@ -5,10 +5,11 @@ import { EXTENSION_AUTHORED_AS } from '@nl-design-system-community/css-scraper';
 import {
   COLOR_KEYS,
   ColorValue,
+  ColorValueSchema,
   EXTENSION_RESOLVED_AS,
-  isRef,
   parseColor,
   stringifyColor,
+  type BaseDesignToken,
   type ColorSpace,
   type ColorToken as ColorTokenType,
 } from '@nl-design-system-community/design-tokens-schema';
@@ -52,53 +53,14 @@ const transformScaleToColorKeys = (scaleObject: ColorScaleObject) => {
 };
 
 /**
- * Look up a token by its reference path
+ * Extract the resolved color value from a token.
+ * Relies on `EXTENSION_RESOLVED_AS` being populated by `resolveRefs`, which
+ * Theme does on every token update.
  */
-const resolveTokenRef = (refString: string, allTokens: Record<string, unknown>): unknown => {
-  const refPath = refString.replaceAll(/[{}]/g, '').split('.');
-  let current: unknown = allTokens;
-  for (const key of refPath) {
-    if (typeof current === 'object' && current !== null && key in current) {
-      current = (current as Record<string, unknown>)[key];
-    } else {
-      return undefined;
-    }
-  }
-  return current;
-};
-
-/**
- * Extract the resolved color value from a token
- */
-export const resolveColorValue = (
-  token: ColorTokenType,
-  allTokens?: Record<string, unknown>,
-): ColorValue | undefined => {
-  // Guard against non-object tokens
-  if (!token || typeof token !== 'object') {
-    return undefined;
-  }
-
-  // Get the resolved color value from extensions or fallback to token's $value
-  if (isRef(token['$value'])) {
-    const resolved = token['$extensions']?.[EXTENSION_RESOLVED_AS];
-    // If resolved value is an object with colorSpace, return it
-    if (resolved && typeof resolved === 'object' && 'colorSpace' in resolved) {
-      return resolved as ColorValue;
-    }
-    // If resolved value is a string ref and we have allTokens, recursively resolve it
-    if (typeof resolved === 'string' && allTokens) {
-      const refToken = resolveTokenRef(resolved, allTokens);
-      if (refToken && typeof refToken === 'object') {
-        return resolveColorValue(refToken as ColorTokenType, allTokens);
-      }
-    }
-  }
-  const value = token['$value'];
-  if (value && typeof value === 'object' && 'colorSpace' in value) {
-    return value as ColorValue;
-  }
-  return undefined;
+export const resolveColorValue = (token: ColorTokenType): ColorValue | undefined => {
+  const value = token.$extensions?.[EXTENSION_RESOLVED_AS] ?? token.$value;
+  const result = ColorValueSchema.safeParse(value);
+  return result.success ? result.data : undefined;
 };
 
 export const EXTENSION_COLORSCALE_SEED = 'nl.nldesignsystem.theme-wizard.color-scale-seed-color';
@@ -168,8 +130,8 @@ export class WizardColorscaleInput extends WizardTokenInput {
   }
 
   get #seedColor(): ColorValue | undefined {
-    const group = this.theme?.at(this.name) as Record<string, unknown> | undefined;
-    const seedColor = (group?.['$extensions'] as Record<string, unknown> | undefined)?.[EXTENSION_COLORSCALE_SEED];
+    const group = this.theme?.at(this.name) as BaseDesignToken | undefined;
+    const seedColor = group?.$extensions?.[EXTENSION_COLORSCALE_SEED];
     if (seedColor && typeof seedColor === 'object' && 'colorSpace' in seedColor) {
       return seedColor as ColorValue;
     }
@@ -183,7 +145,7 @@ export class WizardColorscaleInput extends WizardTokenInput {
   #updateColorFromToken(colorToken: ColorTokenType | undefined) {
     if (!colorToken) return;
     try {
-      const colorValue = resolveColorValue(colorToken, this.theme?.tokens as Record<string, unknown>);
+      const colorValue = resolveColorValue(colorToken);
       if (colorValue) {
         this.#scale.from = new ColorToken({ $value: colorValue });
         this.currentColorValue = stringifyColor(colorValue);

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/index.ts
@@ -175,12 +175,6 @@ export class WizardColorscaleInput extends WizardTokenInput {
   }
 
   override willUpdate(changedProperties: Map<string, unknown>) {
-    // If the full value is being set, restore from it (takes precedence)
-    if (changedProperties.has('value')) {
-      this.#updateColorFromToken(this.colorToken);
-      return;
-    }
-
     // Initialize from the colorToken property if changed
     if (changedProperties.has('colorToken')) {
       this.#updateColorFromToken(this.colorToken);

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/index.ts
@@ -12,9 +12,13 @@ import {
   type ColorSpace,
   type ColorToken as ColorTokenType,
 } from '@nl-design-system-community/design-tokens-schema';
+import { dequal } from 'dequal';
 import { html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import type Theme from '../../lib/Theme';
 import { scrapedTokensContext } from '../../contexts/scraped-tokens';
+import { themeContext } from '../../contexts/theme';
 import ColorScale from '../../lib/ColorScale';
 import ColorToken from '../../lib/ColorToken';
 import { EXTENSION_TOKEN_STAGED, StagedDesignToken } from '../../utils';
@@ -97,6 +101,8 @@ export const resolveColorValue = (
   return undefined;
 };
 
+export const EXTENSION_COLORSCALE_SEED = 'nl.nldesignsystem.theme-wizard.color-scale-seed-color';
+
 const tag = 'wizard-colorscale-input';
 
 declare global {
@@ -146,8 +152,9 @@ export class WizardColorscaleInput extends WizardTokenInput {
     this.requestUpdate('value', oldValue);
   }
 
-  @property({ attribute: false })
-  colorToken?: ColorTokenType;
+  @consume({ context: themeContext, subscribe: true })
+  @state()
+  private readonly theme?: Theme;
 
   @consume({ context: scrapedTokensContext, subscribe: true })
   @property({ attribute: false })
@@ -156,10 +163,27 @@ export class WizardColorscaleInput extends WizardTokenInput {
   @state()
   private currentColorValue: string = '';
 
+  get #colorToken(): ColorTokenType | undefined {
+    return this.theme?.at(`${this.name}.color-default`) as ColorTokenType | undefined;
+  }
+
+  get #seedColor(): ColorValue | undefined {
+    const group = this.theme?.at(this.name) as Record<string, unknown> | undefined;
+    const seedColor = (group?.['$extensions'] as Record<string, unknown> | undefined)?.[EXTENSION_COLORSCALE_SEED];
+    if (seedColor && typeof seedColor === 'object' && 'colorSpace' in seedColor) {
+      return seedColor as ColorValue;
+    }
+    return undefined;
+  }
+
+  get seedColor(): ColorValue {
+    return this.#scale.from.$value;
+  }
+
   #updateColorFromToken(colorToken: ColorTokenType | undefined) {
     if (!colorToken) return;
     try {
-      const colorValue = resolveColorValue(colorToken);
+      const colorValue = resolveColorValue(colorToken, this.theme?.tokens as Record<string, unknown>);
       if (colorValue) {
         this.#scale.from = new ColorToken({ $value: colorValue });
         this.currentColorValue = stringifyColor(colorValue);
@@ -175,9 +199,14 @@ export class WizardColorscaleInput extends WizardTokenInput {
   }
 
   override willUpdate(changedProperties: Map<string, unknown>) {
-    // Initialize from the colorToken property if changed
-    if (changedProperties.has('colorToken')) {
-      this.#updateColorFromToken(this.colorToken);
+    if (changedProperties.has('theme') || changedProperties.has('name')) {
+      const seedColor = this.#seedColor;
+      if (seedColor) {
+        this.#scale.from = new ColorToken({ $value: seedColor });
+        this.currentColorValue = stringifyColor(seedColor);
+      } else {
+        this.#updateColorFromToken(this.#colorToken);
+      }
       this.#updateScaleValue();
     }
   }
@@ -196,13 +225,15 @@ export class WizardColorscaleInput extends WizardTokenInput {
     const target = event.target;
     if (target instanceof ClippyColorCombobox && target.value) {
       const value = typeof target.value === 'string' ? parseColor(target.value) : target.value;
+      const newColorValue = stringifyColor(value);
+      // Skip initialization-triggered events where the value hasn't actually changed
+      if (newColorValue === this.currentColorValue) return;
       const newToken = new ColorToken({
         $value: value,
       });
       this.#scale.from = newToken;
       this.value = this.#scale.toObject();
-      this.currentColorValue = stringifyColor(value);
-      this.requestUpdate();
+      this.currentColorValue = newColorValue;
       if (!this.isConnected) return;
       this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
     }
@@ -235,7 +266,10 @@ export class WizardColorscaleInput extends WizardTokenInput {
             const cssColor = stop.toCSSColorFunction();
             return html`
               <div
-                class="wizard-colorscale-input__stop"
+                class="${classMap({
+                  'wizard-colorscale-input__stop': true,
+                  'wizard-colorscale-input__stop--seed': dequal(this.seedColor, stop.$value),
+                })}"
                 style=${`background-color: ${cssColor}`}
                 title=${`${COLOR_KEYS.at(index)}: ${cssColor}`}
               ></div>

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
@@ -2,16 +2,6 @@ import { css } from 'lit';
 
 export default css`
   .wizard-colorscale-input {
-    display: grid;
-  }
-
-  .wizard-colorscale-input__label {
-    display: flex;
-    justify-content: space-between;
-
-    & p {
-      margin-block: 0;
-    }
   }
 
   .wizard-colorscale-input__input input {
@@ -25,7 +15,11 @@ export default css`
   }
 
   .wizard-colorscale-input__stop {
-    block-size: 0.75em;
+    block-size: var(--basis-size-2xs);
     inline-size: 100%;
+  }
+
+  .wizard-colorscale-input__stop--seed {
+    /* TODO: implement */
   }
 `;

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
@@ -1,6 +1,12 @@
 import { css } from 'lit';
 
 export default css`
+  :host {
+    --nl-color-sample-border-radius: var(--basis-border-radius-round);
+    --nl-color-sample-block-size: var(--basis-size-xs);
+    --nl-color-sample-inline-size: var(--basis-size-xs);
+  }
+
   .wizard-colorscale-input__input input {
     inline-size: 100%;
   }

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
@@ -18,7 +18,7 @@ export default css`
   }
 
   .wizard-colorscale-input__stop {
-    block-size: var(--basis-size-2xs);
+    block-size: var(--basis-size-3xs);
     inline-size: 100%;
   }
 `;

--- a/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-colorscale-input/styles.ts
@@ -1,9 +1,6 @@
 import { css } from 'lit';
 
 export default css`
-  .wizard-colorscale-input {
-  }
-
   .wizard-colorscale-input__input input {
     inline-size: 100%;
   }
@@ -17,9 +14,5 @@ export default css`
   .wizard-colorscale-input__stop {
     block-size: var(--basis-size-2xs);
     inline-size: 100%;
-  }
-
-  .wizard-colorscale-input__stop--seed {
-    /* TODO: implement */
   }
 `;

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
@@ -55,7 +55,7 @@ export class WizardStyleGuideColors extends LitElement {
         const colorEntries = Object.entries(value as Record<string, unknown>)
           .filter(([, token]) => typeof token === 'object' && token !== null && '$value' in token)
           .map(([colorKey, token]) => {
-            const color = resolveColorValue(token as ColorTokenType, this.theme.tokens);
+            const color = resolveColorValue(token as ColorTokenType);
             const displayValue = color ? stringifyColor(color) : '#000';
             const tokenId = `basis.color.${key}.${colorKey}`;
             const usage = tokenUsage.get(tokenId) || [];

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/styles.ts
@@ -1,19 +1,22 @@
 import { css } from 'lit';
 
 export default css`
+  :host {
+    --nl-color-sample-border-radius: var(--basis-border-radius-round);
+    --nl-color-sample-block-size: var(--basis-size-xs);
+    --nl-color-sample-inline-size: var(--basis-size-xs);
+  }
+
   .wizard-token-combobox__option {
     align-items: center;
     display: flex;
     gap: var(--wizard-token-combobox-option-gap, var(--basis-space-inline-md));
   }
-  .wizard-token-combobox__preview {
-    block-size: 24px !important;
-    inline-size: 24px !important;
-  }
+
   .wizard-token-combobox__preview--font-family {
     align-items: center;
     display: inline-flex;
-    font-size: 20px;
+    font-size: var(--basis-text-font-size-lg);
     justify-content: center;
     overflow: hidden;
     text-wrap: nowrap;

--- a/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
@@ -77,7 +77,7 @@ export class WizardTokensForm extends LitElement {
   private readonly theme!: Theme;
 
   @state()
-  private displayMode: DisplayMode = 'colors'; // TODO change back
+  private displayMode: DisplayMode = 'initial';
 
   private readonly handleModeSwitch = (event: MouseEvent, newMode: DisplayMode) => {
     event.preventDefault();

--- a/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
@@ -77,7 +77,7 @@ export class WizardTokensForm extends LitElement {
   private readonly theme!: Theme;
 
   @state()
-  private displayMode: DisplayMode = 'initial';
+  private displayMode: DisplayMode = 'colors'; // TODO change back
 
   private readonly handleModeSwitch = (event: MouseEvent, newMode: DisplayMode) => {
     event.preventDefault();
@@ -198,13 +198,12 @@ export class WizardTokensForm extends LitElement {
                 ([colorKey, docs]) => html`
                   <wizard-stack size="lg" class="wizard-form__field">
                     <clippy-heading level="4">${t(`tokens.fieldLabels.basis.color.${colorKey}.label`)}</clippy-heading>
-                    <wc-markdown class="wizard-tokens-form__markdown">${docs}</wc-markdown>
+                    <wc-markdown class="wizard-tokens-form__markdown" .textContent=${docs}></wc-markdown>
                     <wizard-colorscale-input
                       key=${colorKey}
                       label=${t(`tokens.fieldLabels.basis.color.${colorKey}.label`)}
                       id=${`basis.color.${colorKey}`}
                       name=${`basis.color.${colorKey}`}
-                      .colorToken=${this.theme.at(`basis.color.${colorKey}.color-default`)}
                     >
                     </wizard-colorscale-input>
                     <a class="nl-link" href=${t(`tokens.fieldLabels.basis.color.${colorKey}.docs`)} target="_blank">

--- a/packages/theme-wizard-app/src/lib/Theme/index.ts
+++ b/packages/theme-wizard-app/src/lib/Theme/index.ts
@@ -1,6 +1,7 @@
 import {
   StrictThemeSchema,
   type Theme as ThemeType,
+  type BaseDesignToken,
   EXTENSION_RESOLVED_AS,
   stringifyColor,
   stringifyFontFamily,
@@ -9,6 +10,8 @@ import {
   EXTENSION_TOKEN_SUBTYPE,
   walkTokens,
   SKIP,
+  resolveRefs,
+  setExtension,
 } from '@nl-design-system-community/design-tokens-schema';
 import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tokens.json';
 import { dequal } from 'dequal';
@@ -86,6 +89,7 @@ export default class Theme {
   set tokens(values: DesignTokens) {
     this.#modified = !dequal(this.#defaults, values);
     this.#validateTheme(values);
+    resolveRefs(values, values as Record<string, unknown>);
     this.#tokens = values;
     this.toCSS();
   }
@@ -118,6 +122,13 @@ export default class Theme {
       Theme.#updateAt(tokens, path, value);
     }
     this.tokens = tokens;
+  }
+
+  setGroupExtension(groupPath: string, extensionKey: string, value: unknown): void {
+    const group = dlv(this.#tokens, groupPath);
+    if (group && typeof group === 'object') {
+      setExtension(group as BaseDesignToken, extensionKey, value);
+    }
   }
 
   resetAt(path: string) {

--- a/packages/theme-wizard-templates/src/pages/gemeentevoorbeeld/components/QuickTasks/index.tsx
+++ b/packages/theme-wizard-templates/src/pages/gemeentevoorbeeld/components/QuickTasks/index.tsx
@@ -1,14 +1,6 @@
 import '@amsterdam/design-system-css/dist/visually-hidden/visually-hidden.css';
 import { Link } from '@nl-design-system-candidate/link-react';
 import { Icon } from '@utrecht/component-library-react';
-import {
-  UtrechtIconPaspoort,
-  UtrechtIconMeldingKlacht,
-  UtrechtIconVerhuizen,
-  UtrechtIconWerken,
-  UtrechtIconNummerbord,
-  UtrechtIconAfvalScheiden,
-} from '@utrecht/web-component-library-react';
 import React, { type ReactElement } from 'react';
 import type { QuickTask } from './types';
 import { Column, Row } from '../Layout';
@@ -20,12 +12,12 @@ export interface QuickTasksProps {
 type IconName = 'afval-scheiden' | 'melding-klacht' | 'nummerbord' | 'paspoort' | 'verhuizen' | 'werken';
 
 const ICON_COMPONENTS: Record<IconName, ReactElement> = {
-  'afval-scheiden': <UtrechtIconAfvalScheiden />,
-  'melding-klacht': <UtrechtIconMeldingKlacht />,
-  nummerbord: <UtrechtIconNummerbord />,
-  paspoort: <UtrechtIconPaspoort />,
-  verhuizen: <UtrechtIconVerhuizen />,
-  werken: <UtrechtIconWerken />,
+  'afval-scheiden': React.createElement('utrecht-icon-afval-scheiden', { suppressHydrationWarning: true }),
+  'melding-klacht': React.createElement('utrecht-icon-melding-klacht', { suppressHydrationWarning: true }),
+  nummerbord: React.createElement('utrecht-icon-nummerbord', { suppressHydrationWarning: true }),
+  paspoort: React.createElement('utrecht-icon-paspoort', { suppressHydrationWarning: true }),
+  verhuizen: React.createElement('utrecht-icon-verhuizen', { suppressHydrationWarning: true }),
+  werken: React.createElement('utrecht-icon-werken', { suppressHydrationWarning: true }),
 };
 
 const renderIcon = (iconName: string): JSX.Element | null => {

--- a/packages/theme-wizard-website/e2e/styleguide.spec.ts
+++ b/packages/theme-wizard-website/e2e/styleguide.spec.ts
@@ -16,12 +16,12 @@ test('page uses values as stored by the configuration page', async ({ page }) =>
   await page.goto('/basis-tokens');
   await page.getByRole('button', { name: 'Kleuren' }).click();
   const accent1Input = page.getByLabel('Accent 1');
-  await accent1Input.fill('#800000');
+  await accent1Input.fill('#ff0000');
   await accent1Input.press('Enter');
 
   // Style guide page uses the same storage and theme, thus showing a red-ish initial for accent-1.border-default
   await page.goto('/style-guide');
-  await expect(page.getByRole('button', { name: '#800000' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '#ff0000' })).toBeVisible();
 });
 
 test.describe('interaction tests', () => {

--- a/packages/theme-wizard-website/e2e/styleguide.spec.ts
+++ b/packages/theme-wizard-website/e2e/styleguide.spec.ts
@@ -21,7 +21,9 @@ test('page uses values as stored by the configuration page', async ({ page }) =>
 
   // Style guide page uses the same storage and theme, thus showing a red-ish initial for accent-1.border-default
   await page.goto('/style-guide');
-  await expect(page.getByRole('button', { name: '#ff0000' })).toBeVisible();
+  const table = page.getByRole('table', { name: 'Accent 1' });
+  await expect(table).toBeVisible();
+  await expect(table.getByRole('button', { name: 'Kopieer "#ff0000" naar klembord' })).toBeVisible();
 });
 
 test.describe('interaction tests', () => {

--- a/packages/theme-wizard-website/e2e/wizard.spec.ts
+++ b/packages/theme-wizard-website/e2e/wizard.spec.ts
@@ -261,7 +261,7 @@ test.describe('colorscale inputs', () => {
     await themeWizard.page.reload();
     await themeWizard.page.getByRole('button', { name: 'Kleuren' }).click();
     // This is the mid-range darker red that the input stores (it does not store the user's actual picked color)
-    await expect(input).toHaveValue('#8b0000');
+    await expect(input).toHaveValue('#ff0000');
   });
 
   test('Changing value updates individual color inputs ("All tokens")', async ({ themeWizard }) => {


### PR DESCRIPTION


<img width="351" height="211" alt="Screenshot 2026-03-19 at 13 07 31" src="https://github.com/user-attachments/assets/e4f224c0-dded-46d1-9c22-53bb953459a0" />

<img width="505" height="296" alt="Screenshot 2026-03-19 at 13 12 20" src="https://github.com/user-attachments/assets/3569a0b4-8b14-4c6f-8d87-a54afe21d316" />



Several updates to the colorscale input:

- Fix bug that caused the preview underneath the input to not show the correct color
- Fix bug that caused accent-2 and accent-3 not to update in sync when accent-1 was updated (fixed by re-resolving references after updates to the theme)
- Fix UI issue in colorscale input where there was no space between the color preview and the input's text
- Deduplicate token resolution logic inside the colorscale input Reuse logic from design-tokens-schema package
- Add `$extensions` to the color group to store it's seed color so we can always show that in the UI when present. Falls back to `color-default` like it did before.
- Cleaned up some unused styles
- Converted some hardcoded CSS values to NLDS design tokens
- Added Figma-compliant radius to color previews

## Unrelated changes:

These were not strictly necessary but they were cluttering the console, making it harder to spot if the color scale input caused any new issues.

- Fix console React-hydration-related error when showing the "homepage" preview
- Fix error thrown after changing a color. The `<wc-markdown>` element didn't play nice with how we passed it the contents.