### PR TITLE
Fix dat grote tabellen zorgen voor scrollen van de hele pagina

### DIFF
--- a/packages/theme-wizard-app/index.ts
+++ b/packages/theme-wizard-app/index.ts
@@ -21,6 +21,7 @@ import './src/components/wizard-style-guide-typography';
 import './src/components/wizard-style-guide-colors';
 import './src/components/wizard-style-guide-spacing';
 import './src/components/wizard-style-guide-components';
+import './src/components/wizard-table-scroller';
 import './src/components/wizard-theme-reset-button';
 import './src/components/wizard-tokens-download';
 import './src/components/wizard-tokens-form';

--- a/packages/theme-wizard-app/src/components/wizard-container/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-container/styles.ts
@@ -6,35 +6,37 @@ export default css`
   }
 
   .wizard-container {
-    max-inline-size: 100%;
-    padding-inline: var(--basis-space-inline-xl);
+    box-sizing: border-box;
+    display: block;
+    inline-size: 100%;
   }
 
   .wizard-container--page {
-    inline-size: var(--basis-page-max-inline-size);
+    max-inline-size: var(--basis-page-max-max-inline-size);
+    padding-inline: var(--basis-space-inline-xl);
   }
 
   .wizard-container--sm {
-    inline-size: 20rem;
+    max-inline-size: 20rem;
   }
 
   .wizard-container--md {
-    inline-size: 33rem;
+    max-inline-size: 33rem;
   }
 
   .wizard-container--lg {
-    inline-size: 44rem;
+    max-inline-size: 44rem;
   }
 
   .wizard-container--xl {
-    inline-size: 55rem;
+    max-inline-size: 55rem;
   }
 
   .wizard-container--2xl {
-    inline-size: 72rem;
+    max-inline-size: 72rem;
   }
 
   .wizard-container--3xl {
-    inline-size: 96rem;
+    max-inline-size: 96rem;
   }
 `;

--- a/packages/theme-wizard-app/src/components/wizard-layout/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-layout/styles.ts
@@ -30,6 +30,10 @@ export default css`
     padding-inline: var(--basis-space-inline-lg);
     position: sticky;
     z-index: 1;
+
+    @media (forced-colors: active) {
+      border-block-end: var(--basis-border-width-sm) solid;
+    }
   }
 
   .wizard-layout__sidebar {
@@ -57,6 +61,7 @@ export default css`
     grid-area: main;
     inline-size: 100%;
     min-block-size: 100%;
+    min-inline-size: 0;
     padding-inline: var(--basis-space-inline-xl);
     scroll-margin: var(--basis-space-block-6xl);
   }
@@ -90,6 +95,10 @@ export default css`
     padding-block-start: var(--basis-space-block-5xl);
     padding-inline: var(--basis-space-inline-lg);
     row-gap: var(--basis-space-row-2xl);
+
+    @media (forced-colors: active) {
+      border-block-start: var(--basis-border-width-sm) solid;
+    }
 
     @container (inline-size > 44rem) {
       grid-template-columns: 1fr 1fr 1fr;

--- a/packages/theme-wizard-app/src/components/wizard-scraped-tokens-preview/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraped-tokens-preview/index.ts
@@ -57,40 +57,42 @@ export class WizardScrapedTokensPreview extends LitElement {
     tokens: StagedDesignToken[],
     renderSample: (token: StagedDesignToken) => TemplateResult,
   ) => html`
