### PR TITLE
Maak `<clippy-color-sample>` beschikbaar voor hergebruik

### DIFF
--- a/.changeset/dry-sheep-follow.md
+++ b/.changeset/dry-sheep-follow.md
@@ -1,0 +1,8 @@
+---
+'@nl-design-system-community/theme-wizard-app': major
+'@nl-design-system-community/clippy-components': minor
+'@nl-design-system-community/clippy-storybook': minor
+---
+
+feat: add `<clippy-color-sample>`
+breaking(theme-wizard-app): removed `<wizard-color-sample>` and moved into clippy-components as `<clippy-color-sample>`

--- a/packages/clippy-components/src/clippy-color-sample/index.test.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { ClippyColorSample } from './index';
+
+const tag = 'clippy-color-sample';
+
+describe(`<${tag}>`, () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders element', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const imgElement = page.getByRole('img');
+    expect(imgElement).toBeDefined();
+  });
+
+  it('has role="img"', () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const element = document.querySelector(tag);
+    const imgElement = element?.shadowRoot?.querySelector('[role="img"]');
+    expect(imgElement).toBeDefined();
+  });
+
+  it('renders an svg element', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = document.querySelector(tag) as ClippyColorSample;
+    await component?.updateComplete;
+
+    const svg = component.shadowRoot?.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+
+  it('applies color property as inline style', async () => {
+    document.body.innerHTML = `<${tag} color="red"></${tag}>`;
+    const component = document.querySelector(tag) as ClippyColorSample;
+    await component?.updateComplete;
+
+    const svg = component.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('style')).toContain('color: red');
+  });
+
+  it('defaults to empty color', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = document.querySelector(tag) as ClippyColorSample;
+    await component?.updateComplete;
+
+    const svg = component.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('style')).toContain('color: ;');
+  });
+
+  it('updates color when property changes', async () => {
+    document.body.innerHTML = `<${tag} color="blue"></${tag}>`;
+    const component = document.querySelector(tag) as ClippyColorSample;
+    await component?.updateComplete;
+
+    component.color = 'green';
+    await component?.updateComplete;
+
+    const svg = component.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('style')).toContain('color: green');
+  });
+
+  it('renders multiple instances independently', async () => {
+    document.body.innerHTML = `
+      <${tag} color="red"></${tag}>
+      <${tag} color="blue"></${tag}>
+    `;
+
+    const [first, second] = Array.from(document.querySelectorAll(tag)) as ClippyColorSample[];
+    await first?.updateComplete;
+    await second?.updateComplete;
+
+    const firstSvg = first.shadowRoot?.querySelector('svg');
+    const secondSvg = second.shadowRoot?.querySelector('svg');
+
+    expect(firstSvg?.getAttribute('style')).toContain('color: red');
+    expect(secondSvg?.getAttribute('style')).toContain('color: blue');
+  });
+});

--- a/packages/clippy-components/src/clippy-color-sample/index.test.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.test.ts
@@ -1,80 +1,65 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { page } from 'vitest/browser';
-import { ClippyColorSample } from './index';
+import './index';
 
 const tag = 'clippy-color-sample';
