### PR TITLE
chore: simplify fetch timeout error handling

### DIFF
--- a/packages/css-scraper/src/errors.ts
+++ b/packages/css-scraper/src/errors.ts
@@ -4,7 +4,7 @@ export type UrlLike = URL | string;
 
 export class ScrapingError extends Error {
   // @ts-expect-error This is a private, unused field
-  private url: UrlLike;
+  private readonly url: UrlLike;
 
   constructor(message: string, url: UrlLike) {
     super(message);

--- a/packages/css-scraper/src/get-css.test.ts
+++ b/packages/css-scraper/src/get-css.test.ts
@@ -247,7 +247,7 @@ describe('getCssResources', () => {
     });
 
     it('TimeoutError', async () => {
-      (fetch as Mock).mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
+      (fetch as Mock).mockRejectedValueOnce(new DOMException('signal timed out', 'TimeoutError'));
       await expect(getCssResources('http://example.com/style.css', { timeout: 0 })).rejects.toThrowError(TimeoutError);
     });
   });
@@ -291,7 +291,7 @@ describe('getCss', () => {
   });
 
   it('custom timeout with TimeoutError', async () => {
-    (fetch as Mock).mockRejectedValueOnce(new DOMException('Aborted', 'AbortError'));
+    (fetch as Mock).mockRejectedValueOnce(new DOMException('signal timed out', 'TimeoutError'));
     await expect(getCss('http://example.com/style.css', { timeout: 0 })).rejects.toThrowError(TimeoutError);
   });
 

--- a/packages/css-scraper/src/get-css.ts
+++ b/packages/css-scraper/src/get-css.ts
@@ -54,7 +54,7 @@ export const getImportUrls = (css: string): string[] => {
 const handleFetchError = (error: unknown | Error, url: UrlLike, timeout: number) => {
   // TODO: pass error cause
   if (error instanceof Error) {
-    if (error.name === 'AbortError') {
+    if (error.name === 'TimeoutError') {
       throw new TimeoutError(url, timeout);
     }
 
@@ -240,16 +240,13 @@ export const getCssResources = async (
     throw new InvalidUrlError(url);
   }
 
-  // Setup a timeout and abortcontroller so we can stop in-flight fetch requests when we've crossed the timeout limit
-  const abortController = new AbortController();
-  const timeoutId = setTimeout(() => abortController.abort(), timeout);
+  const signal = AbortSignal.timeout(timeout);
 
   try {
-    const response = await fetchHtml(resolvedUrl, abortController.signal, userAgent);
+    const response = await fetchHtml(resolvedUrl, signal, userAgent);
     let body = response.body;
 
     if (response.contentType?.includes('text/css')) {
-      clearTimeout(timeoutId);
       return [
         {
           css: body,
@@ -264,12 +261,8 @@ export const getCssResources = async (
     }
 
     const resources = getCssFromHtml(body, resolvedUrl);
-    const result = processResources(resources, abortController.signal, userAgent);
-
-    clearTimeout(timeoutId);
-    return result;
+    return processResources(resources, signal, userAgent);
   } catch (error: unknown) {
-    clearTimeout(timeoutId);
     handleFetchError(error, resolvedUrl, timeout);
     return [];
   }


### PR DESCRIPTION
Replaces homebrew timeout solution with a Web Standards based solution: `AbortController.timeout()`. This reduces risk of me lingering stray timeouts. Support for `AbortController.timeout()` is NodeJS 17.0+