-    <table class="utrecht-table">
-      <caption class="utrecht-table__caption">
-        ${caption}
-      </caption>
-      <thead class="utrecht-table__header">
-        <tr class="utrecht-table__row">
-          <th class="utrecht-table__header-cell">${t('stagedTokens.staged')}</th>
-          <th class="utrecht-table__header-cell">${t('stagedTokens.preview')}</th>
-          <th class="utrecht-table__header-cell">${t('stagedTokens.value')}</th>
-          <th class="utrecht-table__header-cell">${t('stagedTokens.count')}</th>
-        </tr>
-      </thead>
-      <tbody class="utrecht-table__body" @change=${this.#handleChange}>
-        ${tokens.map(
-          (token) => html`
-            <tr class="utrecht-table__row">
-              <td class="utrecht-table__cell">
-                <input
-                  type="checkbox"
-                  name="enabled-tokens"
-                  id=${token.$extensions[EXTENSION_TOKEN_ID]}
-                  ?checked=${token.$extensions[EXTENSION_TOKEN_STAGED] === true}
-                />
-              </td>
-              <td class="utrecht-table__cell">${renderSample(token)}</td>
-              <td class="utrecht-table__cell">
-                <code class="nl-code">${token.$extensions[EXTENSION_AUTHORED_AS]}</code>
-              </td>
-              <td class="utrecht-table__cell">${token.$extensions[EXTENSION_USAGE_COUNT]}</td>
-            </tr>
-          `,
-        )}
-      </tbody>
-    </table>
+    <wizard-table-scroller>
+      <table class="utrecht-table">
+        <caption class="utrecht-table__caption">
+          ${caption}
+        </caption>
+        <thead class="utrecht-table__header">
+          <tr class="utrecht-table__row">
+            <th class="utrecht-table__header-cell">${t('stagedTokens.staged')}</th>
+            <th class="utrecht-table__header-cell">${t('stagedTokens.preview')}</th>
+            <th class="utrecht-table__header-cell">${t('stagedTokens.value')}</th>
+            <th class="utrecht-table__header-cell">${t('stagedTokens.count')}</th>
+          </tr>
+        </thead>
+        <tbody class="utrecht-table__body" @change=${this.#handleChange}>
+          ${tokens.map(
+            (token) => html`
+              <tr class="utrecht-table__row">
+                <td class="utrecht-table__cell">
+                  <input
+                    type="checkbox"
+                    name="enabled-tokens"
+                    id=${token.$extensions[EXTENSION_TOKEN_ID]}
+                    ?checked=${token.$extensions[EXTENSION_TOKEN_STAGED] === true}
+                  />
+                </td>
+                <td class="utrecht-table__cell">${renderSample(token)}</td>
+                <td class="utrecht-table__cell">
+                  <code class="nl-code">${token.$extensions[EXTENSION_AUTHORED_AS]}</code>
+                </td>
+                <td class="utrecht-table__cell">${token.$extensions[EXTENSION_USAGE_COUNT]}</td>
+              </tr>
+            `,
+          )}
+        </tbody>
+      </table>
+    </wizard-table-scroller>
   `;
 
   override render() {

--- a/packages/theme-wizard-app/src/components/wizard-story-preview/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-story-preview/styles.ts
@@ -1,6 +1,10 @@
 import { css } from 'lit';
 
 export default css`
+  :host:not([hidden]) {
+    display: block;
+  }
+
   .wizard-story-preview {
     background-color: var(--basis-color-default-bg-document);
     border-color: var(--basis-color-default-bg-hover);
@@ -8,6 +12,9 @@ export default css`
     border-style: solid;
     border-width: var(--basis-border-width-sm);
     box-shadow: var(--basis-color-default-bg-default) 0 1px 3px 0;
+    box-sizing: border-box;
+    display: block;
+    inline-size: 100%;
     padding-block: var(--basis-space-block-4xl);
     padding-inline: var(--basis-space-inline-2xl);
     position: relative;

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
@@ -98,68 +98,71 @@ export class WizardStyleGuideColors extends LitElement {
       <div class="wizard-style-guide">
         ${colorGroups.map(({ colorEntries, key }) => {
           return html`
-            <table class="utrecht-table">
-              <caption class="utrecht-table__caption">
-                ${t(`tokens.fieldLabels.basis.color.${key}.label`)}
-              </caption>
-              <thead class="utrecht-table__header">
-                <tr class="utrecht-table__row">
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">
-                    ${t('styleGuide.sections.colors.table.header.hexCode')}
-                  </th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
-                </tr>
-              </thead>
-              <tbody class="utrecht-table__body">
-                ${colorEntries.map(
-                  ({ displayValue, tokenId, usage }) => html`
-                    <tr class="utrecht-table__row">
-                      <td class="utrecht-table__cell">
-                        <wizard-color-sample color=${displayValue}></wizard-color-sample>
-                      </td>
-                      <td class="utrecht-table__cell">
-                        <span class="nl-data-badge" id=${tokenId}>${tokenId}</span>
-                        <clippy-toggletip text=${t('copyToClipboard')}>
+            <wizard-table-scroller>
+              <table class="utrecht-table">
+                <caption class="utrecht-table__caption">
+                  ${t(`tokens.fieldLabels.basis.color.${key}.label`)}
+                </caption>
+                <thead class="utrecht-table__header">
+                  <tr class="utrecht-table__row">
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">
+                      ${t('styleGuide.sections.colors.table.header.hexCode')}
+                    </th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
+                  </tr>
+                </thead>
+                <tbody class="utrecht-table__body">
+                  ${colorEntries.map(
+                    ({ displayValue, tokenId, usage }) => html`
+                      <tr class="utrecht-table__row">
+                        <td class="utrecht-table__cell">
+                          <wizard-color-sample color=${displayValue}></wizard-color-sample>
+                        </td>
+                        <td class="utrecht-table__cell">
+                          <span class="nl-data-badge" id=${tokenId}>${tokenId}</span>
+                          <clippy-toggletip text=${t('copyToClipboard')}>
+                            <clippy-button
+                              icon-only
+                              purpose="subtle"
+                              size="small"
+                              @click=${() => navigator.clipboard.writeText(tokenId)}
+                            >
+                              ${t('copyValueToClipboard', { value: tokenId })}
+                              <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                            </clippy-button>
+                          </clippy-toggletip>
+                        </td>
+                        <td class="utrecht-table__cell">
+                          <code class="nl-code" id=${displayValue}>${displayValue}</code>
+                          <clippy-toggletip text=${t('copyToClipboard')}>
+                            <clippy-button
+                              purpose="subtle"
+                              icon-only
+                              size="small"
+                              @click=${() => navigator.clipboard.writeText(displayValue)}
+                            >
+                              ${t('copyValueToClipboard', { value: displayValue })}
+                              <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                            </clippy-button>
+                          </clippy-toggletip>
+                        </td>
+                        <td class="utrecht-table__cell">
                           <clippy-button
-                            icon-only
-                            purpose="subtle"
-                            size="small"
-                            @click=${() => navigator.clipboard.writeText(tokenId)}
+                            purpose="secondary"
+                            @click=${() => this.#openDialog(displayValue, tokenId, usage)}
                           >
-                            ${t('copyValueToClipboard', { value: tokenId })}
-                            <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                            ${t('styleGuide.showDetails')}
                           </clippy-button>
-                        </clippy-toggletip>
-                      </td>
-                      <td class="utrecht-table__cell">
-                        <code class="nl-code" id=${displayValue}>${displayValue}</code>
-                        <clippy-toggletip text=${t('copyToClipboard')}>
-                          <clippy-button
-                            purpose="subtle"
-                            icon-only
-                            size="small"
-                            @click=${() => navigator.clipboard.writeText(displayValue)}
-                          >
-                            ${t('copyValueToClipboard', { value: displayValue })}
-                            <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
-                          </clippy-button>
-                        </clippy-toggletip>
-                      </td>
-                      <td class="utrecht-table__cell">
-                        <clippy-button
-                          purpose="secondary"
-                          @click=${() => this.#openDialog(displayValue, tokenId, usage)}
-                        >
-                          ${t('styleGuide.showDetails')}
-                        </clippy-button>
-                      </td>
-                    </tr>
-                  `,
-                )}
-              </tbody>
-            </table>
+                        </td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            </wizard-table-scroller>
+
             <p class="nl-paragraph">
               <a class="nl-link" target="_blank" href=${t(`tokens.fieldLabels.basis.color.${key}.docs`)}>docs</a>
             </p>

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-components/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-components/index.ts
@@ -80,52 +80,54 @@ export class WizardStyleGuideComponents extends LitElement {
 
         ${Object.entries(components).map(
           ([componentId, componentConfig]) => html`
-            <table class="utrecht-table">
-              <caption class="utrecht-table__caption">
-                ${`nl.${componentId}`}
-              </caption>
-              <thead class="utrecht-table__header">
-                <tr class="utrecht-table__row">
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.reference')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
-                </tr>
-              </thead>
-              <tbody class="utrecht-table__body">
-                ${this.#collectComponentTokens(componentConfig as Record<string, unknown>, componentId).map(
-                  ({ fullPath, tokenConfig }) => {
-                    const resolvedValue = isRef(tokenConfig.$value)
-                      ? resolveRef(this.theme.tokens, tokenConfig.$value)
-                      : tokenConfig.$value;
-                    const displayValue = stringifyTokenValue(resolvedValue);
+            <wizard-table-scroller>
+              <table class="utrecht-table">
+                <caption class="utrecht-table__caption">
+                  ${`nl.${componentId}`}
+                </caption>
+                <thead class="utrecht-table__header">
+                  <tr class="utrecht-table__row">
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.reference')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
+                  </tr>
+                </thead>
+                <tbody class="utrecht-table__body">
+                  ${this.#collectComponentTokens(componentConfig as Record<string, unknown>, componentId).map(
+                    ({ fullPath, tokenConfig }) => {
+                      const resolvedValue = isRef(tokenConfig.$value)
+                        ? resolveRef(this.theme.tokens, tokenConfig.$value)
+                        : tokenConfig.$value;
+                      const displayValue = stringifyTokenValue(resolvedValue);
 
-                    return html`
-                      <tr class="utrecht-table__row">
-                        <td class="utrecht-table__cell">
-                          ${renderTokenExample({
-                            displayValue: displayValue,
-                            tokenId: fullPath,
-                            tokenType: tokenConfig.$type,
-                          })}
-                        </td>
-                        <td class="utrecht-table__cell">
-                          <span class="nl-data-badge">${fullPath}</span>
-                        </td>
-                        <td class="utrecht-table__cell">
-                          ${isRef(tokenConfig.$value)
-                            ? html`<span class="nl-data-badge">${extractRef(tokenConfig.$value)}</span>`
-                            : nothing}
-                        </td>
-                        <td class="utrecht-table__cell">
-                          <code class="nl-code">${displayValue}</code>
-                        </td>
-                      </tr>
-                    `;
-                  },
-                )}
-              </tbody>
-            </table>
+                      return html`
+                        <tr class="utrecht-table__row">
+                          <td class="utrecht-table__cell">
+                            ${renderTokenExample({
+                              displayValue: displayValue,
+                              tokenId: fullPath,
+                              tokenType: tokenConfig.$type,
+                            })}
+                          </td>
+                          <td class="utrecht-table__cell">
+                            <span class="nl-data-badge">${fullPath}</span>
+                          </td>
+                          <td class="utrecht-table__cell">
+                            ${isRef(tokenConfig.$value)
+                              ? html`<span class="nl-data-badge">${extractRef(tokenConfig.$value)}</span>`
+                              : nothing}
+                          </td>
+                          <td class="utrecht-table__cell">
+                            <code class="nl-code">${displayValue}</code>
+                          </td>
+                        </tr>
+                      `;
+                    },
+                  )}
+                </tbody>
+              </table>
+            </wizard-table-scroller>
           `,
         )}
       </div>

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-spacing/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-spacing/index.ts
@@ -92,72 +92,74 @@ export class WizardStyleGuideSpacing extends LitElement {
         ${spacingData.map(({ space, tokens }) => {
           const captionId = `styleguide-section-space-${space}-title`;
           return html`
-            <table class="utrecht-table" aria-labelledby=${captionId}>
-              <caption class="utrecht-table__caption" id=${captionId}>
-                ${t(`styleGuide.sections.space.${space}.title`)}
-              </caption>
-              <thead class="utrecht-table__header">
-                <tr class="utrecht-table__row">
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
-                  <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
-                </tr>
-              </thead>
-              <tbody class="utrecht-table__body">
-                ${tokens.map(
-                  ({ name, tokenId, usage, value }) => html`
-                    <tr class="utrecht-table__row">
-                      <td class="utrecht-table__cell">${renderSpacingExample(value, space)}</td>
-                      <td class="utrecht-table__cell">
-                        <span class="nl-data-badge" id="${`basis-space-${space}-${name}`}">${tokenId}</span>
-                        <clippy-toggletip text=${t('copyToClipboard')}>
-                          <clippy-button
-                            icon-only
-                            purpose="subtle"
-                            size="small"
-                            @click=${() => navigator.clipboard.writeText(tokenId)}
-                          >
-                            ${t('copyValueToClipboard', { value: tokenId })}
-                            <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
-                          </clippy-button>
-                        </clippy-toggletip>
-                      </td>
-                      <td class="utrecht-table__cell">
-                        <code class="nl-code">${value}</code>
-                        <clippy-toggletip text=${t('copyToClipboard')}>
-                          <clippy-button
-                            icon-only
-                            purpose="subtle"
-                            size="small"
-                            @click=${() => navigator.clipboard.writeText(value)}
-                          >
-                            ${t('copyValueToClipboard', { value })}
-                            <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
-                          </clippy-button>
-                        </clippy-toggletip>
-                      </td>
+            <wizard-table-scroller>
+              <table class="utrecht-table" aria-labelledby=${captionId}>
+                <caption class="utrecht-table__caption" id=${captionId}>
+                  ${t(`styleGuide.sections.space.${space}.title`)}
+                </caption>
+                <thead class="utrecht-table__header">
+                  <tr class="utrecht-table__row">
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
+                    <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
+                  </tr>
+                </thead>
+                <tbody class="utrecht-table__body">
+                  ${tokens.map(
+                    ({ name, tokenId, usage, value }) => html`
+                      <tr class="utrecht-table__row">
+                        <td class="utrecht-table__cell">${renderSpacingExample(value, space)}</td>
+                        <td class="utrecht-table__cell">
+                          <span class="nl-data-badge" id="${`basis-space-${space}-${name}`}">${tokenId}</span>
+                          <clippy-toggletip text=${t('copyToClipboard')}>
+                            <clippy-button
+                              icon-only
+                              purpose="subtle"
+                              size="small"
+                              @click=${() => navigator.clipboard.writeText(tokenId)}
+                            >
+                              ${t('copyValueToClipboard', { value: tokenId })}
+                              <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                            </clippy-button>
+                          </clippy-toggletip>
+                        </td>
+                        <td class="utrecht-table__cell">
+                          <code class="nl-code">${value}</code>
+                          <clippy-toggletip text=${t('copyToClipboard')}>
+                            <clippy-button
+                              icon-only
+                              purpose="subtle"
+                              size="small"
+                              @click=${() => navigator.clipboard.writeText(value)}
+                            >
+                              ${t('copyValueToClipboard', { value })}
+                              <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                            </clippy-button>
+                          </clippy-toggletip>
+                        </td>
 
-                      <td class="utrecht-table__cell">
-                        <clippy-button
-                          purpose="secondary"
-                          @click=${() =>
-                            this.#openDialog({
-                              displayValue: value,
-                              metadata: { space },
-                              tokenId,
-                              tokenType: 'dimension',
-                              usage,
-                            })}
-                        >
-                          ${t('styleGuide.showDetails')}
-                        </clippy-button>
-                      </td>
-                    </tr>
-                  `,
-                )}
-              </tbody>
-            </table>
+                        <td class="utrecht-table__cell">
+                          <clippy-button
+                            purpose="secondary"
+                            @click=${() =>
+                              this.#openDialog({
+                                displayValue: value,
+                                metadata: { space },
+                                tokenId,
+                                tokenType: 'dimension',
+                                usage,
+                              })}
+                          >
+                            ${t('styleGuide.showDetails')}
+                          </clippy-button>
+                        </td>
+                      </tr>
+                    `,
+                  )}
+                </tbody>
+              </table>
+            </wizard-table-scroller>
 
             <p class="nl-paragraph">
               <a

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-typography/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-typography/index.ts
@@ -95,76 +95,78 @@ export class WizardStyleGuideTypography extends LitElement {
 
     return html`
       <div class="wizard-style-guide">
-        <table class="utrecht-table">
-          <caption class="utrecht-table__caption">
-            ${t(`styleGuide.sections.typography.families.title`)}
-          </caption>
-          <thead class="utrecht-table__header">
-            <tr class="utrecht-table__row">
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
-            </tr>
-          </thead>
-          <tbody class="utrecht-table__body">
-            ${fontFamilies.map(
-              ({ name, displayValue, googleFontsSpecimen, tokenId, usage }) => html`
-                <tr class="utrecht-table__row">
-                  <td class="utrecht-table__cell">
-                    <wizard-font-sample
-                      family=${displayValue}
-                      size="var(--basis-text-font-size-xl)"
-                    ></wizard-font-sample>
-                    ${googleFontsSpecimen
-                      ? html`<p class="nl-paragraph">
-                          <a class="nl-link" href=${googleFontsSpecimen} rel="external noreferrer" target="_blank">
-                            ${t('tokens.showOnGoogleFonts')}
-                          </a>
-                        </p>`
-                      : nothing}
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <span class="nl-data-badge" id="${`basis-text-font-family-${name}`}">${tokenId}</span>
-                    <clippy-toggletip text=${t('copyToClipboard')}>
+        <wizard-table-scroller>
+          <table class="utrecht-table">
+            <caption class="utrecht-table__caption">
+              ${t(`styleGuide.sections.typography.families.title`)}
+            </caption>
+            <thead class="utrecht-table__header">
+              <tr class="utrecht-table__row">
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
+              </tr>
+            </thead>
+            <tbody class="utrecht-table__body">
+              ${fontFamilies.map(
+                ({ name, displayValue, googleFontsSpecimen, tokenId, usage }) => html`
+                  <tr class="utrecht-table__row">
+                    <td class="utrecht-table__cell">
+                      <wizard-font-sample
+                        family=${displayValue}
+                        size="var(--basis-text-font-size-xl)"
+                      ></wizard-font-sample>
+                      ${googleFontsSpecimen
+                        ? html`<p class="nl-paragraph">
+                            <a class="nl-link" href=${googleFontsSpecimen} rel="external noreferrer" target="_blank">
+                              ${t('tokens.showOnGoogleFonts')}
+                            </a>
+                          </p>`
+                        : nothing}
+                    </td>
+                    <td class="utrecht-table__cell">
+                      <span class="nl-data-badge" id="${`basis-text-font-family-${name}`}">${tokenId}</span>
+                      <clippy-toggletip text=${t('copyToClipboard')}>
+                        <clippy-button
+                          icon-only
+                          purpose="subtle"
+                          size="small"
+                          @click=${() => navigator.clipboard.writeText(tokenId)}
+                        >
+                          ${t('copyValueToClipboard', { value: tokenId })}
+                          <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        </clippy-button>
+                      </clippy-toggletip>
+                    </td>
+                    <td class="utrecht-table__cell">
+                      <code class="nl-code">${displayValue}</code>
+                      <clippy-toggletip text=${t('copyToClipboard')}>
+                        <clippy-button
+                          icon-only
+                          purpose="subtle"
+                          size="small"
+                          @click=${() => navigator.clipboard.writeText(displayValue)}
+                        >
+                          ${t('copyValueToClipboard', { value: displayValue })}
+                          <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        </clippy-button>
+                      </clippy-toggletip>
+                    </td>
+                    <td class="utrecht-table__cell">
                       <clippy-button
-                        icon-only
-                        purpose="subtle"
-                        size="small"
-                        @click=${() => navigator.clipboard.writeText(tokenId)}
+                        purpose="secondary"
+                        @click=${() => this.#openDialog({ displayValue, tokenId, tokenType: 'fontFamily', usage })}
                       >
-                        ${t('copyValueToClipboard', { value: tokenId })}
-                        <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        ${t('styleGuide.showDetails')}
                       </clippy-button>
-                    </clippy-toggletip>
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <code class="nl-code">${displayValue}</code>
-                    <clippy-toggletip text=${t('copyToClipboard')}>
-                      <clippy-button
-                        icon-only
-                        purpose="subtle"
-                        size="small"
-                        @click=${() => navigator.clipboard.writeText(displayValue)}
-                      >
-                        ${t('copyValueToClipboard', { value: displayValue })}
-                        <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
-                      </clippy-button>
-                    </clippy-toggletip>
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <clippy-button
-                      purpose="secondary"
-                      @click=${() => this.#openDialog({ displayValue, tokenId, tokenType: 'fontFamily', usage })}
-                    >
-                      ${t('styleGuide.showDetails')}
-                    </clippy-button>
-                  </td>
-                </tr>
-              `,
-            )}
-          </tbody>
-        </table>
+                    </td>
+                  </tr>
+                `,
+              )}
+            </tbody>
+          </table>
+        </wizard-table-scroller>
 
         <p class="nl-paragraph">
           <a
@@ -176,66 +178,68 @@ export class WizardStyleGuideTypography extends LitElement {
           </a>
         </p>
 
-        <table class="utrecht-table">
-          <caption class="utrecht-table__caption">
-            ${t(`styleGuide.sections.typography.sizes.title`)}
-          </caption>
-          <thead class="utrecht-table__header">
-            <tr class="utrecht-table__row">
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
-            </tr>
-          </thead>
-          <tbody class="utrecht-table__body">
-            ${fontSizes.map(
-              ({ name, displayValue, tokenId, usage }) => html`
-                <tr class="utrecht-table__row">
-                  <td class="utrecht-table__cell">
-                    <wizard-font-sample size=${displayValue}></wizard-font-sample>
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <span class="nl-data-badge" id="${`basis-text-font-size-${name}`}">${tokenId}</span>
-                    <clippy-toggletip text=${t('copyToClipboard')}>
+        <wizard-table-scroller>
+          <table class="utrecht-table">
+            <caption class="utrecht-table__caption">
+              ${t(`styleGuide.sections.typography.sizes.title`)}
+            </caption>
+            <thead class="utrecht-table__header">
+              <tr class="utrecht-table__row">
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.value')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.details')}</th>
+              </tr>
+            </thead>
+            <tbody class="utrecht-table__body">
+              ${fontSizes.map(
+                ({ name, displayValue, tokenId, usage }) => html`
+                  <tr class="utrecht-table__row">
+                    <td class="utrecht-table__cell">
+                      <wizard-font-sample size=${displayValue}></wizard-font-sample>
+                    </td>
+                    <td class="utrecht-table__cell">
+                      <span class="nl-data-badge" id="${`basis-text-font-size-${name}`}">${tokenId}</span>
+                      <clippy-toggletip text=${t('copyToClipboard')}>
+                        <clippy-button
+                          icon-only
+                          purpose="subtle"
+                          size="small"
+                          @click=${() => navigator.clipboard.writeText(tokenId)}
+                        >
+                          ${t('copyValueToClipboard', { value: tokenId })}
+                          <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        </clippy-button>
+                      </clippy-toggletip>
+                    </td>
+                    <td class="utrecht-table__cell">
+                      <code class="nl-code">${displayValue}</code>
+                      <clippy-toggletip text=${t('copyToClipboard')}>
+                        <clippy-button
+                          icon-only
+                          purpose="subtle"
+                          size="small"
+                          @click=${() => navigator.clipboard.writeText(displayValue)}
+                        >
+                          ${t('copyValueToClipboard', { value: displayValue })}
+                          <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        </clippy-button>
+                      </clippy-toggletip>
+                    </td>
+                    <td class="utrecht-table__cell">
                       <clippy-button
-                        icon-only
-                        purpose="subtle"
-                        size="small"
-                        @click=${() => navigator.clipboard.writeText(tokenId)}
+                        purpose="secondary"
+                        @click=${() => this.#openDialog({ displayValue, tokenId, tokenType: 'fontSize', usage })}
                       >
-                        ${t('copyValueToClipboard', { value: tokenId })}
-                        <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        ${t('styleGuide.showDetails')}
                       </clippy-button>
-                    </clippy-toggletip>
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <code class="nl-code">${displayValue}</code>
-                    <clippy-toggletip text=${t('copyToClipboard')}>
-                      <clippy-button
-                        icon-only
-                        purpose="subtle"
-                        size="small"
-                        @click=${() => navigator.clipboard.writeText(displayValue)}
-                      >
-                        ${t('copyValueToClipboard', { value: displayValue })}
-                        <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
-                      </clippy-button>
-                    </clippy-toggletip>
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <clippy-button
-                      purpose="secondary"
-                      @click=${() => this.#openDialog({ displayValue, tokenId, tokenType: 'fontSize', usage })}
-                    >
-                      ${t('styleGuide.showDetails')}
-                    </clippy-button>
-                  </td>
-                </tr>
-              `,
-            )}
-          </tbody>
-        </table>
+                    </td>
+                  </tr>
+                `,
+              )}
+            </tbody>
+          </table>
+        </wizard-table-scroller>
         <p class="nl-paragraph">
           <a
             class="nl-link"
@@ -246,48 +250,50 @@ export class WizardStyleGuideTypography extends LitElement {
           </a>
         </p>
 
-        <table class="utrecht-table">
-          <caption class="utrecht-table__caption">
-            ${t(`styleGuide.sections.typography.headings.title`)}
-          </caption>
-          <thead class="utrecht-table__header">
-            <tr class="utrecht-table__row">
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
-              <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
-            </tr>
-          </thead>
-          <tbody class="utrecht-table__body">
-            ${[1, 2, 3, 4, 5, 6].map((level) => {
-              const heading = staticHtml`<clippy-heading level=${level} style="line-clamp: 3; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3;">Wijzigingswet Vreemdelingenwet 2000, enz. (vaststelling criteria en instrumenten ter bepaling van de verantwoordelijke lidstaat voor behandeling verzoek om internationale bescherming)</clippy-heading>`;
-              return html`
-                <tr class="utrecht-table__row">
-                  <td class="utrecht-table__cell">
-                    <clippy-html-image>
-                      <span slot="label">${t('styleGuide.sections.typography.headings.sample')}</span>
-                      ${heading}
-                    </clippy-html-image>
-                  </td>
-                  <td class="utrecht-table__cell">
-                    <code class="nl-code" id="${`basis.heading.level-${level}`}" style="white-space: nowrap">
-                      ${`basis.heading.level-${level}`}
-                    </code>
-                    <clippy-toggletip text=${t('copyToClipboard')}>
-                      <clippy-button
-                        icon-only
-                        purpose="subtle"
-                        size="small"
-                        @click=${() => navigator.clipboard.writeText(`basis.heading.level-${level}`)}
-                      >
-                        ${t('copyValueToClipboard', { value: `basis.heading.level-${level}` })}
-                        <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
-                      </clippy-button>
-                    </clippy-toggletip>
-                  </td>
-                </tr>
-              `;
-            })}
-          </tbody>
-        </table>
+        <wizard-table-scroller>
+          <table class="utrecht-table">
+            <caption class="utrecht-table__caption">
+              ${t(`styleGuide.sections.typography.headings.title`)}
+            </caption>
+            <thead class="utrecht-table__header">
+              <tr class="utrecht-table__row">
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.sample')}</th>
+                <th scope="col" class="utrecht-table__header-cell">${t('styleGuide.tokenName')}</th>
+              </tr>
+            </thead>
+            <tbody class="utrecht-table__body">
+              ${[1, 2, 3, 4, 5, 6].map((level) => {
+                const heading = staticHtml`<clippy-heading level=${level} style="line-clamp: 3; overflow: hidden; display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 3;">Wijzigingswet Vreemdelingenwet 2000, enz. (vaststelling criteria en instrumenten ter bepaling van de verantwoordelijke lidstaat voor behandeling verzoek om internationale bescherming)</clippy-heading>`;
+                return html`
+                  <tr class="utrecht-table__row">
+                    <td class="utrecht-table__cell">
+                      <clippy-html-image>
+                        <span slot="label">${t('styleGuide.sections.typography.headings.sample')}</span>
+                        ${heading}
+                      </clippy-html-image>
+                    </td>
+                    <td class="utrecht-table__cell">
+                      <code class="nl-code" id="${`basis.heading.level-${level}`}" style="white-space: nowrap">
+                        ${`basis.heading.level-${level}`}
+                      </code>
+                      <clippy-toggletip text=${t('copyToClipboard')}>
+                        <clippy-button
+                          icon-only
+                          purpose="subtle"
+                          size="small"
+                          @click=${() => navigator.clipboard.writeText(`basis.heading.level-${level}`)}
+                        >
+                          ${t('copyValueToClipboard', { value: `basis.heading.level-${level}` })}
+                          <clippy-icon size="small" slot="iconEnd">${unsafeSVG(ClipboardCopyIcon)}</clippy-icon>
+                        </clippy-button>
+                      </clippy-toggletip>
+                    </td>
+                  </tr>
+                `;
+              })}
+            </tbody>
+          </table>
+        </wizard-table-scroller>
         <p class="nl-paragraph">
           <a class="nl-link" href="https://nldesignsystem.nl/heading/" target="_blank">docs</a>
         </p>

--- a/packages/theme-wizard-app/src/components/wizard-style-guide/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide/styles.ts
@@ -2,6 +2,8 @@ import { css } from 'lit';
 
 export default css`
   .wizard-style-guide {
+    --utrecht-table-caption-text-align: start;
+
     display: grid;
     row-gap: var(--basis-space-row-4xl);
   }

--- a/packages/theme-wizard-app/src/components/wizard-table-scroller/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-table-scroller/index.ts
@@ -25,7 +25,6 @@ export class WizardTableScroller extends LitElement {
    */
   override connectedCallback() {
     super.connectedCallback();
-    this.style.display = 'block';
     this.style.inlineSize = '100%';
     this.style.overflowX = 'auto';
   }

--- a/packages/theme-wizard-app/src/components/wizard-table-scroller/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-table-scroller/index.ts
@@ -1,0 +1,36 @@
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+import styles from './styles';
+
+const tag = 'wizard-table-scroller';
+
+// Declare the custom element for TypeScript
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: WizardTableScroller;
+  }
+}
+
+@customElement(tag)
+export class WizardTableScroller extends LitElement {
+  static override readonly styles = [styles];
+
+  /**
+   * These must be inline styles, not `:host` CSS rules. When the parent grid
+   * (wizard-stack) sizes this element, it only sees styles from its own shadow
+   * scope — `:host` rules from this component's shadow root are invisible to it.
+   * That means `overflow-x: auto` via CSS never registers as a scroll container,
+   * so the grid still expands to the table's min-content width. Inline styles sit
+   * on the element itself and are always visible across shadow DOM boundaries.
+   */
+  override connectedCallback() {
+    super.connectedCallback();
+    this.style.display = 'block';
+    this.style.inlineSize = '100%';
+    this.style.overflowX = 'auto';
+  }
+
+  override render() {
+    return html`<slot></slot>`;
+  }
+}

--- a/packages/theme-wizard-app/src/components/wizard-table-scroller/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-table-scroller/styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'lit';
+
+export default css`
+  :host:not([hidden]) {
+    display: block;
+  }
+`;

--- a/packages/theme-wizard-website/src/components/WithPageNav.astro
+++ b/packages/theme-wizard-website/src/components/WithPageNav.astro
@@ -12,17 +12,21 @@
     align-items: start;
     column-gap: var(--basis-space-column-3xl);
     display: grid;
-    grid-template-columns: 1fr 18rem;
     position: relative;
-  }
+    row-gap: var(--basis-space-row-4xl);
 
