### PR TITLE
Fix de testautomatisering van de scaper zodat deze niet af en toe onverwacht faalt

### DIFF
--- a/packages/theme-wizard-website/e2e/index.spec.ts
+++ b/packages/theme-wizard-website/e2e/index.spec.ts
@@ -27,19 +27,15 @@ test.describe('scraping css design tokens', () => {
   test('scrapes a valid, absolute URL', async ({ homePage, page, stagingTokensPage }) => {
     // This test waits for the loaders to disappear after scraping, which takes several seconds
     test.slow();
-    const navigationPromise = page.waitForEvent('load');
     await homePage.scrapeUrl('https://theme-wizard.nl-design-system-community.nl');
-    await navigationPromise;
-    expect(page.url()).toContain(stagingTokensPage.url);
+    await expect(page).toHaveURL(new RegExp(stagingTokensPage.url));
   });
 
   test('scrapes a valid, non-absolute URL', async ({ homePage, page, stagingTokensPage }) => {
     // This test waits for the loaders to disappear after scraping, which takes several seconds
     test.slow();
-    const navigationPromise = page.waitForEvent('load');
     await homePage.scrapeUrl('theme-wizard.nl-design-system-community.nl');
-    await navigationPromise;
-    expect(page.url()).toContain(stagingTokensPage.url);
+    await expect(page).toHaveURL(new RegExp(stagingTokensPage.url));
   });
 
   test('errors on an invalid URL', async ({ homePage }) => {


### PR DESCRIPTION
Fixes this:

<img width="1824" height="637" alt="Screenshot 2026-03-30 at 09 37 13" src="https://github.com/user-attachments/assets/1c5ce644-79d2-4295-9c0a-abb8667dbfdf" />