+
+type ComponentElement = { shadowRoot: ShadowRoot; updateComplete: Promise<boolean> };
+
+function getComponent() {
+  return document.querySelector(tag) as unknown as ComponentElement;
+}
+
+/**
+ * @returns An rgb() string because that is what getComputedStyle() always returns
+ */
+function getSvgComputedColor(component: ComponentElement) {
+  const svg = component.shadowRoot.querySelector('svg');
+  return getComputedStyle(svg!).color;
+}
 
 describe(`<${tag}>`, () => {
   afterEach(() => {
     document.body.innerHTML = '';
   });
 
-  it('renders element', async () => {
+  it('renders a svg with role="img"', async () => {
     document.body.innerHTML = `<${tag}></${tag}>`;
-    const imgElement = page.getByRole('img');
-    expect(imgElement).toBeDefined();
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component.shadowRoot.querySelector('[role="img"]')).toBeTruthy();
   });
 
-  it('has role="img"', () => {
-    document.body.innerHTML = `<${tag}></${tag}>`;
-    const element = document.querySelector(tag);
-    const imgElement = element?.shadowRoot?.querySelector('[role="img"]');
-    expect(imgElement).toBeDefined();
-  });
-
-  it('renders an svg element', async () => {
-    document.body.innerHTML = `<${tag}></${tag}>`;
-    const component = document.querySelector(tag) as ClippyColorSample;
-    await component?.updateComplete;
-
-    const svg = component.shadowRoot?.querySelector('svg');
-    expect(svg).toBeTruthy();
-  });
-
-  it('applies color property as inline style', async () => {
+  it('applies the color attribute as the SVG computed color', async () => {
     document.body.innerHTML = `<${tag} color="red"></${tag}>`;
-    const component = document.querySelector(tag) as ClippyColorSample;
-    await component?.updateComplete;
+    const component = getComponent();
+    await component.updateComplete;
 
-    const svg = component.shadowRoot?.querySelector('svg');
-    expect(svg?.getAttribute('style')).toContain('color: red');
+    expect(getSvgComputedColor(component)).toBe('rgb(255, 0, 0)');
   });
 
-  it('defaults to empty color', async () => {
-    document.body.innerHTML = `<${tag}></${tag}>`;
-    const component = document.querySelector(tag) as ClippyColorSample;
-    await component?.updateComplete;
-
-    const svg = component.shadowRoot?.querySelector('svg');
-    expect(svg?.getAttribute('style')).toContain('color: ;');
-  });
-
-  it('updates color when property changes', async () => {
-    document.body.innerHTML = `<${tag} color="blue"></${tag}>`;
-    const component = document.querySelector(tag) as ClippyColorSample;
-    await component?.updateComplete;
+  it('updates the SVG computed color when the color property changes', async () => {
+    document.body.innerHTML = `<${tag} color="rgb(0, 0, 255)"></${tag}>`;
+    const component = getComponent() as ComponentElement & { color: string };
+    await component.updateComplete;
 
     component.color = 'green';
-    await component?.updateComplete;
+    await component.updateComplete;
 
-    const svg = component.shadowRoot?.querySelector('svg');
-    expect(svg?.getAttribute('style')).toContain('color: green');
+    expect(getSvgComputedColor(component)).toBe('rgb(0, 128, 0)');
   });
 
-  it('renders multiple instances independently', async () => {
+  it('renders multiple instances with independent colors', async () => {
     document.body.innerHTML = `
-      <${tag} color="red"></${tag}>
-      <${tag} color="blue"></${tag}>
+      <${tag} color="rgb(255, 0, 0)"></${tag}>
+      <${tag} color="rgb(0, 0, 255)"></${tag}>
     `;
 
-    const [first, second] = Array.from(document.querySelectorAll(tag)) as ClippyColorSample[];
-    await first?.updateComplete;
-    await second?.updateComplete;
+    const [first, second] = Array.from(document.querySelectorAll(tag)) as unknown as ComponentElement[];
+    await first.updateComplete;
+    await second.updateComplete;
 
-    const firstSvg = first.shadowRoot?.querySelector('svg');
-    const secondSvg = second.shadowRoot?.querySelector('svg');
-
-    expect(firstSvg?.getAttribute('style')).toContain('color: red');
-    expect(secondSvg?.getAttribute('style')).toContain('color: blue');
+    expect(getSvgComputedColor(first)).toBe('rgb(255, 0, 0)');
+    expect(getSvgComputedColor(second)).toBe('rgb(0, 0, 255)');
   });
 });

--- a/packages/clippy-components/src/clippy-color-sample/index.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.ts
@@ -1,17 +1,18 @@
 import colorSampleStyles from '@nl-design-system-candidate/color-sample-css/color-sample.css?inline';
+import { safeCustomElement } from '@src/lib/decorators';
 import { LitElement, html, unsafeCSS } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
 
-const tag = 'wizard-color-sample';
+const tag = 'clippy-color-sample';
 
 declare global {
   interface HTMLElementTagNameMap {
-    [tag]: WizardColorSample;
+    [tag]: ClippyColorSample;
   }
 }
 
-@customElement(tag)
-export class WizardColorSample extends LitElement {
+@safeCustomElement(tag)
+export class ClippyColorSample extends LitElement {
   static override readonly styles = [unsafeCSS(colorSampleStyles)];
 
   @property() color: string = '';

--- a/packages/clippy-storybook/src/web-components/clippy-color-sample.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-color-sample.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '@nl-design-system-community/clippy-components/clippy-color-sample';
+import React from 'react';
+
+type ColorSampleStoryArgs = {
+  color?: string;
+};
+
+const meta = {
+  id: 'clippy-color-sample',
+  argTypes: {
+    color: {
+      control: { type: 'color' },
+      description: 'De kleur van de color-sample. Ondersteunt alle geldige CSS-kleurwaarden.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '`<clippy-color-sample>` is een web component om een color-sample te renderen als een SVG-afbeelding. Het `color`-attribuut bepaalt de weergegeven kleur en ondersteunt alle geldige CSS-kleurwaarden. Het is een web-component-implementatie van de `nl-color-sample` component.',
+      },
+    },
+  },
+  render: ({ color }) => React.createElement('clippy-color-sample', { color }),
+  tags: ['autodocs'],
+  title: 'Clippy/Color Sample',
+} satisfies Meta<ColorSampleStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Basis color-sample',
+  args: {
+    color: '#8a3a9f',
+  },
+};
+
+export const Multiple: Story = {
+  name: 'Meerdere color-samples',
+  render: () =>
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement('clippy-color-sample', { color: '#007BC7' }),
+      React.createElement('clippy-color-sample', { color: 'hsl(200deg 50% 20%)' }),
+      React.createElement('clippy-color-sample', { color: 'rgb(from red r g b / 50%)' }),
+    ),
+};

--- a/packages/theme-wizard-app/index.ts
+++ b/packages/theme-wizard-app/index.ts
@@ -1,6 +1,5 @@
 import './src/components/app/app';
 import './src/components/wizard-anchor-nav';
-import './src/components/wizard-color-sample';
 import './src/components/wizard-container';
 import './src/components/wizard-font-sample';
 import './src/components/wizard-layout';

--- a/packages/theme-wizard-app/src/components/wizard-scraped-tokens-preview/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraped-tokens-preview/index.ts
@@ -1,6 +1,7 @@
 import { consume } from '@lit/context';
 import codeStyles from '@nl-design-system-candidate/code-css/code.css?inline';
 import srOnlyStyles from '@nl-design-system-community/clippy-components/lib/sr-only';
+import '@nl-design-system-community/clippy-components/clippy-color-sample';
 import {
   EXTENSION_AUTHORED_AS,
   EXTENSION_TOKEN_ID,
@@ -132,7 +133,7 @@ export class WizardScrapedTokensPreview extends LitElement {
             t('tokens.types.colors'),
             colors,
             (token) =>
-              html`<wizard-color-sample color=${token.$extensions[EXTENSION_AUTHORED_AS]}></wizard-color-sample>`,
+              html`<clippy-color-sample color=${token.$extensions[EXTENSION_AUTHORED_AS]}></clippy-color-sample>`,
           )}
         </wizard-stack>
       </div>

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
@@ -7,6 +7,7 @@ import '@nl-design-system-community/clippy-components/clippy-toggletip';
 import linkCss from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphCss from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
 import { type ColorToken as ColorTokenType, stringifyColor } from '@nl-design-system-community/design-tokens-schema';
+import '@nl-design-system-community/clippy-components/clippy-color-sample';
 import ClipboardCopyIcon from '@tabler/icons/outline/clipboard-copy.svg?raw';
 import buttonLinkStyles from '@utrecht/link-button-css?inline';
 import tableCss from '@utrecht/table-css/dist/index.css?inline';
@@ -120,7 +121,7 @@ export class WizardStyleGuideColors extends LitElement {
                     ({ displayValue, tokenId, usage }) => html`
                       <tr class="utrecht-table__row">
                         <td class="utrecht-table__cell">
-                          <wizard-color-sample color=${displayValue}></wizard-color-sample>
+                          <clippy-color-sample color=${displayValue}></clippy-color-sample>
                         </td>
                         <td class="utrecht-table__cell">
                           <span class="nl-data-badge" id=${tokenId}>${tokenId}</span>

--- a/packages/theme-wizard-app/src/components/wizard-style-guide/utils.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide/utils.ts
@@ -1,4 +1,5 @@
 import type { ClippyModal } from '@nl-design-system-community/clippy-components/clippy-modal';
+import '@nl-design-system-community/clippy-components/clippy-color-sample';
 import '@nl-design-system-community/clippy-components/clippy-modal';
 import '@nl-design-system-community/clippy-components/clippy-heading';
 import type { DesignTokens } from 'style-dictionary/types';
@@ -72,7 +73,7 @@ export function renderSpacingExample(value: string, space: string = 'block') {
 export function renderTokenExample(token: Omit<DisplayToken, 'usage'>) {
   switch (token.tokenType) {
     case 'color':
-      return html`<wizard-color-sample color=${token.displayValue}></wizard-color-sample>`;
+      return html`<clippy-color-sample color=${token.displayValue}></clippy-color-sample>`;
     case 'fontSize':
       return html`<wizard-font-sample size=${token.displayValue}></wizard-font-sample>`;
     case 'fontFamily':


### PR DESCRIPTION
Moves the `color-sample` component from theme-wizard to clippy-components

- [x] Storybook and docs at https://clippy-storybook-git-feat-clippy-color-sample-nl-design-system.vercel.app/?path=/docs/clippy-color-sample--documentatie
- [x] color samples render as expected, for example on https://theme-wizard-git-feat-clippy-color-sample-nl-design-system.vercel.app/style-guide#colors