-  .wizard-page-content {
-    grid-column: 1;
-    grid-row: 1;
-  }
+    @container (inline-size > 54rem) {
+      grid-template-columns: 1fr 18rem;
 
-  .wizard-page-nav {
-    grid-column: 2;
-    grid-row: 1;
+      .wizard-page-content {
+        grid-column: 1;
+        grid-row: 1;
+      }
+
+      .wizard-page-nav {
+        grid-column: 2;
+        grid-row: 1;
+      }
+    }
   }
 </style>

--- a/packages/theme-wizard-website/src/pages/components/[...slug].astro
+++ b/packages/theme-wizard-website/src/pages/components/[...slug].astro
@@ -4,6 +4,8 @@ import WithPageNav from '@/components/WithPageNav.astro';
 import { components } from '@/lib/components'
 import { Traverse } from 'neotraverse/modern'
 import dlv from 'dlv'
+import '@nl-design-system-candidate/paragraph-css/paragraph.css'
+import '@nl-design-system-candidate/link-css/link.css'
 import { getStories } from '../../../../theme-wizard-app/src/utils/csf-utils'
 
 type StoryObject = {
@@ -84,15 +86,15 @@ const storiesWithTokens = stories.map(([id, story]) => {
       <main slot="main" class="wizard-main">
         <!-- TODO: make proper breadcrumb https://github.com/nl-design-system/theme-wizard/issues/531 -->
         <nav>
-          <a href="/">Wizard</a> /
-          <a href="/components">Componenten</a> /
+          <a class="nl-link" href="/">Wizard</a> /
+          <a class="nl-link" href="/components">Componenten</a> /
           <span>{slug}</span>
         </nav>
 
-        <h1>{slug}</h1>
+        <clippy-heading level="1">{slug}</clippy-heading>
 
-        <p>
-          Bekijk de component-documentatie op <a href={nlDesignSystemDocsUrl.toString()} target="_blank">nldesignsystem.nl</a>.
+        <p class="nl-paragraph">
+          Bekijk de component-documentatie op <a class="nl-link" href={nlDesignSystemDocsUrl.toString()} target="_blank">nldesignsystem.nl</a>.
         </p>
 
         <WithPageNav>
@@ -135,8 +137,10 @@ const storiesWithTokens = stories.map(([id, story]) => {
 <style>
   .wizard-main {
     background-color: var(--basis-color-default-bg-document);
+    display: grid;
     padding-block: var(--basis-space-block-3xl);
     padding-inline: var(--basis-space-inline-xl);
+    row-gap: var(--basis-space-row-3xl);
   }
 
   .wizard-page-content {

--- a/packages/theme-wizard-website/src/pages/index.astro
+++ b/packages/theme-wizard-website/src/pages/index.astro
@@ -16,11 +16,13 @@ const scraperUrl = withRelatedProject({
     <wizard-layout>
       <main slot="main" class="wizard-main">
         <wizard-container size="md">
-          <wizard-story-preview size="lg">
-            <h1 class="wizard-title">Maak je eigen thema</h1>
-            <wizard-scraper scraperUrl={scraperUrl}></wizard-scraper>
-          </wizard-story-preview>
-          <p class="nl-paragraph">Begin direct met <a href="/basis-tokens" class="nl-link">basis tokens</a>.</p>
+          <wizard-stack>
+            <wizard-story-preview size="lg">
+              <h1 class="wizard-title">Maak je eigen thema</h1>
+              <wizard-scraper scraperUrl={scraperUrl}></wizard-scraper>
+            </wizard-story-preview>
+            <p class="nl-paragraph">Begin direct met <a href="/basis-tokens" class="nl-link">basis tokens</a>.</p>
+          </wizard-stack>
         </wizard-container>
       </main>
      </wizard-layout>
@@ -31,6 +33,7 @@ const scraperUrl = withRelatedProject({
   .wizard-main {
     block-size: 100%;
     display: grid;
+    padding-block: var(--basis-space-block-5xl);
     place-content: center;
   }
 

--- a/packages/theme-wizard-website/src/pages/staging-tokens.astro
+++ b/packages/theme-wizard-website/src/pages/staging-tokens.astro
@@ -19,11 +19,11 @@ import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react'
                       <IconArrowLeft />
                       Vorige stap
                     </a>
-                    <h1 class="wizard-page-title">Design tokens gevonden!</h1>
-                    <p class="nl-paragraph nl-paragraph--lead">Je kunt deze design tokens gebruiken als opties om je huisstijl te bewerken.</p>
+                    <h1 class="wizard-page-title">Design beslissingen gevonden!</h1>
+                    <p class="nl-paragraph nl-paragraph--lead">Bij NL Design System noemen wij deze design beslissingen <i>design tokens</i>. Je kunt deze design tokens als keuzeopties gebruiken om je huisstijl vast te leggen.</p>
                     <p class="nl-paragraph">Selecteer de design tokens die je wilt kunnen gebruiken. Geen zorgen: je kunt deze selectie altijd aanpassen.</p>
                     <a class="nl-button nl-button--primary nl-button--icon" href="/basis-tokens">
-                      <span class="nl-button__label">Huisstijl bewerken</span>
+                      <span class="nl-button__label">Huisstijl vastleggen</span>
                       <span class="nl-button__icon-end">
                         <IconArrowRight />
                       </span>
@@ -35,7 +35,7 @@ import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react'
                 <wizard-scraped-tokens-preview></wizard-scraped-tokens-preview>
 
                 <a class="nl-button nl-button--primary nl-button--icon" href="/basis-tokens">
-                  <span class="nl-button__label">Huisstijl bewerken</span>
+                  <span class="nl-button__label">Huisstijl vastleggen</span>
                   <span class="nl-button__icon-end">
                     <IconArrowRight />
                   </span>


### PR DESCRIPTION
- prevent large tables causing page overflow
- reword some texts, based on the figma designs
- add borders to header+footer in high-contrast mode
- use `nl-` candidate components for the Component pages header