### PR TITLE
Zorg dat size tokens een preview hebben in de combobox

### DIFF
--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/dimension.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/dimension.ts
@@ -1,3 +1,4 @@
+import '@nl-design-system-community/clippy-components/clippy-html-image';
 import {
   type DimensionToken,
   type ModernDimensionValue,
@@ -5,8 +6,10 @@ import {
   EXTENSION_RESOLVED_AS,
   isRef,
   stringifyDimension,
+  EXTENSION_TOKEN_SUBTYPE,
 } from '@nl-design-system-community/design-tokens-schema';
-import '@nl-design-system-community/clippy-components/clippy-html-image';
+import { html, nothing } from 'lit';
+import { styleMap } from 'lit/directives/style-map.js';
 
 const getActualValue = (token: ModernDimensionToken): ModernDimensionValue => {
   const { $extensions, $value } = token;
@@ -30,4 +33,20 @@ export const queryToValue = (query: string): DimensionToken => {
 
 export const valueToQuery = <T extends { $value: DimensionToken['$value'] }>({ $value }: T): string => {
   return typeof $value === 'string' ? $value : stringifyDimension($value);
+};
+
+export const preview = <T extends { label: string; value: ModernDimensionToken }>({ value }: T) => {
+  if (value.$extensions?.[EXTENSION_TOKEN_SUBTYPE] !== 'font-size') return nothing;
+  const PREVIEW_VALUE = 'Ag';
+  const actualValue = getActualValue(value);
+  const styles = {
+    fontSize: stringifyDimension(actualValue),
+  };
+  return html`
+    <clippy-html-image>
+      <span class="wizard-token-combobox__preview wizard-token-combobox__preview--font-size" style=${styleMap(styles)}
+        >${PREVIEW_VALUE}</span
+      >
+    </clippy-html-image>
+  `;
 };

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/dimension.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/dimension.ts
@@ -1,0 +1,33 @@
+import {
+  type DimensionToken,
+  type ModernDimensionValue,
+  type ModernDimensionToken,
+  EXTENSION_RESOLVED_AS,
+  isRef,
+  stringifyDimension,
+} from '@nl-design-system-community/design-tokens-schema';
+import '@nl-design-system-community/clippy-components/clippy-html-image';
+
+const getActualValue = (token: ModernDimensionToken): ModernDimensionValue => {
+  const { $extensions, $value } = token;
+  const resolvedAs = $extensions?.[EXTENSION_RESOLVED_AS];
+  if (isRef($value)) {
+    return resolvedAs as ModernDimensionValue;
+  }
+  return $value;
+};
+
+export const filter = <T extends { value: ModernDimensionToken }>(query: string): ((option: T) => boolean) => {
+  return ({ value: token }: T) => {
+    const actualValue = getActualValue(token);
+    return stringifyDimension(actualValue).toLowerCase().includes(query);
+  };
+};
+
+export const queryToValue = (query: string): DimensionToken => {
+  return { $type: 'dimension', $value: query };
+};
+
+export const valueToQuery = <T extends { $value: DimensionToken['$value'] }>({ $value }: T): string => {
+  return typeof $value === 'string' ? $value : stringifyDimension($value);
+};

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/dimension.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/dimension.ts
@@ -36,7 +36,10 @@ export const valueToQuery = <T extends { $value: DimensionToken['$value'] }>({ $
 };
 
 export const preview = <T extends { label: string; value: ModernDimensionToken }>({ value }: T) => {
-  if (value.$extensions?.[EXTENSION_TOKEN_SUBTYPE] !== 'font-size') return nothing;
+  if (value.$extensions?.[EXTENSION_TOKEN_SUBTYPE] !== 'font-size') {
+    return nothing;
+  }
+
   const PREVIEW_VALUE = 'Ag';
   const actualValue = getActualValue(value);
   const styles = {

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/font-family.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/font-family.ts
@@ -16,7 +16,7 @@ export const filter = <T extends { value: FontFamilyToken }>(query: string): ((o
   return ({ value: token }: T) => {
     const actualValue = getActualValue(token);
     const value = Array.isArray(actualValue) ? actualValue[0] : (actualValue ?? '');
-    return value.toLowerCase().includes(query.toLowerCase());
+    return value.toLowerCase().includes(query);
   };
 };
 

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/index.ts
@@ -186,14 +186,14 @@ export class WizardTokenCombobox extends LocalizationMixin(C) {
   }
 
   renderPreview(option: Option) {
+    // TODO fix type safety by making sure option type is inferred from `option.value.$type`
     switch (option.value.$type) {
       case 'color':
-        // TODO fix type safety by making sure option type is inferred from `option.value.$type`
         return libColor.preview(option as Option & { value: ColorToken });
       case 'fontFamily':
-        // TODO fix type safety by making sure option type is inferred from `option.value.$type`
         return libFontFamily.preview(option as Option & { value: FontFamilyToken });
       case 'dimension':
+        return libDimension.preview(option as Option & { value: ModernDimensionToken });
       case 'number':
       default:
         return nothing;

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/index.ts
@@ -6,8 +6,9 @@ import LocalizationMixin from '@nl-design-system-community/clippy-components/lib
 import {
   EXTENSION_RESOLVED_AS,
   isRef,
+  stringifyDimension,
   type ColorToken,
-  type DimensionToken,
+  type ModernDimensionToken,
   type FontFamilyToken,
   type ResolvedToken,
 } from '@nl-design-system-community/design-tokens-schema';
@@ -18,13 +19,14 @@ import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { DesignToken } from 'style-dictionary/types';
 import * as libColor from './color'; // Consider loading this dynamically based on component attribute `type`
+import * as libDimension from './dimension'; // Consider loading this dynamically based on component attribute `type`
 import * as libFontFamily from './font-family'; // Consider loading this dynamically based on component attribute `type`
 import styles from './styles';
 
 export type Option = {
   label: string;
   description?: string;
-  value: ColorToken | DimensionToken | FontFamilyToken | ResolvedToken | DesignToken;
+  value: ColorToken | ModernDimensionToken | FontFamilyToken | ResolvedToken | DesignToken;
   color?: Color;
 };
 
@@ -61,6 +63,9 @@ export class WizardTokenCombobox extends LocalizationMixin(C) {
     if (typeof token?.$value === 'string' || typeof token?.$value === 'number' || token.$value === undefined) {
       return token.$value;
     }
+    if (token.$type === 'dimension') {
+      return stringifyDimension(token.$value);
+    }
     return JSON.stringify(token.$value); // TODO: improve this for better display of complex tokens
   }
 
@@ -84,6 +89,9 @@ export class WizardTokenCombobox extends LocalizationMixin(C) {
         return ({ label, value }: Option) =>
           filterByLabel({ label, value }) || libFontFamily.filter(normalizedQuery)({ value: value as FontFamilyToken });
       case 'dimension':
+        return ({ label, value }: Option) =>
+          filterByLabel({ label, value }) ||
+          libDimension.filter(normalizedQuery)({ value: value as ModernDimensionToken });
       case 'number':
       default:
         return filterByLabel;
@@ -143,6 +151,7 @@ export class WizardTokenCombobox extends LocalizationMixin(C) {
             case 'fontFamily':
               return libFontFamily.queryToValue(query);
             case 'dimension':
+              return libDimension.queryToValue(query);
             case 'number':
             default:
               return super.queryToValue(query);
@@ -169,6 +178,7 @@ export class WizardTokenCombobox extends LocalizationMixin(C) {
       case 'fontFamily':
         return stringValue || libFontFamily.valueToQuery({ $value });
       case 'dimension':
+        return stringValue || libDimension.valueToQuery({ $value });
       case 'number':
       default:
         return stringValue || JSON.stringify($value);

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/styles.ts
@@ -13,12 +13,15 @@ export default css`
     gap: var(--wizard-token-combobox-option-gap, var(--basis-space-inline-md));
   }
 
-  .wizard-token-combobox__preview--font-family {
+  .wizard-token-combobox__preview--font-family,
+  .wizard-token-combobox__preview--font-size {
     align-items: center;
+    block-size: var(--nl-color-sample-block-size);
     display: inline-flex;
     font-size: var(--basis-text-font-size-lg);
+    inline-size: var(--nl-color-sample-block-size);
     justify-content: center;
-    overflow: hidden;
+    overflow: clip;
     text-wrap: nowrap;
   }
 `;

--- a/packages/theme-wizard-app/src/components/wizard-token-combobox/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-combobox/styles.ts
@@ -19,7 +19,7 @@ export default css`
     block-size: var(--nl-color-sample-block-size);
     display: inline-flex;
     font-size: var(--basis-text-font-size-lg);
-    inline-size: var(--nl-color-sample-block-size);
+    inline-size: var(--nl-color-sample-inline-size);
     justify-content: center;
     overflow: clip;
     text-wrap: nowrap;

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -628,11 +628,11 @@ export const nl = {
     issue: {
       contrastValue: 'Contrast: {{value}}',
       fontSizeTooSmall: ({ context, token }: { context?: TokenLinkRenderer; token: string }) => {
-        const guidelinesLink = html`
-          <a href="https://nldesignsystem.nl/richtlijnen/stijl/typografie/lettergrootte" target="_blank">
-            Bekijk richtlijnen
-          </a>
-        `;
+        const guidelinesLink = html`<a
+          href="https://nldesignsystem.nl/richtlijnen/stijl/typografie/lettergrootte"
+          target="_blank"
+          >Bekijk richtlijnen</a
+        >`;
         if (!token) return html`Lettergrootte is te klein. ${guidelinesLink}`;
 
         const tokenLink = context ? context(token) : html`<strong>${token}</strong>`;
@@ -647,14 +647,11 @@ export const nl = {
       },
       lineHeight: 'Regelafstand: {{value}}',
       lineHeightTooSmall: ({ context, token }: { context?: TokenLinkRenderer; token: string }) => {
-        const guidelinesLink = html`
-          <a
-            href="https://nldesignsystem.nl/richtlijnen/stijl/typografie/regelafstand/#zorg-voor-een-comfortabele-regelafstand"
-            target="_blank"
-          >
-            Bekijk richtlijnen
-          </a>
-        `;
+        const guidelinesLink = html`<a
+          href="https://nldesignsystem.nl/richtlijnen/stijl/typografie/regelafstand/#zorg-voor-een-comfortabele-regelafstand"
+          target="_blank"
+          >Bekijk richtlijnen</a
+        >`;
         if (!token) return html`Regelafstand is te klein. ${guidelinesLink}`;
 
         const tokenLink = context ? context(token) : html`<strong>${token}</strong>`;

--- a/packages/theme-wizard-website/e2e/component-page.spec.ts
+++ b/packages/theme-wizard-website/e2e/component-page.spec.ts
@@ -81,8 +81,28 @@ test.describe('stories', () => {
     });
   });
 
+  test.describe('inputs allow manual input', () => {
+    test('color', async ({ page }) => {
+      const input = page.getByLabel('nl.code-block.color');
+      expect(await input.inputValue()).not.toBe('#ff0000');
+      await input.fill('#ff0000');
+      await input.press('Enter');
+      expect(await input.inputValue()).toBe('#ff0000');
+    });
+
+    test('dimension (font-size)', async ({ page }) => {
+      const input = page.getByLabel('nl.code-block.font-size');
+      expect(await input.inputValue()).not.toBe('24px');
+      await input.fill('24px');
+      await input.press('Enter');
+      expect(await input.inputValue()).toBe('24px');
+    });
+  });
+
   test.describe('validations', () => {
-    test('shows validation warning when bg+color tokens have insufficient contrast', async ({ page }) => {
+    test('shows validation warning when bg+color tokens have insufficient contrast - basis tokens', async ({
+      page,
+    }) => {
       const color = page.getByLabel('nl.code-block.color');
       const ERROR_MESSAGE = 'Onvoldoende contrast met nl.code-block.background-color';
       const OPTION = 'basis.color.accent-1-inverse.color-default';
@@ -98,10 +118,17 @@ test.describe('stories', () => {
       await expect(color).toHaveAccessibleErrorMessage(ERROR_MESSAGE);
     });
 
-    // Entering custom dimensions does not work yet
     test('shows min-font-size validation', async ({ page }) => {
+      const ERROR_MESSAGE =
+        'Lettergrootte is te klein. Bekijk richtlijnen. Lettergrootte: 12px. Minimaal vereist: 14px / 0.875rem';
+
       const input = page.getByLabel('nl.code-block.font-size');
+      // Make sure there's not already a validation message there
+      await expect(input).not.toHaveAccessibleErrorMessage(ERROR_MESSAGE);
+
       await input.fill('12px');
+      await input.press('Enter');
+      await expect(input).toHaveAccessibleErrorMessage(ERROR_MESSAGE);
     });
 
     // Entering custom dimensions/numbers does not work yet


### PR DESCRIPTION
- adds a new `dimension` lib file for the token-input, similar to the font-family and color ones (implements the same methods)
- Dimension preview is only shown for font-sizes
- We now finally have font-size validation visible in the frontend

---

Previews in the dropdown of the combobox:
<img width="488" height="405" alt="Screenshot 2026-03-26 at 16 31 41" src="https://github.com/user-attachments/assets/e0199cf8-dfa0-47c9-8a8d-83eb850c90af" />

Preview in the combobox itself when dropdown is closed
<img width="511" height="232" alt="Screenshot 2026-03-26 at 16 20 09" src="https://github.com/user-attachments/assets/fd9e7d38-0bd1-4ffb-a5da-cc72ce764340" />
