### PR TITLE
Toon duidelijke foutmelding als scrapen van een URL niet lukt

### DIFF
--- a/.changeset/bumpy-regions-sin.md
+++ b/.changeset/bumpy-regions-sin.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/theme-wizard-app': minor
+---
+
+feat: show useful error message when scraping a website fails

--- a/packages/theme-wizard-app/src/components/wizard-scraper/state-machine.ts
+++ b/packages/theme-wizard-app/src/components/wizard-scraper/state-machine.ts
@@ -4,6 +4,13 @@ import { assign, fromPromise, raise, setup } from 'xstate';
 import { t } from '../../i18n';
 import Scraper from '../../lib/Scraper';
 
+const errorNameToMessageKey: Record<string, string> = {
+  ConnectionRefusedError: 'scraper.errors.connectionRefused',
+  ForbiddenError: 'scraper.errors.forbidden',
+  NotFoundError: 'scraper.errors.notFound',
+  TimeoutError: 'scraper.errors.timeOut',
+};
+
 export const scraperMachine = setup({
   actions: {
     assignUrl: assign({
@@ -92,7 +99,13 @@ export const scraperMachine = setup({
         },
         onError: {
           // Exit immediately regardless of where the timer is.
-          actions: assign({ error: ({ context }) => t('scraper.scrapeFailed', { url: context.url }) }),
+          actions: assign({
+            error: ({ event }) => {
+              const [firstError] = (event.error as { errors?: { name: string }[] })?.errors ?? [];
+              const messageKey = firstError?.name && errorNameToMessageKey[firstError.name];
+              return messageKey ? t(messageKey) : t('scraper.errors.error');
+            },
+          }),
           target: 'error',
         },
         src: 'scrapeTokens',

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -41,6 +41,13 @@ export const en = {
   save: 'Save',
   scraper: {
     directStart: html`Begin directly with <a href="/basis-tokens" class="nl-link">basic tokens</a>.`,
+    errors: {
+      connectionRefused: 'This website does not seem to exist.',
+      error: 'Cannot analyze this website',
+      forbidden: 'This website does not allow analysis.',
+      notFound: 'This website or webpage cannot be found.',
+      timeOut: 'It takes too long for this website to respond.',
+    },
     input: {
       description: 'E.g. gemeentevoorbeeld.nl',
       label: 'Website URL',
@@ -388,6 +395,13 @@ export const nl = {
   save: 'Opslaan',
   scraper: {
     directStart: html`Begin direct met <a href="/basis-tokens" class="nl-link">basis tokens</a>.`,
+    errors: {
+      connectionRefused: 'Deze website lijkt niet te bestaan.',
+      error: 'Kan deze website niet analyseren',
+      forbidden: 'Deze website staat niet toe om geanalyseerd te worden.',
+      notFound: 'Deze pagina kan niet worden gevonden.',
+      timeOut: 'Deze website reageert te langzaam om te kunnen analyseren',
+    },
     input: {
       description: 'Bijvoorbeeld gemeentevoorbeeld.nl',
       label: 'Website URL',

--- a/packages/theme-wizard-app/src/lib/Scraper/index.ts
+++ b/packages/theme-wizard-app/src/lib/Scraper/index.ts
@@ -28,7 +28,10 @@ export default class Scraper {
   async getTokens(url: URL): Promise<ScrapedDesignToken[]> {
     const response = await this.#get(this.#requestTokenUrl, url);
     if (!response.ok) {
-      throw new Error('Scraping design tokens failed');
+      const body = await response.json().catch(() => ({}));
+      throw Object.assign(new Error('Scraping design tokens failed'), {
+        errors: body.errors ?? [],
+      });
     }
     return response.json();
   }

--- a/packages/theme-wizard-website/e2e/index.spec.ts
+++ b/packages/theme-wizard-website/e2e/index.spec.ts
@@ -41,7 +41,7 @@ test.describe('scraping css design tokens', () => {
   test('errors on an invalid URL', async ({ homePage }) => {
     await homePage.scrapeUrl('https://.com');
     await expect.soft(homePage.input).toHaveAttribute('aria-invalid', 'true');
-    await expect.soft(homePage.input).toHaveAccessibleErrorMessage('Kan "https://.com" niet analyseren.');
+    await expect.soft(homePage.input).toHaveAccessibleErrorMessage('Deze website lijkt niet te bestaan.');
   });
 
   test('errors when no URL is entered', async ({ homePage }) => {


### PR DESCRIPTION
closes #640

---

<img width="610" height="509" alt="Screenshot 2026-04-14 at 19 38 02" src="https://github.com/user-attachments/assets/86c24cda-dd6d-4eae-a2b3-9e3700e576e7" />
<img width="589" height="500" alt="Screenshot 2026-04-14 at 19 38 11" src="https://github.com/user-attachments/assets/46def0e6-a1b1-46a7-ab88-7a58945ef524" />
<img width="564" height="497" alt="Screenshot 2026-04-14 at 19 38 42" src="https://github.com/user-attachments/assets/ae836201-d1a3-41dc-9a05-53bb65d6b2de" />
