### PR TITLE
chore: performance quick wins voor thema validaties

### DIFF
--- a/packages/design-tokens-schema/src/theme.ts
+++ b/packages/design-tokens-schema/src/theme.ts
@@ -331,7 +331,7 @@ export const StrictThemeSchema = z
         const contrast = compareContrast(baseColor, compareColor);
         const tokenAPath = path.join('.');
         const tokenBPathRaw = background.$extensions?.[EXTENSION_RESOLVED_FROM] as string | undefined;
-        const tokenBPath = tokenBPathRaw?.replaceAll(/(^\{)|(\}$)/g, '');
+        const tokenBPath = tokenBPathRaw ? extractRef(tokenBPathRaw as TokenReference) : undefined;
 
         if (contrast < expectedRatio) {
           ctx.addIssue(

--- a/packages/design-tokens-schema/src/theme.ts
+++ b/packages/design-tokens-schema/src/theme.ts
@@ -92,18 +92,16 @@ const ALL_LINE_HEIGHT_FONT_SIZE_PAIRS = addComponentFontSizeLineHeightPairs(
   ]),
 );
 
+const COLOR_KEY_POSITION = new Map<string, number>(COLOR_KEYS.map((key, i) => [key, i + 1]));
+
 export const addBasisColorScalePositionExtensions = (rootConfig: Record<string, unknown>) => {
   walkColors(rootConfig, (color, path) => {
     const lastPath = path.at(-1)!;
 
-    // Find if the token name ends with any COLOR_KEYS value
-    const matchingColorKeyIndex = COLOR_KEYS.findIndex((colorKey) => lastPath.endsWith(colorKey));
+    const position = COLOR_KEY_POSITION.get(lastPath);
+    if (position === undefined) return undefined;
 
-    // If no match found, skip this token
-    if (matchingColorKeyIndex === -1) return undefined;
-
-    // Add the extension with the index
-    setExtension(color, EXTENSION_COLOR_SCALE_POSITION, matchingColorKeyIndex + 1);
+    setExtension(color, EXTENSION_COLOR_SCALE_POSITION, position);
     return SKIP;
   });
   return rootConfig;

--- a/packages/design-tokens-schema/src/theme.ts
+++ b/packages/design-tokens-schema/src/theme.ts
@@ -50,16 +50,6 @@ export const resolveConfigRefs = (rootConfig: Theme) => {
   return rootConfig;
 };
 
-const KNOWN_LINE_HEIGHT_FONT_SIZE_COMBOS = new Map<string, string>([
-  ['basis.text.font-size.sm', 'basis.text.line-height.sm'],
-  ['basis.text.font-size.md', 'basis.text.line-height.md'],
-  ['basis.text.font-size.lg', 'basis.text.line-height.lg'],
-  ['basis.text.font-size.xl', 'basis.text.line-height.xl'],
-  ['basis.text.font-size.2xl', 'basis.text.line-height.2xl'],
-  ['basis.text.font-size.3xl', 'basis.text.line-height.3xl'],
-  ['basis.text.font-size.4xl', 'basis.text.line-height.4xl'],
-]);
-
 export const addComponentFontSizeLineHeightPairs = (initialMap: Map<string, string>) => {
   const result = new Map(initialMap);
   const componentsTokens = [
@@ -89,6 +79,18 @@ export const addComponentFontSizeLineHeightPairs = (initialMap: Map<string, stri
   }
   return result;
 };
+
+const ALL_LINE_HEIGHT_FONT_SIZE_PAIRS = addComponentFontSizeLineHeightPairs(
+  new Map([
+    ['basis.text.font-size.sm', 'basis.text.line-height.sm'],
+    ['basis.text.font-size.md', 'basis.text.line-height.md'],
+    ['basis.text.font-size.lg', 'basis.text.line-height.lg'],
+    ['basis.text.font-size.xl', 'basis.text.line-height.xl'],
+    ['basis.text.font-size.2xl', 'basis.text.line-height.2xl'],
+    ['basis.text.font-size.3xl', 'basis.text.line-height.3xl'],
+    ['basis.text.font-size.4xl', 'basis.text.line-height.4xl'],
+  ]),
+);
 
 export const addBasisColorScalePositionExtensions = (rootConfig: Record<string, unknown>) => {
   walkColors(rootConfig, (color, path) => {
@@ -404,8 +406,7 @@ export const StrictThemeSchema = z
     });
 
     // Validation 5: check that contextual line-heights are large enough
-    const knownLineHeightFontSizePairs = addComponentFontSizeLineHeightPairs(KNOWN_LINE_HEIGHT_FONT_SIZE_COMBOS);
-    for (const [fontSizePath, lineHeightPath] of knownLineHeightFontSizePairs) {
+    for (const [fontSizePath, lineHeightPath] of ALL_LINE_HEIGHT_FONT_SIZE_PAIRS) {
       const fontSizeToken = dlv(root, fontSizePath);
       const lineHeightToken = dlv(root, lineHeightPath);
 


### PR DESCRIPTION
- dont re-compute known line-height/font-size combox on every parse
- make color-position O(1) lookup instead of O(n)
- replace Regex in loop with .slice()