### PR TITLE
Laat de gescrapete font tokens zien bij het kiezen van de koppen font

### DIFF
--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -63,13 +63,15 @@ export class WizardFontInput extends WizardTokenInput {
   override render() {
     const value = Array.isArray(this.value) ? this.value : [this.value];
     const options: FontOption[] = [
-      ...this.scrapedTokens
-        .filter((token) => token.$extensions?.[EXTENSION_TOKEN_STAGED] === true)
-        .filter((token) => token.$type === 'fontFamily')
-        .map((token) => ({
-          label: token.$value.join(', '),
-          value: token.$value,
-        })),
+      ...this.scrapedTokens.reduce<FontOption[]>((acc, token) => {
+        if (token.$extensions?.[EXTENSION_TOKEN_STAGED] === true && token.$type === 'fontFamily') {
+          acc.push({
+            label: token.$value.join(', '),
+            value: token.$value,
+          });
+        }
+        return acc;
+      }, []),
       ...DEFAULT_FONT_OPTIONS,
     ];
 

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -1,12 +1,12 @@
 import { consume } from '@lit/context';
 import '@nl-design-system-community/clippy-components/clippy-font-combobox';
 import { ClippyFontCombobox } from '@nl-design-system-community/clippy-components/clippy-font-combobox';
-import { ScrapedDesignToken } from '@nl-design-system-community/css-scraper';
 import { ModernFontFamilyToken } from '@nl-design-system-community/design-tokens-schema';
 import { html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { scrapedTokensContext } from '../../contexts/scraped-tokens';
 import { t } from '../../i18n';
+import { EXTENSION_TOKEN_STAGED, StagedDesignToken } from '../../utils';
 import { WizardTokenInput } from '../wizard-token-input';
 
 export type FontOption = { label: string; value: ModernFontFamilyToken['$value'] };
@@ -40,7 +40,7 @@ export class WizardFontInput extends WizardTokenInput {
 
   @consume({ context: scrapedTokensContext, subscribe: true })
   @property({ attribute: false })
-  scrapedTokens: ScrapedDesignToken[] = [];
+  scrapedTokens: StagedDesignToken[] = [];
 
   override get value() {
     return this.#token.$value;
@@ -62,14 +62,16 @@ export class WizardFontInput extends WizardTokenInput {
 
   override render() {
     const value = Array.isArray(this.value) ? this.value : [this.value];
-    const options = DEFAULT_FONT_OPTIONS.concat(
-      this.scrapedTokens
+    const options: FontOption[] = [
+      ...this.scrapedTokens
+        .filter((token) => token.$extensions?.[EXTENSION_TOKEN_STAGED] === true)
         .filter((token) => token.$type === 'fontFamily')
         .map((token) => ({
           label: token.$value.join(', '),
           value: token.$value,
         })),
-    );
+      ...DEFAULT_FONT_OPTIONS,
+    ];
 
     return html`
       <div class="utrecht-form-field__input">

--- a/packages/theme-wizard-website/e2e/wizard.spec.ts
+++ b/packages/theme-wizard-website/e2e/wizard.spec.ts
@@ -14,23 +14,60 @@ test('page has accessibility basics', async ({ basisTokensPage }) => {
 });
 
 test.describe('change fonts', () => {
-  test.beforeEach(async ({ basisTokensPage }) => {
+  // Make sure we have access to scraped tokens
+  test.use({ storageState: storageStatePath });
+
+  test('Shows all options from staging tokens in font dropdown', async ({
+    basisTokensPage,
+    page,
+    stagingTokensPage,
+  }) => {
+    await stagingTokensPage.goto();
+    const tbody = page.getByRole('table', { name: 'Lettertypes' }).locator('tbody');
+    const stagedFamilies = await tbody.getByRole('code').allTextContents();
+
     await basisTokensPage.goto();
-    await basisTokensPage.page.getByRole('button', { name: 'Typografie' }).click();
+    await page.getByRole('button', { name: 'Typografie' }).click();
+    const options = await basisTokensPage.getInputOptions('Koppen');
+    const optionFamilies = (await options.allTextContents()).map((s) => s.trim());
+
+    expect(optionFamilies).toEqual(expect.arrayContaining(stagedFamilies));
   });
 
-  test('can change heading font to Courier New on preview', async ({ basisTokensPage }) => {
-    const heading = basisTokensPage.getHeading(2);
-    await expect(heading).not.toHaveFont('Courier New');
-    await basisTokensPage.changeHeadingFont('Courier New');
-    await expect(heading).toHaveFont('Courier New');
+  test('Unstaged font family is not shown in font dropdown', async ({ basisTokensPage, page, stagingTokensPage }) => {
+    await stagingTokensPage.goto();
+    const tbody = page.getByRole('table', { name: 'Lettertypes' }).locator('tbody');
+
+    await tbody.getByRole('row').first().getByRole('checkbox').uncheck();
+    const unstagedFamily = await tbody.getByRole('row').first().getByRole('code').textContent();
+
+    await basisTokensPage.goto();
+    await page.getByRole('button', { name: 'Typografie' }).click();
+    const options = await basisTokensPage.getInputOptions('Koppen');
+    const optionFamilies = (await options.allTextContents()).map((s) => s.trim());
+
+    expect(optionFamilies).not.toContain(unstagedFamily);
   });
 
-  test('can change body font to Courier New', async ({ basisTokensPage }) => {
-    const paragraph = basisTokensPage.getParagraph();
-    await expect(paragraph).not.toHaveFont('Courier New');
-    await basisTokensPage.changeBodyFont('Courier New');
-    await expect(paragraph).toHaveFont('Courier New');
+  test.describe('wizard page only', () => {
+    test.beforeEach(async ({ basisTokensPage }) => {
+      await basisTokensPage.goto();
+      await basisTokensPage.page.getByRole('button', { name: 'Typografie' }).click();
+    });
+
+    test('can change heading font to Courier New on preview', async ({ basisTokensPage }) => {
+      const heading = basisTokensPage.getHeading(2);
+      await expect(heading).not.toHaveFont('Courier New');
+      await basisTokensPage.changeHeadingFont('Courier New');
+      await expect(heading).toHaveFont('Courier New');
+    });
+
+    test('can change body font to Courier New', async ({ basisTokensPage }) => {
+      const paragraph = basisTokensPage.getParagraph();
+      await expect(paragraph).not.toHaveFont('Courier New');
+      await basisTokensPage.changeBodyFont('Courier New');
+      await expect(paragraph).toHaveFont('Courier New');
+    });
   });
 });
 


### PR DESCRIPTION
- Show scraped tokens in the font-family dropdown on the basis-tokens page
- Place the scraped tokens on top of the list, default fonts at the bottom

closes #537

<img width="381" height="323" alt="Screenshot 2026-03-27 at 09 37 07" src="https://github.com/user-attachments/assets/10412f5f-e4c9-4018-8b96-242d1b6accce" />
