### PR TITLE
chore: skip changeset for private packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "privatePackages": false
 }


### PR DESCRIPTION
Since private packages are not published to npm, we don't need to run changeset for them.  By not showing them in the changeset list we avoid accidental changesets.