### PR TITLE
Voeg indicatie toe dat de scraper bezig is

### DIFF
--- a/packages/theme-wizard-app/index.ts
+++ b/packages/theme-wizard-app/index.ts
@@ -12,6 +12,7 @@ import './src/components/wizard-react-element';
 import './src/components/wizard-reset-theme';
 import './src/components/wizard-scraped-tokens-preview';
 import './src/components/wizard-scraper';
+import './src/components/wizard-scraper-loader';
 import './src/components/wizard-scroll-container';
 import './src/components/wizard-sidebar-link';
 import './src/components/wizard-stack';

--- a/packages/theme-wizard-app/package.json
+++ b/packages/theme-wizard-app/package.json
@@ -102,6 +102,7 @@
     "react-dom": "^18.3.1",
     "rosetta": "1.1.0",
     "style-dictionary": "5.3.3",
+    "xstate": "5.28.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/theme-wizard-app/src/components/app/app.ts
+++ b/packages/theme-wizard-app/src/components/app/app.ts
@@ -1,3 +1,4 @@
+import type { ScrapedDesignToken } from '@nl-design-system-community/css-scraper';
 import { provide } from '@lit/context';
 import { defineCustomElements } from '@utrecht/web-component-library-stencil/loader/index.js';
 import { LitElement, html } from 'lit';
@@ -63,14 +64,14 @@ export class App extends LitElement {
       this.scrapedTokens = previousScrapedTokens;
     }
 
