### PR TITLE
fix(clippy-storybook): combobox stories pass correct options

### DIFF
--- a/packages/clippy-storybook/src/web-components/clippy-color-combobox.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-color-combobox.stories.tsx
@@ -105,7 +105,7 @@ const meta = {
   render: ({ lang, options }: ColorComboboxStoryArgs) =>
     React.createElement('clippy-color-combobox', {
       lang,
-      options: JSON.stringify(options, null, 2),
+      options,
     }),
   tags: ['autodocs'],
   title: 'Clippy/Combobox/Color Combobox',

--- a/packages/clippy-storybook/src/web-components/clippy-combobox.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-combobox.stories.tsx
@@ -40,7 +40,7 @@ const meta = {
   },
   render: ({ options }: ComboboxStoryArgs) =>
     React.createElement('clippy-combobox', {
-      options: JSON.stringify(options, null, 2),
+      options,
     }),
   tags: ['autodocs'],
   title: 'Clippy/Combobox',

--- a/packages/clippy-storybook/src/web-components/clippy-lang-combobox.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-lang-combobox.stories.tsx
@@ -83,7 +83,7 @@ const meta = {
     React.createElement('clippy-lang-combobox', {
       format,
       lang,
-      options: JSON.stringify(options, null, 2),
+      options,
     }),
   tags: ['autodocs'],
   title: 'Clippy/Combobox/Language Combobox',


### PR DESCRIPTION
Our comboboxes [expect an array of options](https://github.com/nl-design-system/theme-wizard/blob/main/packages/clippy-components/src/clippy-combobox/index.ts#L56) but receive [JSON.stringified options](https://github.com/nl-design-system/theme-wizard/blob/main/packages/clippy-storybook/src/web-components/clippy-combobox.stories.tsx#L43). 

This results in errors in those stories: https://clippy-storybook-8jhxj3buy-nl-design-system.vercel.app/?path=/story/clippy-combobox--default

This PR fixes that issue. 
