### PR TITLE
ci: opt in to pnpm v11 for pnpm audit with an environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -64,6 +71,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -92,6 +106,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -129,6 +150,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -176,6 +204,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,6 +31,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/periodic-e2e.yml
+++ b/.github/workflows/periodic-e2e.yml
@@ -37,6 +37,13 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,13 @@ jobs:
         uses: pnpm/action-setup@26f6d4f2c533a43e6b5da0b4a5dd983f98f7b49a # v6.0.4
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical


### PR DESCRIPTION
This PR updates the pnpm audit command to use the v11 version of the command.

It only affects the pnpm audit command, and does not affect the other pnpm commands like pnpm install.
You have to opt in to this by setting the `ENABLE_PNPM_AUDIT_V11` environment variable to `1`.
You can choose to do this on the repository level or on the organization level.

See https://github.com/nl-design-system/beheer/issues/70 for more details.