-    this.addEventListener('change', this.#handleScrapeDone);
+    this.addEventListener('wizard-scraper-done', this.#handleScrapeDone);
     this.addEventListener('change', this.#handleTokenChange);
     this.addEventListener('reset', this.#handleReset);
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
-    this.removeEventListener('change', this.#handleScrapeDone);
+    this.removeEventListener('wizard-scraper-done', this.#handleScrapeDone);
     this.removeEventListener('change', this.#handleTokenChange);
     this.removeEventListener('reset', this.#handleReset);
   }
@@ -84,10 +85,10 @@ export class App extends LitElement {
   };
 
   readonly #handleScrapeDone = (event: Event) => {
-    const target = event.target;
-    if (!(target instanceof WizardScraper)) return;
+    if (!(event.target instanceof WizardScraper)) return;
+    const { result } = (event as CustomEvent<{ result: ScrapedDesignToken[] }>).detail;
 
-    this.scrapedTokens = target.options.map((token) => ({
+    this.scrapedTokens = result.map((token) => ({
       ...token,
       $extensions: {
         ...token.$extensions,

--- a/packages/theme-wizard-app/src/components/wizard-scraper-loader/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper-loader/index.ts
@@ -23,13 +23,13 @@ export class WizardScraperLoader extends LitElement {
       <div class="wizard-scraper-loader">
         <clippy-heading class="wizard-scraper-loader__heading">
           ${this.heading}
-          <span class="wizard-scraper-loader__ellipsis-wrapper">
+          <span class="wizard-scraper-loader__ellipsis-wrapper" aria-hidden="true">
             <span class="wizard-scraper-loader__ellipsis">.</span>
             <span class="wizard-scraper-loader__ellipsis">.</span>
             <span class="wizard-scraper-loader__ellipsis">.</span>
           </span>
         </clippy-heading>
-        <p class="nl-paragraph" class="wizard-scraper-loader__text">${this.text}</p>
+        <p class="nl-paragraph wizard-scraper-loader__text">${this.text}</p>
         <div aria-hidden="true" class="wizard-scraper-loader__emoji">
           <span class="wizard-scraper-loader__emoji-icon">${this.emoji}</span>
         </div>

--- a/packages/theme-wizard-app/src/components/wizard-scraper-loader/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper-loader/index.ts
@@ -1,0 +1,39 @@
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import styles from './styles';
+
+const tag = 'wizard-scraper-loader';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: WizardScraperLoader;
+  }
+}
+
+@customElement(tag)
+export class WizardScraperLoader extends LitElement {
+  static override readonly styles = [styles];
+
+  @property() emoji?: string;
+  @property() text?: string;
+  @property() heading?: string;
+
+  override render() {
+    return html`
+      <div class="wizard-scraper-loader">
+        <clippy-heading class="wizard-scraper-loader__heading">
+          ${this.heading}
+          <span class="wizard-scraper-loader__ellipsis-wrapper">
+            <span class="wizard-scraper-loader__ellipsis">.</span>
+            <span class="wizard-scraper-loader__ellipsis">.</span>
+            <span class="wizard-scraper-loader__ellipsis">.</span>
+          </span>
+        </clippy-heading>
+        <p class="nl-paragraph" class="wizard-scraper-loader__text">${this.text}</p>
+        <div aria-hidden="true" class="wizard-scraper-loader__emoji">
+          <span class="wizard-scraper-loader__emoji-icon">${this.emoji}</span>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/packages/theme-wizard-app/src/components/wizard-scraper-loader/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper-loader/styles.ts
@@ -1,0 +1,124 @@
+import { css } from 'lit';
+
+export default css`
+  .wizard-scraper-loader {
+    --wizard-scraper-loader-animation-duration: 2000ms;
+    --wizard-scraper-loader-animation-timing-function: ease-in-out;
+    --wizard-scraper-loader-emoji-size: calc(var(--basis-text-font-size-4xl) * 2);
+
+    display: flex;
+    flex-direction: column-reverse;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .wizard-scraper-loader__text {
+    font-size: var(--basis-text-font-size-lg);
+  }
+
+  .wizard-scraper-loader__emoji {
+    display: flex;
+    font-size: var(--wizard-scraper-loader-emoji-size);
+    justify-content: center;
+    position: relative;
+  }
+
+  @keyframes --wizard-fade-in-out {
+    0%,
+    100% {
+      opacity: 0%;
+    }
+    50% {
+      opacity: 100%;
+    }
+  }
+
+  .wizard-scraper-loader__emoji::after {
+    animation-duration: var(--wizard-scraper-loader-animation-duration);
+    animation-iteration-count: infinite;
+    animation-name: --wizard-shadow;
+    animation-timing-function: var(--wizard-scraper-loader-animation-timing-function);
+    background: rgb(0 0 0 / 30%);
+    block-size: var(--basis-size-sm);
+    border-radius: 50%;
+    content: '';
+    filter: blur(4px);
+    inline-size: var(--wizard-scraper-loader-emoji-size);
+    inset-block-end: 0;
+    inset-inline-start: 50%;
+    position: absolute;
+    transform: translateX(-50%);
+
+    @media (prefers-reduced-motion: reduce) {
+      animation-name: --wizard-fade-in-out;
+    }
+  }
+
+  @keyframes --wizard-shadow {
+    0%,
+    100% {
+      opacity: 60%;
+      transform: translateX(-50%) scaleX(1);
+    }
+    50% {
+      opacity: 20%;
+      transform: translateX(-50%) scaleX(0.6);
+    }
+  }
+
+  .wizard-scraper-loader__emoji-icon {
+    animation-duration: var(--wizard-scraper-loader-animation-duration);
+    animation-iteration-count: infinite;
+    animation-name: --wizard-float;
+    animation-timing-function: var(--wizard-scraper-loader-animation-timing-function);
+    display: block;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation-name: --wizard-fade-in-out;
+      opacity: 0%;
+    }
+  }
+
+  @keyframes --wizard-float {
+    0%,
+    100% {
+      transform: translateY(0);
+    }
+    50% {
+      transform: translateY(-0.25em);
+    }
+  }
+
+  .wizard-scraper-loader__ellipsis {
+    animation-duration: var(--wizard-scraper-loader-animation-duration);
+    animation-iteration-count: infinite;
+    animation-name: --wizard-ellipsis-jump;
+    animation-timing-function: var(--wizard-scraper-loader-animation-timing-function);
+    display: inline-block;
+    letter-spacing: -0.1em;
+
+    &:nth-child(2) {
+      animation-delay: 100ms;
+    }
+
+    &:nth-child(3) {
+      animation-delay: 200ms;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      animation-name: --wizard-fade-in-out;
+      opacity: 0%;
+    }
+  }
+
+  @keyframes --wizard-ellipsis-jump {
+    0%,
+    33%,
+    100% {
+      transform: translateY(0);
+    }
+    16% {
+      transform: translateY(-0.35em);
+    }
+  }
+`;

--- a/packages/theme-wizard-app/src/components/wizard-scraper-loader/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper-loader/styles.ts
@@ -88,13 +88,17 @@ export default css`
     }
   }
 
+  .wizard-scraper-loader__ellipsis-wrapper {
+    margin-inline-start: -0.25ch;
+  }
+
   .wizard-scraper-loader__ellipsis {
     animation-duration: var(--wizard-scraper-loader-animation-duration);
     animation-iteration-count: infinite;
     animation-name: --wizard-ellipsis-jump;
     animation-timing-function: var(--wizard-scraper-loader-animation-timing-function);
     display: inline-block;
-    letter-spacing: -0.1em;
+    letter-spacing: -0.2ch;
 
     &:nth-child(2) {
       animation-delay: 100ms;

--- a/packages/theme-wizard-app/src/components/wizard-scraper-loader/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper-loader/styles.ts
@@ -75,7 +75,6 @@ export default css`
 
     @media (prefers-reduced-motion: reduce) {
       animation-name: --wizard-fade-in-out;
-      opacity: 0%;
     }
   }
 
@@ -107,7 +106,6 @@ export default css`
 
     @media (prefers-reduced-motion: reduce) {
       animation-name: --wizard-fade-in-out;
-      opacity: 0%;
     }
   }
 

--- a/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
@@ -45,11 +45,10 @@ export class WizardScraper extends LitElement {
     const scraper = new Scraper(this.scraperUrl);
     this.#actor = createActor(scraperMachine, { input: { scraper } });
     this.#actor.subscribe((snapshot) => {
-      const prev = this._snapshot;
       this._snapshot = snapshot;
 
       // Let the host app know that we're done so it can start navigating
-      if (snapshot.matches('done') && !prev?.matches('done')) {
+      if (snapshot.matches('done')) {
         this.dispatchEvent(
           new CustomEvent('wizard-scraper-done', {
             bubbles: true,
@@ -124,15 +123,12 @@ export class WizardScraper extends LitElement {
                         <div class="utrecht-form-field__label">
                           <label for="scraper-url" class="utrecht-form-label">${t('scraper.input.label')}</label>
                         </div>
-                        <div class="utrecht-form-field__description" id="scraper-description">
-                          ${t('scraper.input.description')}
-                        </div>
+                        <div class="utrecht-form-field__description">${t('scraper.input.description')}</div>
                         ${errorMessage}
                         <div class="utrecht-form-field__input">
                           <input
                             aria-errormessage=${ariaErrorMessage}
                             aria-invalid=${ariaInvalid}
-                            aria-described-by="scraper-description"
                             class="utrecht-textbox utrecht-textbox--html-input"
                             id="scraper-url"
                             inputmode="url"

--- a/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
@@ -1,166 +1,295 @@
-import { ScrapedDesignToken, resolveUrl } from '@nl-design-system-community/css-scraper';
+// Requires `xstate` to be installed: pnpm add xstate
+import type { ScrapedDesignToken } from '@nl-design-system-community/css-scraper';
+import linkStyles from '@nl-design-system-candidate/link-css/link.css?inline';
+import paragraphStyles from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
+import { resolveUrl } from '@nl-design-system-community/css-scraper';
 import formFieldStyles from '@utrecht/form-field-css?inline';
 import formLabelStyles from '@utrecht/form-label-css?inline';
 import textboxStyles from '@utrecht/textbox-css?inline';
-import { html, LitElement, unsafeCSS, nothing, TemplateResult } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { html, LitElement, nothing, type TemplateResult, unsafeCSS } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { assign, createActor, fromPromise, raise, setup, type Actor, type SnapshotFrom } from 'xstate';
 import { t } from '../../i18n';
-import PersistentStorage from '../../lib/PersistentStorage';
 import Scraper from '../../lib/Scraper';
 import styles from './styles';
 
-const OPTIONS_STORAGE_KEY = 'options';
-const SRC_STORAGE_KEY = 'src';
-
 const tag = 'wizard-scraper';
 
-// Declare the custom element for TypeScript
 declare global {
   interface HTMLElementTagNameMap {
     [tag]: WizardScraper;
   }
 }
 
+// ---------------------------------------------------------------------------
+// State machine
+// ---------------------------------------------------------------------------
+
+const scraperMachine = setup({
+  actors: {
+    scrapeTokens: fromPromise<ScrapedDesignToken[], { scraper: Scraper; url: URL }>(({ input }) =>
+      input.scraper.getTokens(input.url),
+    ),
+  },
+  types: {
+    context: {} as {
+      error: string | TemplateResult;
+      result: ScrapedDesignToken[];
+      scraper: Scraper;
+      url: URL | null;
+    },
+    events: {} as { type: 'SUBMIT'; url: URL } | { type: 'TASK_RESOLVED' } | { type: 'VALIDATION_FAILED' },
+    input: {} as { scraper: Scraper },
+  },
+}).createMachine({
+  id: 'scraper-form',
+  context: ({ input }) => ({
+    error: '',
+    result: [],
+    scraper: input.scraper,
+    url: null,
+  }),
+  initial: 'idle',
+
+  states: {
+    done: {},
+
+    error: {
+      on: {
+        SUBMIT: {
+          actions: assign({ url: ({ event }) => event.url }),
+          target: 'loading',
+        },
+        VALIDATION_FAILED: {
+          actions: assign({ error: () => t('scraper.invalidUrl') }),
+        },
+      },
+    },
+
+    idle: {
+      on: {
+        SUBMIT: {
+          actions: assign({ url: ({ event }) => event.url }),
+          target: 'loading',
+        },
+        VALIDATION_FAILED: {
+          actions: assign({ error: () => t('scraper.invalidUrl') }),
+          target: 'error',
+        },
+      },
+    },
+
+    loading: {
+      invoke: {
+        // url is guaranteed non-null here: SUBMIT always sets it before entering loading.
+        input: ({ context }) => ({ scraper: context.scraper, url: context.url as URL }), // NOSONAR
+        onDone: {
+          // No target — stay in the parallel regions; just record the result
+          // and raise an internal event so the `task` region can finalize.
+          actions: [assign({ result: ({ event }) => event.output }), raise({ type: 'TASK_RESOLVED' })],
+        },
+        onError: {
+          // Exit immediately regardless of where the timer is.
+          actions: assign({ error: ({ context }) => t('scraper.scrapeFailed', { url: context.url }) }),
+          target: 'error',
+        },
+        src: 'scrapeTokens',
+      },
+
+      // Fires when task.resolved AND timer.timerDone are both reached.
+      onDone: 'done',
+
+      // Both regions must reach their final state before `loading.onDone`
+      // fires — this enforces the minimum 3 + 3 = 6 second display time
+      // while also waiting for slow async tasks.
+      states: {
+        // Tracks async task completion.
+        task: {
+          initial: 'pending',
+          states: {
+            pending: {
+              on: { TASK_RESOLVED: 'resolved' },
+            },
+            resolved: { type: 'final' },
+          },
+        },
+
+        // Drives the visual loading steps.
+        timer: {
+          initial: 'loader1',
+          states: {
+            loader1: { after: { 3000: 'loader2' } },
+            loader2: { after: { 3000: 'timerDone' } },
+            timerDone: { type: 'final' },
+          },
+        },
+      },
+
+      type: 'parallel',
+    },
+  },
+});
+
+type ScraperMachine = typeof scraperMachine;
+
+// ---------------------------------------------------------------------------
+// Web component
+// ---------------------------------------------------------------------------
+
 @customElement(tag)
 export class WizardScraper extends LitElement {
-  @property({ type: Array }) tokens: ScrapedDesignToken[] = [];
-  @property() scraperUrl?: string;
-  readonly #storage = new PersistentStorage({ prefix: 'theme-wizard-scraper' });
-  #options: ScrapedDesignToken[] = [];
-  error: string | TemplateResult = '';
-  readonly #id = 'target-id';
-  #scraper?: Scraper;
-  #src: string = '';
-  #state: 'idle' | 'pending' | 'error' | 'success' = 'idle';
-  readonly #errorMessageId = 'scraper-error-message';
-  readonly #statusMessageId = 'scraper-status-message';
-
   static override readonly styles = [
-    styles,
     unsafeCSS(formFieldStyles),
-    unsafeCSS(textboxStyles),
     unsafeCSS(formLabelStyles),
+    unsafeCSS(textboxStyles),
+    unsafeCSS(paragraphStyles),
+    unsafeCSS(linkStyles),
+    styles,
   ];
 
-  constructor() {
-    super();
-    this.options = this.#storage.getJSON(OPTIONS_STORAGE_KEY) || [];
-    this.src = this.#storage.getItem(SRC_STORAGE_KEY) || '';
-    if (this.#options.length > 0) {
-      this.#state = 'success';
-    }
-  }
+  @property() scraperUrl?: string;
+
+  #actor?: Actor<ScraperMachine>;
+
+  @state() private _snapshot?: SnapshotFrom<ScraperMachine>;
 
   override connectedCallback() {
     super.connectedCallback();
 
-    if (this.scraperUrl) {
-      this.#scraper = new Scraper(this.scraperUrl);
-    }
+    const scraper = new Scraper(this.scraperUrl);
+    this.#actor = createActor(scraperMachine, { input: { scraper } });
+    this.#actor.subscribe((snapshot) => {
+      const prev = this._snapshot;
+      this._snapshot = snapshot;
+
+      if (snapshot.matches('loading') && !prev?.matches('loading')) {
+        this.dispatchEvent(new CustomEvent('wizard-scraper-loading', { bubbles: true, composed: true }));
+      } else if (snapshot.matches('error') && !prev?.matches('error')) {
+        this.dispatchEvent(
+          new CustomEvent('wizard-scraper-error', {
+            bubbles: true,
+            composed: true,
+            detail: { error: snapshot.context.error },
+          }),
+        );
+      } else if (snapshot.matches('done') && !prev?.matches('done')) {
+        this.dispatchEvent(
+          new CustomEvent('wizard-scraper-done', {
+            bubbles: true,
+            composed: true,
+            detail: { result: snapshot.context.result },
+          }),
+        );
+      }
+    });
+    this.#actor.start();
   }
 
-  override firstUpdated() {
-    if (this.options.length > 0) {
-      this.dispatchEvent(
-        new Event('change', {
-          bubbles: true,
-        }),
-      );
-    }
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#actor?.stop();
   }
 
-  get options() {
-    return this.#options;
-  }
-
-  set options(options: ScrapedDesignToken[]) {
-    this.#storage.setJSON(OPTIONS_STORAGE_KEY, options);
-    this.#options = options;
-    this.requestUpdate();
-  }
-
-  @property({ reflect: true })
-  get src() {
-    return this.#src || '';
-  }
-
-  set src(value: string) {
-    this.#storage.setItem(SRC_STORAGE_KEY, value);
-    this.#src = value;
-  }
-
-  readonly #handleScrape = async (event: SubmitEvent) => {
+  readonly #handleSubmit = (event: SubmitEvent) => {
     event.preventDefault();
     const form = event.target;
     if (!(form instanceof HTMLFormElement)) return;
+
     const formData = new FormData(form);
-    const urlLike = resolveUrl(formData.get(this.#id)?.toString() || '');
+    const urlValue = formData.get('url');
+    const urlLike = resolveUrl(typeof urlValue === 'string' ? urlValue : '');
 
     if (!urlLike) {
-      this.error = t(`scraper.invalidUrl`);
-      this.#state = 'error';
-      this.requestUpdate();
+      this.#actor?.send({ type: 'VALIDATION_FAILED' });
       return;
     }
 
-    if (!this.#scraper) return;
-
-    try {
-      this.#state = 'pending';
-      this.options = await this.#scraper.getTokens(urlLike);
-      this.dispatchEvent(new Event('change', { bubbles: true }));
-      this.src = urlLike.toString();
-      this.#state = 'success';
-    } catch {
-      this.options = [];
-      this.error = t('scraper.scrapeFailed', { url: urlLike });
-      this.#state = 'error';
-    }
+    this.#actor?.send({ type: 'SUBMIT', url: urlLike });
   };
 
+  get #timerState() {
+    if (!this._snapshot?.matches('loading')) return null;
+    const timer = (this._snapshot.value as { loading: { timer: string } }).loading.timer;
+    // Keep showing loader2 while waiting for a slow task after the timer is done.
+    return timer === 'loader1' ? 'loader1' : 'loader2';
+  }
+
   override render() {
+    const snapshot = this._snapshot;
+    if (!snapshot) return nothing;
+
+    const isIdle = snapshot.matches('idle');
+    const isLoading = snapshot.matches('loading');
+    const isDone = snapshot.matches('done');
+    const isError = snapshot.matches('error');
+
+    const ariaErrorMessage = isError ? 'scraper-error' : nothing;
+    const ariaInvalid = isError ? 'true' : nothing;
+    const errorMessage = isError
+      ? html`
+          <utrecht-form-field-error-message id="scraper-error" class="utrecht-form-field__error-message">
+            <p class="nl-paragraph utrecht-form-field-error-message">${snapshot.context.error}</p>
+          </utrecht-form-field-error-message>
+        `
+      : nothing;
+
     return html`
-      <form
-        @submit=${this.#handleScrape}
-        class="utrecht-form-field utrecht-form-field--text ${classMap({
-          'utrecht-form-field--invalid': this.#state === 'error',
-        })}"
-      >
-        <div class="utrecht-form-label">
-          <label for=${this.#id} class="utrecht-form-label">${t('scraper.input.label')}</label>
-        </div>
-        <div class="wizard-scraper__input utrecht-form-field__input">
-          <input
-            class="utrecht-textbox utrecht-textbox--html-input"
-            id=${this.#id}
-            name=${this.#id}
-            type="text"
-            inputmode="url"
-            placeholder="gemeentevoorbeeld.nl"
-            value=${this.src}
-            aria-invalid=${this.#state === 'error' ? 'true' : nothing}
-            aria-errormessage=${this.#state === 'error' ? this.#errorMessageId : nothing}
-            aria-describedby=${this.#state === 'success' ? this.#statusMessageId : nothing}
-            data-state=${this.#state}
-          />
-          <utrecht-button appearance="primary-action-button" type="submit"> ${t('scraper.submit')} </utrecht-button>
-        </div>
-        ${this.#state === 'error'
-          ? html`
-              <utrecht-form-field-error-message id=${this.#errorMessageId} class="utrecht-form-field__error-message">
-                <utrecht-paragraph class="utrecht-form-field-error-message">${this.error}</utrecht-paragraph>
-              </utrecht-form-field-error-message>
-            `
-          : nothing}
-        ${this.#state === 'success'
-          ? html`
-              <utrecht-paragraph role="status" id=${this.#statusMessageId}>
-                ${t('scraper.success', { tokenCount: this.options.length })}
-              </utrecht-paragraph>
-            `
-          : nothing}
-      </form>
+      ${isIdle || isError
+        ? html`
+            <wizard-stack>
+              <wizard-story-preview size="lg">
+                <wizard-stack>
+                  <clippy-heading level="2">${t('scraper.title')}</clippy-heading>
+                  <form
+                    @submit=${this.#handleSubmit}
+                    class="utrecht-form-field utrecht-form-field--text ${classMap({
+                      'utrecht-form-field--invalid': isError,
+                    })}"
+                  >
+                    <div class="utrecht-form-label">
+                      <label for="scraper-url" class="utrecht-form-label">${t('scraper.input.label')}</label>
+                    </div>
+                    <div class="wizard-scraper-form__input utrecht-form-field__input wizard-scraper__input">
+                      <input
+                        aria-errormessage=${ariaErrorMessage}
+                        aria-invalid=${ariaInvalid}
+                        class="utrecht-textbox utrecht-textbox--html-input"
+                        data-state=${snapshot.value}
+                        id="scraper-url"
+                        inputmode="url"
+                        name="url"
+                        placeholder="gemeentevoorbeeld.nl"
+                        type="text"
+                        value=${snapshot.context.url?.toString() ?? ''}
+                      />
+                      <utrecht-button appearance="primary-action-button" type="submit">
+                        ${t('scraper.submit')}
+                      </utrecht-button>
+                    </div>
+                    ${errorMessage}
+                  </form>
+                </wizard-stack>
+              </wizard-story-preview>
+              <p class="nl-paragraph">${t('scraper.directStart')}</p>
+            </wizard-stack>
+          `
+        : nothing}
+      ${isLoading && this.#timerState === 'loader1'
+        ? html`<wizard-scraper-loader
+            emoji="🧙"
+            text=${t('scraper.loaders.loader1.text', { url: this._snapshot?.context.url })}
+            heading=${t('scraper.loaders.loader1.heading')}
+          ></wizard-scraper-loader>`
+        : nothing}
+      ${isLoading && this.#timerState === 'loader2'
+        ? html`<wizard-scraper-loader
+            emoji="🎨"
+            text=${t('scraper.loaders.loader2.text', { url: this._snapshot?.context.url })}
+            heading=${t('scraper.loaders.loader2.heading')}
+          ></wizard-scraper-loader>`
+        : nothing}
+      ${isDone ? html`<slot name="done"></slot>` : nothing}
     `;
   }
 }

--- a/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
@@ -225,6 +225,8 @@ export class WizardScraper extends LitElement {
 
     const ariaErrorMessage = isError ? 'scraper-error' : nothing;
     const ariaInvalid = isError ? 'true' : nothing;
+    const loader1AriaHidden = this.#timerState === 'loader1' ? nothing : 'true';
+    const loader2AriaHidden = this.#timerState === 'loader2' ? nothing : 'true';
     const errorMessage = isError
       ? html`
           <utrecht-form-field-error-message id="scraper-error" class="utrecht-form-field__error-message">
@@ -273,19 +275,25 @@ export class WizardScraper extends LitElement {
             </wizard-stack>
           `
         : nothing}
-      ${isLoading && this.#timerState === 'loader1'
-        ? html`<wizard-scraper-loader
-            emoji="🧙"
-            text=${t('scraper.loaders.loader1.text', { url: this._snapshot?.context.url })}
-            heading=${t('scraper.loaders.loader1.heading')}
-          ></wizard-scraper-loader>`
-        : nothing}
-      ${isLoading && this.#timerState === 'loader2'
-        ? html`<wizard-scraper-loader
-            emoji="🎨"
-            text=${t('scraper.loaders.loader2.text', { url: this._snapshot?.context.url })}
-            heading=${t('scraper.loaders.loader2.heading')}
-          ></wizard-scraper-loader>`
+      ${isLoading
+        ? html`
+            <div class="wizard-scraper__loaders">
+              <wizard-scraper-loader
+                aria-hidden=${loader1AriaHidden}
+                class=${classMap({ 'wizard-scraper__loader--active': this.#timerState === 'loader1' })}
+                emoji="🧙"
+                heading=${t('scraper.loaders.loader1.heading')}
+                text=${t('scraper.loaders.loader1.text', { url: this._snapshot?.context.url })}
+              ></wizard-scraper-loader>
+              <wizard-scraper-loader
+                aria-hidden=${loader2AriaHidden}
+                class=${classMap({ 'wizard-scraper__loader--active': this.#timerState === 'loader2' })}
+                emoji="🎨"
+                heading=${t('scraper.loaders.loader2.heading')}
+                text=${t('scraper.loaders.loader2.text', { url: this._snapshot?.context.url })}
+              ></wizard-scraper-loader>
+            </div>
+          `
         : nothing}
       ${isDone ? html`<slot name="done"></slot>` : nothing}
     `;

--- a/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
@@ -1,4 +1,3 @@
-// Requires `xstate` to be installed: pnpm add xstate
 import type { ScrapedDesignToken } from '@nl-design-system-community/css-scraper';
 import linkStyles from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphStyles from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
@@ -255,7 +254,6 @@ export class WizardScraper extends LitElement {
                         aria-errormessage=${ariaErrorMessage}
                         aria-invalid=${ariaInvalid}
                         class="utrecht-textbox utrecht-textbox--html-input"
-                        data-state=${snapshot.value}
                         id="scraper-url"
                         inputmode="url"
                         name="url"

--- a/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/index.ts
@@ -1,16 +1,16 @@
-import type { ScrapedDesignToken } from '@nl-design-system-community/css-scraper';
 import linkStyles from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphStyles from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
-import { resolveUrl } from '@nl-design-system-community/css-scraper';
 import formFieldStyles from '@utrecht/form-field-css?inline';
+import formFieldErrorCss from '@utrecht/form-field-error-message-css?inline';
 import formLabelStyles from '@utrecht/form-label-css?inline';
 import textboxStyles from '@utrecht/textbox-css?inline';
-import { html, LitElement, nothing, type TemplateResult, unsafeCSS } from 'lit';
+import { html, LitElement, nothing, unsafeCSS } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { assign, createActor, fromPromise, raise, setup, type Actor, type SnapshotFrom } from 'xstate';
+import { createActor, type Actor, type SnapshotFrom } from 'xstate';
 import { t } from '../../i18n';
 import Scraper from '../../lib/Scraper';
+import { scraperMachine, type ScraperMachine } from './state-machine';
 import styles from './styles';
 
 const tag = 'wizard-scraper';
@@ -21,121 +21,6 @@ declare global {
   }
 }
 
-// ---------------------------------------------------------------------------
-// State machine
-// ---------------------------------------------------------------------------
-
-const scraperMachine = setup({
-  actors: {
-    scrapeTokens: fromPromise<ScrapedDesignToken[], { scraper: Scraper; url: URL }>(({ input }) =>
-      input.scraper.getTokens(input.url),
-    ),
-  },
-  types: {
-    context: {} as {
-      error: string | TemplateResult;
-      result: ScrapedDesignToken[];
-      scraper: Scraper;
-      url: URL | null;
-    },
-    events: {} as { type: 'SUBMIT'; url: URL } | { type: 'TASK_RESOLVED' } | { type: 'VALIDATION_FAILED' },
-    input: {} as { scraper: Scraper },
-  },
-}).createMachine({
-  id: 'scraper-form',
-  context: ({ input }) => ({
-    error: '',
-    result: [],
-    scraper: input.scraper,
-    url: null,
-  }),
-  initial: 'idle',
-
-  states: {
-    done: {},
-
-    error: {
-      on: {
-        SUBMIT: {
-          actions: assign({ url: ({ event }) => event.url }),
-          target: 'loading',
-        },
-        VALIDATION_FAILED: {
-          actions: assign({ error: () => t('scraper.invalidUrl') }),
-        },
-      },
-    },
-
-    idle: {
-      on: {
-        SUBMIT: {
-          actions: assign({ url: ({ event }) => event.url }),
-          target: 'loading',
-        },
-        VALIDATION_FAILED: {
-          actions: assign({ error: () => t('scraper.invalidUrl') }),
-          target: 'error',
-        },
-      },
-    },
-
-    loading: {
-      invoke: {
-        // url is guaranteed non-null here: SUBMIT always sets it before entering loading.
-        input: ({ context }) => ({ scraper: context.scraper, url: context.url as URL }), // NOSONAR
-        onDone: {
-          // No target — stay in the parallel regions; just record the result
-          // and raise an internal event so the `task` region can finalize.
-          actions: [assign({ result: ({ event }) => event.output }), raise({ type: 'TASK_RESOLVED' })],
-        },
-        onError: {
-          // Exit immediately regardless of where the timer is.
-          actions: assign({ error: ({ context }) => t('scraper.scrapeFailed', { url: context.url }) }),
-          target: 'error',
-        },
-        src: 'scrapeTokens',
-      },
-
-      // Fires when task.resolved AND timer.timerDone are both reached.
-      onDone: 'done',
-
-      // Both regions must reach their final state before `loading.onDone`
-      // fires — this enforces the minimum 3 + 3 = 6 second display time
-      // while also waiting for slow async tasks.
-      states: {
-        // Tracks async task completion.
-        task: {
-          initial: 'pending',
-          states: {
-            pending: {
-              on: { TASK_RESOLVED: 'resolved' },
-            },
-            resolved: { type: 'final' },
-          },
-        },
-
-        // Drives the visual loading steps.
-        timer: {
-          initial: 'loader1',
-          states: {
-            loader1: { after: { 3000: 'loader2' } },
-            loader2: { after: { 3000: 'timerDone' } },
-            timerDone: { type: 'final' },
-          },
-        },
-      },
-
-      type: 'parallel',
-    },
-  },
-});
-
-type ScraperMachine = typeof scraperMachine;
-
-// ---------------------------------------------------------------------------
-// Web component
-// ---------------------------------------------------------------------------
-
 @customElement(tag)
 export class WizardScraper extends LitElement {
   static override readonly styles = [
@@ -144,6 +29,7 @@ export class WizardScraper extends LitElement {
     unsafeCSS(textboxStyles),
     unsafeCSS(paragraphStyles),
     unsafeCSS(linkStyles),
+    unsafeCSS(formFieldErrorCss),
     styles,
   ];
 
@@ -162,17 +48,8 @@ export class WizardScraper extends LitElement {
       const prev = this._snapshot;
       this._snapshot = snapshot;
 
-      if (snapshot.matches('loading') && !prev?.matches('loading')) {
-        this.dispatchEvent(new CustomEvent('wizard-scraper-loading', { bubbles: true, composed: true }));
-      } else if (snapshot.matches('error') && !prev?.matches('error')) {
-        this.dispatchEvent(
-          new CustomEvent('wizard-scraper-error', {
-            bubbles: true,
-            composed: true,
-            detail: { error: snapshot.context.error },
-          }),
-        );
-      } else if (snapshot.matches('done') && !prev?.matches('done')) {
+      // Let the host app know that we're done so it can start navigating
+      if (snapshot.matches('done') && !prev?.matches('done')) {
         this.dispatchEvent(
           new CustomEvent('wizard-scraper-done', {
             bubbles: true,
@@ -197,14 +74,8 @@ export class WizardScraper extends LitElement {
 
     const formData = new FormData(form);
     const urlValue = formData.get('url');
-    const urlLike = resolveUrl(typeof urlValue === 'string' ? urlValue : '');
 
-    if (!urlLike) {
-      this.#actor?.send({ type: 'VALIDATION_FAILED' });
-      return;
-    }
-
-    this.#actor?.send({ type: 'SUBMIT', url: urlLike });
+    this.#actor?.send({ type: 'SUBMIT', url: typeof urlValue === 'string' ? urlValue : '' });
   };
 
   get #timerState() {
@@ -220,9 +91,9 @@ export class WizardScraper extends LitElement {
 
     const isIdle = snapshot.matches('idle');
     const isLoading = snapshot.matches('loading');
-    const isDone = snapshot.matches('done');
     const isError = snapshot.matches('error');
 
+    const submittedUrl = snapshot.context.url;
     const ariaErrorMessage = isError ? 'scraper-error' : nothing;
     const ariaInvalid = isError ? 'true' : nothing;
     const loader1AriaHidden = this.#timerState === 'loader1' ? nothing : 'true';
@@ -238,36 +109,44 @@ export class WizardScraper extends LitElement {
     return html`
       ${isIdle || isError
         ? html`
-            <wizard-stack>
+            <wizard-stack size="xl">
               <wizard-story-preview size="lg">
-                <wizard-stack>
+                <wizard-stack size="3xl">
                   <clippy-heading level="2">${t('scraper.title')}</clippy-heading>
-                  <form
-                    @submit=${this.#handleSubmit}
-                    class="utrecht-form-field utrecht-form-field--text ${classMap({
-                      'utrecht-form-field--invalid': isError,
-                    })}"
-                  >
-                    <div class="utrecht-form-label">
-                      <label for="scraper-url" class="utrecht-form-label">${t('scraper.input.label')}</label>
-                    </div>
-                    <div class="wizard-scraper-form__input utrecht-form-field__input wizard-scraper__input">
-                      <input
-                        aria-errormessage=${ariaErrorMessage}
-                        aria-invalid=${ariaInvalid}
-                        class="utrecht-textbox utrecht-textbox--html-input"
-                        id="scraper-url"
-                        inputmode="url"
-                        name="url"
-                        placeholder="gemeentevoorbeeld.nl"
-                        type="text"
-                        value=${snapshot.context.url?.toString() ?? ''}
-                      />
+                  <p class="nl-paragraph nl-paragraph--lead">${t('scraper.intro')}</p>
+                  <form @submit=${this.#handleSubmit}>
+                    <wizard-stack size="3xl">
+                      <div
+                        class="utrecht-form-field utrecht-form-field--text ${classMap({
+                          'utrecht-form-field--invalid': isError,
+                        })}"
+                      >
+                        <div class="utrecht-form-field__label">
+                          <label for="scraper-url" class="utrecht-form-label">${t('scraper.input.label')}</label>
+                        </div>
+                        <div class="utrecht-form-field__description" id="scraper-description">
+                          ${t('scraper.input.description')}
+                        </div>
+                        ${errorMessage}
+                        <div class="utrecht-form-field__input">
+                          <input
+                            aria-errormessage=${ariaErrorMessage}
+                            aria-invalid=${ariaInvalid}
+                            aria-described-by="scraper-description"
+                            class="utrecht-textbox utrecht-textbox--html-input"
+                            id="scraper-url"
+                            inputmode="url"
+                            name="url"
+                            type="text"
+                            value=${submittedUrl ?? ''}
+                          />
+                        </div>
+                      </div>
+
                       <utrecht-button appearance="primary-action-button" type="submit">
                         ${t('scraper.submit')}
                       </utrecht-button>
-                    </div>
-                    ${errorMessage}
+                    </wizard-stack>
                   </form>
                 </wizard-stack>
               </wizard-story-preview>
@@ -283,19 +162,18 @@ export class WizardScraper extends LitElement {
                 class=${classMap({ 'wizard-scraper__loader--active': this.#timerState === 'loader1' })}
                 emoji="🧙"
                 heading=${t('scraper.loaders.loader1.heading')}
-                text=${t('scraper.loaders.loader1.text', { url: this._snapshot?.context.url })}
+                text=${t('scraper.loaders.loader1.text', { url: submittedUrl })}
               ></wizard-scraper-loader>
               <wizard-scraper-loader
                 aria-hidden=${loader2AriaHidden}
                 class=${classMap({ 'wizard-scraper__loader--active': this.#timerState === 'loader2' })}
                 emoji="🎨"
                 heading=${t('scraper.loaders.loader2.heading')}
-                text=${t('scraper.loaders.loader2.text', { url: this._snapshot?.context.url })}
+                text=${t('scraper.loaders.loader2.text', { url: submittedUrl })}
               ></wizard-scraper-loader>
             </div>
           `
         : nothing}
-      ${isDone ? html`<slot name="done"></slot>` : nothing}
     `;
   }
 }

--- a/packages/theme-wizard-app/src/components/wizard-scraper/state-machine.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/state-machine.ts
@@ -84,7 +84,7 @@ export const scraperMachine = setup({
     loading: {
       invoke: {
         // url is guaranteed non-null here: SUBMIT always sets it before entering loading.
-        input: ({ context }) => ({ scraper: context.scraper, url: context.resolvedUrl as URL }), // NOSONAR
+        input: ({ context }) => ({ scraper: context.scraper, url: context.resolvedUrl as URL }),
         onDone: {
           // No target — stay in the parallel regions; just record the result
           // and raise an internal event so the `task` region can finalize.

--- a/packages/theme-wizard-app/src/components/wizard-scraper/state-machine.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/state-machine.ts
@@ -1,0 +1,135 @@
+import { resolveUrl, type ScrapedDesignToken } from '@nl-design-system-community/css-scraper';
+import { type TemplateResult } from 'lit';
+import { assign, fromPromise, raise, setup } from 'xstate';
+import { t } from '../../i18n';
+import Scraper from '../../lib/Scraper';
+
+export const scraperMachine = setup({
+  actions: {
+    assignUrl: assign({
+      resolvedUrl: ({ event }) => {
+        if (event.type === 'SUBMIT') {
+          const resolvedUrl = resolveUrl(event.url);
+          return resolvedUrl ?? null;
+        }
+        return null;
+      },
+      url: ({ event }) => (event.type === 'SUBMIT' ? event.url : null),
+    }),
+  },
+  actors: {
+    scrapeTokens: fromPromise<ScrapedDesignToken[], { scraper: Scraper; url: URL }>(({ input }) =>
+      input.scraper.getTokens(input.url),
+    ),
+  },
+  guards: {
+    isValidUrl: ({ event }) => event.type === 'SUBMIT' && Boolean(resolveUrl(event.url)),
+  },
+  types: {
+    context: {} as {
+      error: string | TemplateResult;
+      result: ScrapedDesignToken[];
+      scraper: Scraper;
+      url: string | null;
+      resolvedUrl: URL | null;
+    },
+    events: {} as { type: 'SUBMIT'; url: string } | { type: 'TASK_RESOLVED' },
+    input: {} as { scraper: Scraper },
+  },
+}).createMachine({
+  id: 'scraper-form',
+  context: ({ input }) => ({
+    error: '',
+    resolvedUrl: null,
+    result: [],
+    scraper: input.scraper,
+    url: null,
+  }),
+  initial: 'idle',
+
+  states: {
+    done: {},
+
+    error: {
+      on: {
+        SUBMIT: [
+          {
+            actions: 'assignUrl',
+            guard: 'isValidUrl',
+            target: 'loading',
+          },
+          {
+            actions: assign({ error: () => t('scraper.invalidUrl') }),
+          },
+        ],
+      },
+    },
+
+    idle: {
+      on: {
+        SUBMIT: [
+          {
+            actions: 'assignUrl',
+            guard: 'isValidUrl',
+            target: 'loading',
+          },
+          {
+            actions: assign({ error: () => t('scraper.invalidUrl') }),
+            target: 'error',
+          },
+        ],
+      },
+    },
+
+    loading: {
+      invoke: {
+        // url is guaranteed non-null here: SUBMIT always sets it before entering loading.
+        input: ({ context }) => ({ scraper: context.scraper, url: context.resolvedUrl as URL }), // NOSONAR
+        onDone: {
+          // No target — stay in the parallel regions; just record the result
+          // and raise an internal event so the `task` region can finalize.
+          actions: [assign({ result: ({ event }) => event.output }), raise({ type: 'TASK_RESOLVED' })],
+        },
+        onError: {
+          // Exit immediately regardless of where the timer is.
+          actions: assign({ error: ({ context }) => t('scraper.scrapeFailed', { url: context.url }) }),
+          target: 'error',
+        },
+        src: 'scrapeTokens',
+      },
+
+      // Fires when task.resolved AND timer.timerDone are both reached.
+      onDone: 'done',
+
+      // Both regions must reach their final state before `loading.onDone`
+      // fires — this enforces the minimum 3 + 3 = 6 second display time
+      // while also waiting for slow async tasks.
+      states: {
+        // Tracks async task completion.
+        task: {
+          initial: 'pending',
+          states: {
+            pending: {
+              on: { TASK_RESOLVED: 'resolved' },
+            },
+            resolved: { type: 'final' },
+          },
+        },
+
+        // Drives the visual loading steps.
+        timer: {
+          initial: 'loader1',
+          states: {
+            loader1: { after: { 3000: 'loader2' } },
+            loader2: { after: { 3000: 'timerDone' } },
+            timerDone: { type: 'final' },
+          },
+        },
+      },
+
+      type: 'parallel',
+    },
+  },
+});
+
+export type ScraperMachine = typeof scraperMachine;

--- a/packages/theme-wizard-app/src/components/wizard-scraper/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/styles.ts
@@ -1,11 +1,15 @@
 import { css } from 'lit';
 
 export default css`
-  .wizard-scraper__input {
-    align-items: center;
-    display: grid;
-    gap: var(--basis-space-inline-md, 0.5rem);
-    grid-template-columns: 1fr max-content;
+  .utrecht-form-field__description {
+    --utrecht-form-field-description-margin-block-end: var(--basis-space-row-2xl);
+    --utrecht-form-field-description-margin-block-start: var(--basis-space-row-sm);
+
+    color: var(--basis-color-default-color-subtle);
+  }
+
+  .utrecht-form-field__error-message {
+    margin-block: var(--basis-space-block-md);
   }
 
   .wizard-scraper__loaders {

--- a/packages/theme-wizard-app/src/components/wizard-scraper/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/styles.ts
@@ -7,4 +7,22 @@ export default css`
     gap: var(--basis-space-inline-md, 0.5rem);
     grid-template-columns: 1fr max-content;
   }
+
+  .wizard-scraper__loaders {
+    display: grid;
+  }
+
+  wizard-scraper-loader {
+    grid-area: 1 / 1;
+    opacity: 0%;
+    transition: opacity 500ms ease-in-out;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+
+    &.wizard-scraper__loader--active {
+      opacity: 100%;
+    }
+  }
 `;

--- a/packages/theme-wizard-app/src/components/wizard-stack/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-stack/styles.ts
@@ -6,7 +6,8 @@ export default css`
   }
 
   .wizard-stack {
-    display: grid;
+    display: flex;
+    flex-direction: column;
   }
 
   .wizard-stack--none {

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -40,13 +40,25 @@ export const en = {
   },
   save: 'Save',
   scraper: {
+    directStart: html`Begin directly with <a href="/basis-tokens" class="nl-link">basic tokens</a>.`,
     input: {
       label: 'Website URL',
     },
     invalidUrl: 'Please fill in a valid URL',
+    loaders: {
+      loader1: {
+        heading: 'Typography',
+        text: 'Fetching styles from {{url}}',
+      },
+      loader2: {
+        heading: 'Colors',
+        text: 'Fetching styles from {{url}}',
+      },
+    },
     scrapeFailed: `Failed to scrape "{{url}}"`,
     submit: 'Analyze',
     success: 'Done! Found {{tokenCount}} tokens.',
+    title: 'Make your own theme',
   },
   stagedTokens: {
     count: 'Count',
@@ -357,13 +369,25 @@ export const nl = {
   },
   save: 'Opslaan',
   scraper: {
+    directStart: html`Begin direct met <a href="/basis-tokens" class="nl-link">basis tokens</a>.`,
     input: {
       label: 'Website URL',
     },
     invalidUrl: 'Vul een valide URL in',
+    loaders: {
+      loader1: {
+        heading: 'Typografie',
+        text: 'Huisstijl ophalen van {{url}}',
+      },
+      loader2: {
+        heading: 'Kleuren',
+        text: 'Huisstijl ophalen van {{url}}',
+      },
+    },
     scrapeFailed: `Kan "{{url}}" niet analyseren`,
     submit: 'Analyseer',
     success: 'Gereed, {{tokenCount}} tokens gevonden',
+    title: 'Maak je eigen thema',
   },
   stagedTokens: {
     count: 'Aantal',

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -42,8 +42,10 @@ export const en = {
   scraper: {
     directStart: html`Begin directly with <a href="/basis-tokens" class="nl-link">basic tokens</a>.`,
     input: {
+      description: 'E.g. gemeentevoorbeeld.nl',
       label: 'Website URL',
     },
+    intro: 'Use the Theme Wizard to easily make an NL Design System theme for your organisation.',
     invalidUrl: 'Please fill in a valid URL',
     loaders: {
       loader1: {
@@ -371,8 +373,10 @@ export const nl = {
   scraper: {
     directStart: html`Begin direct met <a href="/basis-tokens" class="nl-link">basis tokens</a>.`,
     input: {
+      description: 'Bijvoorbeeld gemeentevoorbeeld.nl',
       label: 'Website URL',
     },
+    intro: 'Met de Theme Wizard maak je gemakkelijk een NL Design System thema voor jouw organisatie.',
     invalidUrl: 'Vul een valide URL in',
     loaders: {
       loader1: {
@@ -385,7 +389,7 @@ export const nl = {
       },
     },
     scrapeFailed: `Kan "{{url}}" niet analyseren`,
-    submit: 'Analyseer',
+    submit: 'Huisstijl ophalen',
     success: 'Gereed, {{tokenCount}} tokens gevonden',
     title: 'Maak je eigen thema',
   },

--- a/packages/theme-wizard-website/src/pages/index.astro
+++ b/packages/theme-wizard-website/src/pages/index.astro
@@ -16,13 +16,7 @@ const scraperUrl = withRelatedProject({
     <wizard-layout>
       <main slot="main" class="wizard-main">
         <wizard-container size="md">
-          <wizard-stack>
-            <wizard-story-preview size="lg">
-              <h1 class="wizard-title">Maak je eigen thema</h1>
-              <wizard-scraper scraperUrl={scraperUrl}></wizard-scraper>
-            </wizard-story-preview>
-            <p class="nl-paragraph">Begin direct met <a href="/basis-tokens" class="nl-link">basis tokens</a>.</p>
-          </wizard-stack>
+          <wizard-scraper scraperUrl={scraperUrl}></wizard-scraper>
         </wizard-container>
       </main>
      </wizard-layout>

--- a/packages/theme-wizard-website/src/pages/index.astro
+++ b/packages/theme-wizard-website/src/pages/index.astro
@@ -36,10 +36,6 @@ const scraperUrl = withRelatedProject({
     padding-block: var(--basis-space-block-5xl);
     place-content: center;
   }
-
-  .wizard-title {
-    margin-block-start: 0;
-  }
 </style>
 
 <script>

--- a/packages/theme-wizard-website/src/pages/staging-tokens.astro
+++ b/packages/theme-wizard-website/src/pages/staging-tokens.astro
@@ -20,7 +20,7 @@ import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react'
                       Vorige stap
                     </a>
                     <h1 class="wizard-page-title">Ontwerpkeuzes gevonden!</h1>
-                    <p class="nl-paragraph nl-paragraph--lead">Bij NL Design System noemen wij deze ontwerpkeuzes <i>design tokens</i>. Je kunt deze design tokens als keuzeopties gebruiken om je huisstijl vast te leggen.</p>
+                    <p class="nl-paragraph nl-paragraph--lead">Bij NL Design System noemen wij deze ontwerpkeuzes: design tokens. Je kunt deze design tokens als opties gebruiken om je huisstijl vast te leggen.</p>
                     <p class="nl-paragraph">Selecteer de design tokens die je wilt kunnen gebruiken. Geen zorgen: je kunt deze selectie altijd aanpassen.</p>
                     <a class="nl-button nl-button--primary nl-button--icon" href="/basis-tokens">
                       <span class="nl-button__label">Huisstijl vastleggen</span>

--- a/packages/theme-wizard-website/src/pages/staging-tokens.astro
+++ b/packages/theme-wizard-website/src/pages/staging-tokens.astro
@@ -19,8 +19,8 @@ import { IconArrowLeft, IconArrowRight } from '@tabler/icons-react'
                       <IconArrowLeft />
                       Vorige stap
                     </a>
-                    <h1 class="wizard-page-title">Design beslissingen gevonden!</h1>
-                    <p class="nl-paragraph nl-paragraph--lead">Bij NL Design System noemen wij deze design beslissingen <i>design tokens</i>. Je kunt deze design tokens als keuzeopties gebruiken om je huisstijl vast te leggen.</p>
+                    <h1 class="wizard-page-title">Ontwerpkeuzes gevonden!</h1>
+                    <p class="nl-paragraph nl-paragraph--lead">Bij NL Design System noemen wij deze ontwerpkeuzes <i>design tokens</i>. Je kunt deze design tokens als keuzeopties gebruiken om je huisstijl vast te leggen.</p>
                     <p class="nl-paragraph">Selecteer de design tokens die je wilt kunnen gebruiken. Geen zorgen: je kunt deze selectie altijd aanpassen.</p>
                     <a class="nl-button nl-button--primary nl-button--icon" href="/basis-tokens">
                       <span class="nl-button__label">Huisstijl vastleggen</span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,6 +565,9 @@ importers:
       style-dictionary:
         specifier: 5.3.3
         version: 5.3.3
+      xstate:
+        specifier: 5.28.0
+        version: 5.28.0
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -8648,6 +8651,9 @@ packages:
   xdg-portable@7.3.0:
     resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
     engines: {node: '>= 6.0'}
+
+  xstate@5.28.0:
+    resolution: {integrity: sha512-Iaqq6ZrUzqeUtA3hC5LQKZfR8ZLzEFTImMHJM3jWEdVvXWdKvvVLXZEiNQWm3SCA9ZbEou/n5rcsna1wb9t28A==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -17537,6 +17543,8 @@ snapshots:
   xdg-portable@7.3.0:
     dependencies:
       os-paths: 4.4.0
+
+  xstate@5.28.0: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/b6fb4497-acb5-4a6b-aabb-039fbd6fdec7




- After submitting the scraper form, show two separate loading states
- Each loading state is shown at least 3 seconds, even if scraping finishes sooner
- If scraping fails, the form is shown again
- If users prefer reduced motion, the animations are converted to fading in and out, instead of bounding up and down
- The state management is powered by Xstate because it's nice to set state explicitly and let it handle the various timers and edge cases for us.