### PR TITLE
Documenteer clippy components voor makkelijker hergebruik

### DIFF
--- a/.changeset/tricky-bugs-sneeze.md
+++ b/.changeset/tricky-bugs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/clippy-components': minor
+---
+
+add root and component-level readmes to clippy-components

--- a/packages/clippy-components/README.md
+++ b/packages/clippy-components/README.md
@@ -1,0 +1,50 @@
+# `@nl-design-system-community/clippy-components`
+
+A collection of accessible web components used in the NL Design System Theme Wizard. Built with [Lit](https://lit.dev/).
+
+## Installation
+
+```sh
+npm install @nl-design-system-community/clippy-components
+```
+
+Import the components you need:
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-button';
+import '@nl-design-system-community/clippy-components/clippy-modal';
+```
+
+## Quick example
+
+```html
+<clippy-modal title="Confirm" actions="both" id="confirm-dialog"> Are you sure? </clippy-modal>
+
+<clippy-button purpose="primary" id="open-btn">Open</clippy-button>
+
+<script>
+  const modal = document.getElementById('confirm-dialog');
+  document.getElementById('open-btn').addEventListener('click', () => modal.open());
+  modal.addEventListener('close', () => console.log(modal.returnValue));
+</script>
+```
+
+## Components
+
+| Component                                                        | Description                                                        |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------ |
+| [`<clippy-button>`](src/clippy-button/README.md)                 | Styled button with purpose, hint, size, and toggle variants        |
+| [`<clippy-code>`](src/clippy-code/README.md)                     | Inline code element                                                |
+| [`<clippy-color-combobox>`](src/clippy-color-combobox/README.md) | Combobox for picking a color token, with color-proximity filtering |
+| [`<clippy-color-sample>`](src/clippy-color-sample/README.md)     | Small square color swatch                                          |
+| [`<clippy-combobox>`](src/clippy-combobox/README.md)             | Accessible combobox with keyboard navigation and filtering         |
+| [`<clippy-font-combobox>`](src/clippy-font-combobox/README.md)   | Combobox for selecting a font family with live preview             |
+| [`<clippy-heading>`](src/clippy-heading/README.md)               | Heading element with configurable level (h1–h6)                    |
+| [`<clippy-html-image>`](src/clippy-html-image/README.md)         | Arbitrary HTML content exposed as an accessible image              |
+| [`<clippy-icon>`](src/clippy-icon/README.md)                     | Decorative icon wrapper (auto aria-hidden)                         |
+| [`<clippy-lang-combobox>`](src/clippy-lang-combobox/README.md)   | Combobox for selecting a language                                  |
+| [`<clippy-modal>`](src/clippy-modal/README.md)                   | Modal dialog with focus management and configurable actions        |
+| [`<clippy-react-element>`](src/clippy-react-element/README.md)   | Web component that mounts a React element                          |
+| [`<clippy-reset-theme>`](src/clippy-reset-theme/README.md)       | Resets CSS custom properties to basis token values                 |
+| [`<clippy-story-preview>`](src/clippy-story-preview/README.md)   | Storybook-style preview container                                  |
+| [`<clippy-toggletip>`](src/clippy-toggletip/README.md)           | Tooltip that shows on hover or focus                               |

--- a/packages/clippy-components/src/clippy-button/README.md
+++ b/packages/clippy-components/src/clippy-button/README.md
@@ -1,0 +1,58 @@
+# `<clippy-button>`
+
+Styled button following NL Design System conventions. Supports purposes, hints, sizes, toggle state, busy state, and icon-only mode.
+
+Based on [`@nl-design-system-candidate/button-css`](https://www.npmjs.com/package/@nl-design-system-candidate/button-css). See the [NL Design System button documentation](https://nldesignsystem.nl/button) for available design tokens and guidelines.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-button';
+```
+
+```html
+<clippy-button purpose="primary">Save</clippy-button>
+
+<clippy-button purpose="secondary" hint="negative" busy>Deleting&hellip;</clippy-button>
+
+<clippy-button icon-only purpose="subtle">
+  <clippy-icon slot="iconStart"><svg>…</svg></clippy-icon>
+  Close
+</clippy-button>
+
+<clippy-button toggle .pressed="${isActive}" @click="${toggle}"> Notifications </clippy-button>
+```
+
+## Attributes
+
+| Attribute   | Type    | Values                               | Default  |
+| ----------- | ------- | ------------------------------------ | -------- |
+| `purpose`   | string  | `primary` \| `secondary` \| `subtle` | —        |
+| `hint`      | string  | `positive` \| `negative`             | —        |
+| `size`      | string  | `small` \| `medium`                  | `medium` |
+| `type`      | string  | `button` \| `submit` \| `reset`      | `button` |
+| `busy`      | boolean | —                                    | `false`  |
+| `toggle`    | boolean | —                                    | —        |
+| `pressed`   | boolean | —                                    | `false`  |
+| `icon-only` | boolean | —                                    | `false`  |
+| `disabled`  | boolean | —                                    | `false`  |
+
+Invalid values for `purpose`, `hint`, `size`, and `type` log a console warning and fall back to the default.
+
+## Slots
+
+| Slot        | Description                 |
+| ----------- | --------------------------- |
+| _(default)_ | Button label text           |
+| `iconStart` | Icon displayed before label |
+| `iconEnd`   | Icon displayed after label  |
+
+## CSS custom properties
+
+These apply when `size="small"`:
+
+| Property                                | Default |
+| --------------------------------------- | ------- |
+| `--clippy-button-small-min-inline-size` | `32px`  |
+| `--clippy-button-small-min-block-size`  | `32px`  |
+| `--clippy-button-small-icon`            | `18px`  |

--- a/packages/clippy-components/src/clippy-code/README.md
+++ b/packages/clippy-components/src/clippy-code/README.md
@@ -1,5 +1,21 @@
 # `<clippy-code>`
 
-Computercode die onderdeel is van lopende tekst.
+Wraps inline text in a styled `<code>` element using NL Design System code styles.
 
-De [Code component](https://nldesignsystem.nl/code/) is een web component van `nl-code`.
+Based on [`@nl-design-system-candidate/code-css`](https://www.npmjs.com/package/@nl-design-system-candidate/code-css). See the [NL Design System code documentation](https://nldesignsystem.nl/code) for available design tokens and guidelines.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-code';
+```
+
+```html
+<p>Set the <clippy-code>color</clippy-code> token to apply your brand color.</p>
+```
+
+## Slots
+
+| Slot        | Description  |
+| ----------- | ------------ |
+| _(default)_ | Code content |

--- a/packages/clippy-components/src/clippy-color-combobox/README.md
+++ b/packages/clippy-components/src/clippy-color-combobox/README.md
@@ -1,0 +1,61 @@
+# `<clippy-color-combobox>`
+
+Extends [`<clippy-combobox>`](../clippy-combobox/README.md) for picking a color token. Filters options by label text and by visual color proximity using ΔE 2000. Supports localized color name searching (e.g. searching "oranje" in Dutch finds orange colors).
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-color-combobox';
+```
+
+```html
+<clippy-color-combobox name="background-color" lang="nl"></clippy-color-combobox>
+
+<script>
+  const el = document.querySelector('clippy-color-combobox');
+
+  // Options accept hex strings or design token $value objects
+  el.options = [
+    { label: 'Ocean blue', value: '#006fc0' },
+    { label: 'Forest green', value: '#1a7a4a' },
+    {
+      label: 'Brand red',
+      value: { alpha: 1, colorSpace: 'srgb', components: [0.8, 0.1, 0.1] },
+    },
+  ];
+
+  el.addEventListener('change', () => console.log(el.value));
+</script>
+```
+
+## Attributes
+
+Inherits all attributes from `<clippy-combobox>`. The following differ from the base:
+
+| Attribute | Type   | Values                           | Default         |
+| --------- | ------ | -------------------------------- | --------------- |
+| `allow`   | string | `options` \| `other`             | `other`         |
+| `lang`    | string | Language code, e.g. `nl` or `en` | browser default |
+
+Setting `lang` loads localized color name translations (currently `en` and `nl`). Users can then search for colors using translated names such as "groen" (green) or "rood" (red).
+
+## Options format
+
+Each option must have `label` (string) and `value` (hex string or design token `$value` object):
+
+```js
+// Hex string
+{ label: 'Blue', value: '#0000ff' }
+
+// Design token $value object
+{ label: 'Blue', value: { alpha: 1, colorSpace: 'srgb', components: [0, 0, 1] } }
+```
+
+## Events
+
+| Event    | Description                           |
+| -------- | ------------------------------------- |
+| `change` | Fired when the selected value changes |
+| `input`  | Fired on every keystroke              |
+| `focus`  | Fired when the combobox gains focus   |
+| `blur`   | Fired when the combobox loses focus   |

--- a/packages/clippy-components/src/clippy-color-sample/README.md
+++ b/packages/clippy-components/src/clippy-color-sample/README.md
@@ -1,0 +1,30 @@
+# `<clippy-color-sample>`
+
+Renders a small square SVG swatch for a given CSS color value. Updates reactively when the `color` property changes. Maintains the color, even when in forced-colors document mode.
+
+Based on [`@nl-design-system-candidate/color-sample-css`](https://www.npmjs.com/package/@nl-design-system-candidate/color-sample-css). See the [NL Design System color sample documentation](https://nldesignsystem.nl/color-sample) for available design tokens and guidelines.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-color-sample';
+```
+
+```html
+<clippy-color-sample color="#c0392b"></clippy-color-sample>
+<clippy-color-sample color="oklch(60% 0.2 30)"></clippy-color-sample>
+<clippy-color-sample color="rgb(0, 128, 0)"></clippy-color-sample>
+```
+
+Setting the property directly also works:
+
+```js
+const el = document.querySelector('clippy-color-sample');
+el.color = 'rebeccapurple';
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type   | Description                | Default |
+| -------------------- | ------ | -------------------------- | ------- |
+| `color`              | string | Any valid CSS color string | `''`    |

--- a/packages/clippy-components/src/clippy-combobox/README.md
+++ b/packages/clippy-components/src/clippy-combobox/README.md
@@ -1,0 +1,86 @@
+# `<clippy-combobox>`
+
+Accessible combobox with keyboard navigation, option filtering, and optional free-text input. Participates in form submission. This is the base component for [`<clippy-color-combobox>`](../clippy-color-combobox/README.md), [`<clippy-font-combobox>`](../clippy-font-combobox/README.md), and [`<clippy-lang-combobox>`](../clippy-lang-combobox/README.md).
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-combobox';
+```
+
+```html
+<clippy-combobox name="framework">
+  <span slot="label">Framework</span>
+  <span slot="description">Pick the framework you use</span>
+</clippy-combobox>
+
+<script>
+  const el = document.querySelector('clippy-combobox');
+
+  // Options can be an array of strings…
+  el.options = ['React', 'Vue', 'Svelte'];
+
+  // …or an array of objects with label, value, and optional description
+  el.options = [
+    { label: 'React', value: 'react' },
+    { label: 'Vue', value: 'vue' },
+    { label: 'Svelte', value: 'svelte', description: 'No virtual DOM' },
+  ];
+
+  el.addEventListener('change', () => console.log(el.value));
+</script>
+```
+
+Options can also be passed as an attribute: a space-separated token list, a JSON array of strings, or a JSON array of objects.
+
+```html
+<!-- Space-separated strings -->
+<clippy-combobox name="color" options="red green blue"></clippy-combobox>
+
+<!-- JSON array -->
+<clippy-combobox name="color" options='["red","green","blue"]'></clippy-combobox>
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type    | Values                       | Default     |
+| -------------------- | ------- | ---------------------------- | ----------- |
+| `name`               | string  | —                            | —           |
+| `value`              | string  | —                            | `null`      |
+| `options`            | array   | See above                    | `[]`        |
+| `allow`              | string  | `options` \| `other`         | `options`   |
+| `position`           | string  | `block-end` \| `block-start` | `block-end` |
+| `open`               | boolean | — (reflected)                | `false`     |
+| `invalid`            | boolean | — (reflected)                | `false`     |
+| `disabled`           | boolean | —                            | `false`     |
+
+Setting `allow="other"` lets users type a value that is not in the options list.
+
+## Slots
+
+| Slot          | Description                                                     |
+| ------------- | --------------------------------------------------------------- |
+| _(default)_   | Label — rendered visually only when slotted content is provided |
+| `label`       | Explicit label slot (same as default for backward compat)       |
+| `description` | Hint text displayed below the label                             |
+| `error`       | Validation error message linked via `aria-errormessage`         |
+
+## Events
+
+| Event    | Description                           |
+| -------- | ------------------------------------- |
+| `change` | Fired when the selected value changes |
+| `input`  | Fired on every keystroke              |
+| `focus`  | Fired when the combobox gains focus   |
+| `blur`   | Fired when the combobox loses focus   |
+
+## Keyboard interaction
+
+| Key         | Action                                                            |
+| ----------- | ----------------------------------------------------------------- |
+| `ArrowDown` | Move to next option                                               |
+| `ArrowUp`   | Move to previous option                                           |
+| `Enter`     | Confirm active option (or commit typed text when `allow="other"`) |
+| `Escape`    | Clear active option                                               |
+| `Home`      | Move to first option                                              |
+| `End`       | Move to last option                                               |

--- a/packages/clippy-components/src/clippy-font-combobox/README.md
+++ b/packages/clippy-components/src/clippy-font-combobox/README.md
@@ -1,0 +1,65 @@
+# `<clippy-font-combobox>`
+
+Extends [`<clippy-combobox>`](../clippy-combobox/README.md) for selecting a font family. Options are rendered in their own font. Google Fonts stylesheets are lazily injected into `<head>` as options scroll into view. Typing a name not in the list uses that string as the value (`allow="other"` by default).
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-font-combobox';
+```
+
+```html
+<clippy-font-combobox name="font-family"></clippy-font-combobox>
+
+<script>
+  const el = document.querySelector('clippy-font-combobox');
+
+  el.options = [
+    { label: 'Inter', value: ['Inter', 'sans-serif'] },
+    { label: 'Georgia', value: ['Georgia', 'serif'] },
+    {
+      label: 'Noto Sans',
+      value: ['Noto Sans', 'sans-serif'],
+      cssUrl: 'https://fonts.googleapis.com/css2?family=Noto+Sans',
+    },
+  ];
+
+  el.addEventListener('change', () => {
+    // value is a font stack array, e.g. ['Inter', 'sans-serif']
+    console.log(el.value);
+  });
+</script>
+```
+
+## Attributes & properties
+
+Inherits all attributes from `<clippy-combobox>`. The following differ from the base:
+
+| Attribute / Property | Type         | Values               | Default |
+| -------------------- | ------------ | -------------------- | ------- |
+| `allow`              | string       | `options` \| `other` | `other` |
+| `value`              | string array | Font stack           | `null`  |
+
+## Options format
+
+Each option must have `label` (string) and `value` (string array, the CSS font stack). `description` and `cssUrl` are optional.
+
+```js
+{
+  label: 'Noto Sans',           // displayed in the list
+  value: ['Noto Sans', 'sans-serif'], // CSS font-family stack
+  description: 'Humanist sans', // optional: shown below label in list
+  cssUrl: 'https://…',          // optional: stylesheet injected when option is visible
+}
+```
+
+Typing a font name that is not in the list commits `[query]` as the value.
+
+## Form integration
+
+The value is serialized as a comma-separated string in `FormData`:
+
+```js
+const formData = new FormData(form);
+formData.get('font-family'); // 'Inter,sans-serif'
+```

--- a/packages/clippy-components/src/clippy-heading/README.md
+++ b/packages/clippy-components/src/clippy-heading/README.md
@@ -1,5 +1,31 @@
 # `<clippy-heading>`
 
-Koptekst, met NL Design System heading styles.
+Heading element that renders the correct `h1`–`h6` tag with NL Design System heading styles. The level can be set as an attribute or property and updates reactively.
 
-Gebruik `level` (standaard `1`) om het heading level (`h1`–`h6`) te kiezen.
+Based on [`@nl-design-system-candidate/heading-css`](https://www.npmjs.com/package/@nl-design-system-candidate/heading-css). See the [NL Design System heading documentation](https://nldesignsystem.nl/heading) for available design tokens and guidelines.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-heading';
+```
+
+```html
+<clippy-heading>Page title</clippy-heading>
+<clippy-heading level="2">Section title</clippy-heading>
+<clippy-heading level="3">Subsection</clippy-heading>
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type   | Values  | Default |
+| -------------------- | ------ | ------- | ------- |
+| `level`              | number | `1`–`6` | `1`     |
+
+Values outside the 1–6 range are clamped. Non-numeric values fall back to `1`.
+
+## Slots
+
+| Slot        | Description     |
+| ----------- | --------------- |
+| _(default)_ | Heading content |

--- a/packages/clippy-components/src/clippy-html-image/README.md
+++ b/packages/clippy-components/src/clippy-html-image/README.md
@@ -1,0 +1,31 @@
+# `<clippy-html-image>`
+
+Wraps arbitrary HTML content and presents it to the accessibility tree as a single image (`role="img"`). An optional `label` slot provides the accessible name. Without a label the image is unlabelled (appropriate for decorative content).
+
+Multiple instances on the same page each get an independent label association.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-html-image';
+```
+
+```html
+<!-- With an accessible label -->
+<clippy-html-image>
+  <div style="width:200px;height:100px;background:linear-gradient(to right,#f00,#00f)"></div>
+  <span slot="label">Red to blue gradient</span>
+</clippy-html-image>
+
+<!-- Decorative (no label) -->
+<clippy-html-image>
+  <div class="decorative-pattern"></div>
+</clippy-html-image>
+```
+
+## Slots
+
+| Slot        | Description                                                            |
+| ----------- | ---------------------------------------------------------------------- |
+| _(default)_ | Visual content — rendered `inert` so it is skipped by AT               |
+| `label`     | Accessible name for the image; hidden visually, read by screen readers |

--- a/packages/clippy-components/src/clippy-icon/README.md
+++ b/packages/clippy-components/src/clippy-icon/README.md
@@ -1,0 +1,40 @@
+# `<clippy-icon>`
+
+Decorative icon wrapper. Automatically sets `aria-hidden="true"` on itself so screen readers skip the icon. Size and color are controlled via CSS custom properties.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-icon';
+```
+
+```html
+<clippy-button purpose="primary">
+  <clippy-icon slot="iconStart">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">…</svg>
+  </clippy-icon>
+  Download
+</clippy-button>
+```
+
+Standalone:
+
+```html
+<clippy-icon style="--clippy-icon-size: 24px;">
+  <svg>…</svg>
+</clippy-icon>
+```
+
+## Slots
+
+| Slot        | Description |
+| ----------- | ----------- |
+| _(default)_ | SVG icon    |
+
+## CSS custom properties
+
+| Property                          | Description                      | Default |
+| --------------------------------- | -------------------------------- | ------- |
+| `--clippy-icon-size`              | Width and height of the icon     | —       |
+| `--clippy-icon-color`             | Color of the icon (sets `color`) | —       |
+| `--clippy-icon-inset-block-start` | Vertical offset from baseline    | `0`     |

--- a/packages/clippy-components/src/clippy-lang-combobox/README.md
+++ b/packages/clippy-components/src/clippy-lang-combobox/README.md
@@ -1,0 +1,58 @@
+# `<clippy-lang-combobox>`
+
+Extends [`<clippy-combobox>`](../clippy-combobox/README.md) for selecting a language. Options are language codes like `nl`, `en`, or `de`. Displays language names as autonyms (the name in that language), exonyms (the name in the UI language), or both. Filtering always checks both forms regardless of the display format.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-lang-combobox';
+```
+
+```html
+<clippy-lang-combobox name="lang" options="nl en de fr" format="autonym-exonym" lang="en"></clippy-lang-combobox>
+
+<script>
+  const el = document.querySelector('clippy-lang-combobox');
+  el.addEventListener('change', () => console.log(el.value)); // 'nl'
+</script>
+```
+
+Options can also be set as a property:
+
+```js
+el.options = ['nl', 'en', 'de', 'fr'];
+```
+
+`lang` is inferred from the closest ancestor `lang` attribute when not explicitly set.
+
+## Attributes & properties
+
+Inherits all attributes from `<clippy-combobox>`. The following are specific to this component:
+
+| Attribute / Property | Type   | Values                                                           | Default   |
+| -------------------- | ------ | ---------------------------------------------------------------- | --------- |
+| `options`            | string | Space-separated language codes (`nl en de`), or array of strings | `[]`      |
+| `format`             | string | `autonym` \| `exonym` \| `autonym-exonym` \| `exonym-autonym`    | `autonym` |
+| `lang`               | string | Language code — controls which language exonyms are rendered in  | inherited |
+
+## Format values
+
+| Value            | List shows           | Input shows      |
+| ---------------- | -------------------- | ---------------- |
+| `autonym`        | Native name          | Native name      |
+| `exonym`         | UI-language name     | UI-language name |
+| `autonym-exonym` | Native + UI-language | Native name      |
+| `exonym-autonym` | UI-language + Native | UI-language name |
+
+## Filtering
+
+Filtering always searches both the autonym and the exonym regardless of the `format` setting. Searching "Dutch" in `format="autonym"` mode still finds "nl" (Nederlands).
+
+## Events
+
+| Event    | Description                           |
+| -------- | ------------------------------------- |
+| `change` | Fired when the selected value changes |
+| `input`  | Fired on every keystroke              |
+| `focus`  | Fired when the combobox gains focus   |
+| `blur`   | Fired when the combobox loses focus   |

--- a/packages/clippy-components/src/clippy-modal/README.md
+++ b/packages/clippy-components/src/clippy-modal/README.md
@@ -1,3 +1,65 @@
 # `<clippy-modal>`
 
-Een afsluitbare modal dialog met focus trap.
+Accessible modal dialog built on the native `<dialog>` element. Includes a close button in the header, configurable footer actions, focus management (returns focus to the trigger on close), and a `close` event with a return value.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-modal';
+```
+
+```html
+<clippy-modal title="Confirm delete" actions="both" id="confirm-dialog">
+  Are you sure you want to delete this item?
+</clippy-modal>
+
+<clippy-button purpose="primary" id="open-btn">Delete</clippy-button>
+
+<script>
+  const modal = document.getElementById('confirm-dialog');
+  document.getElementById('open-btn').addEventListener('click', () => modal.open());
+  modal.addEventListener('close', () => {
+    if (modal.returnValue === 'confirm') {
+      // proceed with deletion
+    }
+  });
+</script>
+```
+
+## Attributes
+
+| Attribute          | Type    | Values                                    | Default    |
+| ------------------ | ------- | ----------------------------------------- | ---------- |
+| `title`            | string  | —                                         | `''`       |
+| `actions`          | string  | `none` \| `cancel` \| `confirm` \| `both` | `cancel`   |
+| `confirm-label`    | string  | —                                         | `'OK'`     |
+| `cancel-label`     | string  | —                                         | `'Cancel'` |
+| `standard-open`    | boolean | —                                         | `false`    |
+| `closedby`         | string  | `any` \| `closerequest` \| `none`         | `any`      |
+| `aria-describedby` | string  | ID of an element in light DOM             | `''`       |
+
+## Slots
+
+| Slot        | Description                                     |
+| ----------- | ----------------------------------------------- |
+| _(default)_ | Dialog body content                             |
+| `title`     | Overrides the `title` attribute for the heading |
+
+## Methods
+
+| Method          | Description                                         |
+| --------------- | --------------------------------------------------- |
+| `open()`        | Opens the dialog and traps focus inside it          |
+| `close(value?)` | Closes the dialog and sets `returnValue` to `value` |
+
+## Properties
+
+| Property      | Type   | Description                                                                      |
+| ------------- | ------ | -------------------------------------------------------------------------------- |
+| `returnValue` | string | The value passed to `close()` — `'confirm'` or `'cancel'` after built-in buttons |
+
+## Events
+
+| Event   | Description                                      |
+| ------- | ------------------------------------------------ |
+| `close` | Fired when the dialog closes (bubbles, composed) |

--- a/packages/clippy-components/src/clippy-react-element/README.md
+++ b/packages/clippy-components/src/clippy-react-element/README.md
@@ -1,0 +1,28 @@
+# `<clippy-react-element>`
+
+A plain web component that mounts a React element into a managed `createRoot`. Useful for embedding React components in non-React host applications and for demo purposes. Each instance has its own independent React root; removing the element from the DOM unmounts the root automatically.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-react-element';
+import { createElement } from 'react';
+import '@nl-design-system-community/clippy-components/clippy-react-element';
+
+const el = document.createElement('clippy-react-element');
+document.body.appendChild(el);
+
+// Render a React element into it
+el.render(createElement(MyComponent, { title: 'Hello' }));
+
+// Re-render with updated props
+el.render(createElement(MyComponent, { title: 'Updated' }));
+```
+
+Calling `render()` before the element is connected to the DOM is safe — the call is silently ignored.
+
+## Methods
+
+| Method                          | Description                                                      |
+| ------------------------------- | ---------------------------------------------------------------- |
+| `render(element: ReactElement)` | Renders or re-renders a React element into this component's root |

--- a/packages/clippy-components/src/clippy-reset-theme/README.md
+++ b/packages/clippy-components/src/clippy-reset-theme/README.md
@@ -1,0 +1,25 @@
+# `<clippy-reset-theme>`
+
+Resets all NL Design System CSS custom properties to their basis token values inside its shadow DOM. Use it to neutralize any inherited theme and render content at its default appearance, for example in a live preview.
+
+The reset stylesheet is a module-level singleton parsed only once and shared across all instances.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-reset-theme';
+```
+
+```html
+<clippy-reset-theme>
+  <clippy-button purpose="primary">Default theme</clippy-button>
+</clippy-reset-theme>
+```
+
+Wrapping content with `<clippy-reset-theme>` ensures that any CSS custom properties set by a parent theme do not bleed through into the slotted content.
+
+## Slots
+
+| Slot        | Description                                  |
+| ----------- | -------------------------------------------- |
+| _(default)_ | Content to render with a reset (basis) theme |

--- a/packages/clippy-components/src/clippy-story-preview/README.md
+++ b/packages/clippy-components/src/clippy-story-preview/README.md
@@ -1,0 +1,34 @@
+# `<clippy-story-preview>`
+
+A Storybook-style preview container: white background, rounded corners, subtle box shadow. Good for embedding small component demos or live theme previews.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-story-preview';
+```
+
+```html
+<clippy-story-preview>
+  <clippy-button purpose="primary">Click me</clippy-button>
+</clippy-story-preview>
+
+<!-- Larger canvas -->
+<clippy-story-preview size="lg">
+  <clippy-color-sample color="#e63946"></clippy-color-sample>
+</clippy-story-preview>
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type   | Values | Default |
+| -------------------- | ------ | ------ | ------- |
+| `size`               | string | `lg`   | —       |
+
+The `size` attribute is reflected back to the element. Setting it to anything other than `lg` produces no modifier class.
+
+## Slots
+
+| Slot        | Description     |
+| ----------- | --------------- |
+| _(default)_ | Preview content |

--- a/packages/clippy-components/src/clippy-toggletip/README.md
+++ b/packages/clippy-components/src/clippy-toggletip/README.md
@@ -1,30 +1,46 @@
-# clippy-toggletip
+# `<clippy-toggletip>`
 
-A wrapper component that shows a stylable popup tooltip (Semantic UI-like) for a slotted focusable element, like `<clippy-button>` or `<button>` or `<a>`.
+Shows a tooltip popup above (or beside) the slotted trigger element on hover or focus. The popup has `role="tooltip"` and is shown purely via CSS `:hover`/`:focus-within`.
 
 ## Usage
 
+```js
+import '@nl-design-system-community/clippy-components/clippy-toggletip';
+```
+
 ```html
-<clippy-toggletip text="Copy value to clipboard" position="block-start">
-  <clippy-button purpose="subtle">Copy value</clippy-button>
+<clippy-toggletip text="Copy to clipboard" position="block-start">
+  <clippy-button purpose="subtle">Copy</clippy-button>
 </clippy-toggletip>
 ```
 
 ## Attributes
 
-- `text`: Fallback tooltip text when the default slot is empty.
-- `position`: `block-start` | `inline-end` | `block-end` | `inline-start` (default: `block-start`).
+| Attribute  | Type   | Values                                                         | Default       |
+| ---------- | ------ | -------------------------------------------------------------- | ------------- |
+| `text`     | string | Tooltip text                                                   | `''`          |
+| `position` | string | `block-start` \| `block-end` \| `inline-start` \| `inline-end` | `block-start` |
 
-## CSS Custom Properties
+An invalid `position` value logs a console warning and falls back to `block-start`.
 
-- `--clippy-toggletip-background-color`
-- `--clippy-toggletip-border-radius`
-- `--clippy-toggletip-color`
-- `--clippy-toggletip-font-size`
-- `--clippy-toggletip-line-height`
-- `--clippy-toggletip-max-inline-size`
-- `--clippy-toggletip-padding-block`
-- `--clippy-toggletip-padding-inline`
-- `--clippy-toggletip-arrow-size`
-- `--clippy-toggletip-offset`
-- `--clippy-toggletip-z-index`
+## Slots
+
+| Slot        | Description                                    |
+| ----------- | ---------------------------------------------- |
+| _(default)_ | The trigger element (button, link, or similar) |
+
+## CSS custom properties
+
+| Property                              | Description                   | Default                                       |
+| ------------------------------------- | ----------------------------- | --------------------------------------------- |
+| `--clippy-toggletip-background-color` | Tooltip background            | `--basis-color-default-inverse-bg-document`   |
+| `--clippy-toggletip-color`            | Tooltip text color            | `--basis-color-default-inverse-color-default` |
+| `--clippy-toggletip-font-size`        | Tooltip font size             | `--basis-text-font-size-sm`                   |
+| `--clippy-toggletip-line-height`      | Tooltip line height           | `--basis-text-line-height-sm`                 |
+| `--clippy-toggletip-border-radius`    | Tooltip corner radius         | `--basis-border-radius-sm`                    |
+| `--clippy-toggletip-padding-block`    | Block (vertical) padding      | `--basis-space-block-sm`                      |
+| `--clippy-toggletip-padding-inline`   | Inline (horizontal) padding   | `--basis-space-inline-md`                     |
+| `--clippy-toggletip-max-inline-size`  | Maximum tooltip width         | `18rem`                                       |
+| `--clippy-toggletip-arrow-size`       | Arrow size                    | `0.5rem`                                      |
+| `--clippy-toggletip-offset`           | Gap between trigger and popup | `--clippy-toggletip-arrow-size`               |
+| `--clippy-toggletip-z-index`          | Stacking order                | `10`                                          |


### PR DESCRIPTION
- add readme to root of clippy-components
  - `import` example
  - quick code example
  - links to all individual components
- add readmes to every individual clippy component
  - `import` example
  - link to nldesignsystem.nl and `*-css` package if component is based on candidate component
  - usage example
  - slots table
  - props table
  - events table

NB: used an LLM to generate the docs to speed up the process. Instructed it to use the test files as source for the docs. Manually reviewed them all and seems consistent with what I know.


## before

<img width="339" height="117" alt="Screenshot 2026-04-28 at 15 29 44" src="https://github.com/user-attachments/assets/c24f80ca-2e9f-41d5-9d19-aeb867cd1079" />

## after

<img width="965" height="1217" alt="Screenshot 2026-04-28 at 15 29 16" src="https://github.com/user-attachments/assets/feeac4a0-d4b0-4ee1-b855-8e92bd7751fb" />
