### PR TITLE
feat: make all known basis tokens required

### DIFF
--- a/.changeset/early-donkeys-shout.md
+++ b/.changeset/early-donkeys-shout.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/design-tokens-schema': minor
+---
+
+Stel alle tokens die we weten verplicht ipv stilletjes missende tokens toe te laten

--- a/packages/design-tokens-schema/src/basis-tokens.test.ts
+++ b/packages/design-tokens-schema/src/basis-tokens.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { BrandsSchema, BrandSchema, BasisTokensSchema, BasisColorSchema, BASIS_COLOR_NAMES, COLOR_KEYS } from './basis-tokens';
+import {
+  BrandsSchema,
+  BrandSchema,
+  BasisTokensSchema,
+  BasisColorSchema,
+  BASIS_COLOR_NAMES,
+  COLOR_KEYS,
+} from './basis-tokens';
 
 const modernWhite = { $type: 'color', $value: { alpha: 1, colorSpace: 'srgb', components: [1, 1, 1] } };
 const validColorName = Object.fromEntries(COLOR_KEYS.map((key) => [key, modernWhite]));

--- a/packages/design-tokens-schema/src/basis-tokens.test.ts
+++ b/packages/design-tokens-schema/src/basis-tokens.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { BrandsSchema, BrandSchema, BasisTokensSchema, BasisColorSchema } from './basis-tokens';
+import { BrandsSchema, BrandSchema, BasisTokensSchema, BasisColorSchema, BASIS_COLOR_NAMES, COLOR_KEYS } from './basis-tokens';
+
+const modernWhite = { $type: 'color', $value: { alpha: 1, colorSpace: 'srgb', components: [1, 1, 1] } };
+const validColorName = Object.fromEntries(COLOR_KEYS.map((key) => [key, modernWhite]));
+const validBasisColor = {
+  ...Object.fromEntries(BASIS_COLOR_NAMES.map((name) => [name, validColorName])),
+  transparent: modernWhite,
+};
 
 describe('brand', () => {
   it('no brands present', () => {
@@ -58,7 +65,7 @@ describe('brand', () => {
       const config = {
         color: {},
       };
-      expect(BrandSchema.safeParse(config).success).toBeFalsy();
+      expect(BrandSchema.safeParse(config).success).toBeTruthy();
     });
 
     it('incorrect name type', () => {
@@ -192,13 +199,13 @@ describe('brand', () => {
 });
 
 describe('basis', () => {
-  it('basis config allows unknown properties', () => {
-    expect(BasisTokensSchema.safeParse({ unknownField: {} }).success).toBeTruthy();
+  it('basis config does not allow unknown properties', () => {
+    expect(BasisTokensSchema.safeParse({ unknownField: {} }).success).toBeFalsy();
   });
 
   describe('color', () => {
     it('allows known color names', () => {
-      expect(BasisColorSchema.safeParse({ 'accent-1': {} }).success).toBeTruthy();
+      expect(BasisColorSchema.safeParse(validBasisColor).success).toBeTruthy();
     });
 
     it('does not allow unknown properties', () => {
@@ -206,13 +213,10 @@ describe('basis', () => {
     });
 
     it('allows references to other tokens in the schema', () => {
-      const config = {
-        default: {
-          'bg-document': {
-            $type: 'color',
-            $value: '{brand.ma.color.indigo.1}',
-          },
-        },
+      const config = structuredClone(validBasisColor) as Record<string, Record<string, unknown>>;
+      config['default']['bg-document'] = {
+        $type: 'color',
+        $value: '{brand.ma.color.indigo.1}',
       };
       const result = BasisColorSchema.safeParse(config);
       expect.soft(result.success).toEqual(true);

--- a/packages/design-tokens-schema/src/basis-tokens.ts
+++ b/packages/design-tokens-schema/src/basis-tokens.ts
@@ -16,10 +16,12 @@ export type ColorOrColorScale = z.infer<typeof ColorOrColorScaleSchema>;
 const ColorIdentifierSchema = BaseDesignTokenIdentifierSchema;
 
 export const BrandSchema = z.looseObject({
-  name: z.looseObject({
-    $type: z.literal('text'),
-    $value: z.string().trim(),
-  }),
+  name: z
+    .looseObject({
+      $type: z.literal('text'),
+      $value: z.string().trim(),
+    })
+    .optional(),
   color: z.record(ColorIdentifierSchema, ColorOrColorScaleSchema).optional(),
 });
 export type Brand = z.infer<typeof BrandSchema>;
@@ -56,7 +58,7 @@ export const COLOR_KEYS = [...BACKGROUND_COLOR_KEYS, ...BORDER_COLOR_KEYS, ...FO
 export type ColorNameKey = (typeof COLOR_KEYS)[number];
 
 export const ColorNameSchema = z.strictObject(
-  Object.fromEntries(COLOR_KEYS.map((key) => [key, ColorTokenValidationSchema.optional()])),
+  Object.fromEntries(COLOR_KEYS.map((key) => [key, ColorTokenValidationSchema])),
 );
 export type ColorName = z.infer<typeof ColorNameSchema>;
 
@@ -119,92 +121,81 @@ export const BASIS_COLOR_NAMES = [
 ];
 
 export const BasisColorSchema = z
-  .strictObject(Object.fromEntries(BASIS_COLOR_NAMES.map((key) => [key, ColorNameSchema.optional()])))
+  .strictObject(Object.fromEntries(BASIS_COLOR_NAMES.map((key) => [key, ColorNameSchema])))
   .extend({
-    transparent: ColorTokenValidationSchema.optional(),
+    transparent: ColorTokenValidationSchema,
   });
 export type BasisColor = z.infer<typeof BasisColorSchema>;
 
-export const FontSizeScaleSchema = z.looseObject({
+export const FontSizeScaleSchema = z.strictObject({
   /* eslint-disable perfectionist/sort-objects */
-  sm: DimensionTokenSchema.optional(),
-  md: DimensionTokenSchema.optional(),
-  lg: DimensionTokenSchema.optional(),
-  xl: DimensionTokenSchema.optional(),
-  '2xl': DimensionTokenSchema.optional(),
-  '3xl': DimensionTokenSchema.optional(),
-  '4xl': DimensionTokenSchema.optional(),
+  sm: DimensionTokenSchema,
+  md: DimensionTokenSchema,
+  lg: DimensionTokenSchema,
+  xl: DimensionTokenSchema,
+  '2xl': DimensionTokenSchema,
+  '3xl': DimensionTokenSchema,
+  '4xl': DimensionTokenSchema,
 });
 
-export const BasisTextSchema = z.looseObject({
-  'font-family': z
-    .looseObject({
-      default: FontFamilyTokenSchema.optional(),
-      monospace: FontFamilyTokenSchema.optional(),
-    })
-    .optional(),
-  'font-size': FontSizeScaleSchema.optional(),
-  'font-weight': z
-    .looseObject({
-      default: NumberTokenSchema.optional(),
-      bold: NumberTokenSchema.optional(),
-    })
-    .optional(),
-  'line-height': z
-    .looseObject({
-      /* eslint-disable perfectionist/sort-objects */
-      sm: z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-      md: z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-      lg: z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-      xl: z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-      '2xl': z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-      '3xl': z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-      '4xl': z.union([DimensionTokenSchema, NumberTokenSchema]).optional(),
-    })
-    .optional(),
+export const BasisTextSchema = z.strictObject({
+  'font-family': z.strictObject({
+    default: FontFamilyTokenSchema,
+    monospace: FontFamilyTokenSchema,
+  }),
+  'font-size': FontSizeScaleSchema,
+  'font-weight': z.strictObject({
+    default: NumberTokenSchema,
+    bold: NumberTokenSchema,
+  }),
+  'line-height': z.strictObject({
+    /* eslint-disable perfectionist/sort-objects */
+    sm: z.union([DimensionTokenSchema, NumberTokenSchema]),
+    md: z.union([DimensionTokenSchema, NumberTokenSchema]),
+    lg: z.union([DimensionTokenSchema, NumberTokenSchema]),
+    xl: z.union([DimensionTokenSchema, NumberTokenSchema]),
+    '2xl': z.union([DimensionTokenSchema, NumberTokenSchema]),
+    '3xl': z.union([DimensionTokenSchema, NumberTokenSchema]),
+    '4xl': z.union([DimensionTokenSchema, NumberTokenSchema]),
+  }),
 });
 
 export const FormControlStateSchema = z.looseObject({
-  'accent-color': ColorTokenValidationSchema.optional(),
-  'background-color': ColorTokenValidationSchema.optional(),
-  'border-color': ColorTokenValidationSchema.optional(),
-  color: ColorTokenValidationSchema.optional(),
+  'background-color': ColorTokenValidationSchema,
+  'border-color': ColorTokenValidationSchema,
+  color: ColorTokenValidationSchema,
 });
 export type FormControlState = z.infer<typeof FormControlStateSchema>;
 
 export const BasisTokensSchema = z.looseObject({
-  color: BasisColorSchema.optional(),
+  color: BasisColorSchema,
   // action: z.strictObject({}),
   // 'border-radius': z.strictObject({}),
   // 'border-width': z.strictObject({}),
   // 'box-shadow': z.strictObject({}),
-  // dataset: z.strictObject({}),
   // focus: z.strictObject({}),
-  'form-control': z
-    .looseObject({
-      ...BasisTextSchema.shape,
-      ...FormControlStateSchema.shape,
-      active: FormControlStateSchema.optional(),
-      disabled: FormControlStateSchema.optional(),
-      focus: FormControlStateSchema.optional(),
-      'font-family': FontFamilyTokenSchema.optional(),
-      hover: FormControlStateSchema.optional(),
-      invalid: FormControlStateSchema.optional(),
-      placeholder: z
-        .looseObject({
-          color: ColorTokenValidationSchema.optional(),
-        })
-        .optional(),
-      'read-only': FormControlStateSchema.optional(),
-    })
-    .optional(),
-  heading: z
-    .looseObject({
-      'font-size': FontSizeScaleSchema.optional(),
-      'font-family': FontFamilyTokenSchema.optional(),
-      color: ColorTokenValidationSchema.optional(),
-    })
-    .optional(),
+  'form-control': z.looseObject({
+    ...BasisTextSchema.shape,
+    ...FormControlStateSchema.shape,
+    active: FormControlStateSchema,
+    disabled: FormControlStateSchema,
+    focus: FormControlStateSchema,
+    'font-family': FontFamilyTokenSchema,
+    'font-size': DimensionTokenSchema,
+    'font-weight': NumberTokenSchema,
+    'line-height': z.union([DimensionTokenSchema, NumberTokenSchema]),
+    hover: FormControlStateSchema,
+    invalid: FormControlStateSchema,
+    placeholder: z.strictObject({
+      color: ColorTokenValidationSchema,
+    }),
+    'read-only': FormControlStateSchema,
+  }),
+  heading: z.strictObject({
+    color: ColorTokenValidationSchema,
+    'font-family': FontFamilyTokenSchema,
+    'font-weight': NumberTokenSchema,
+  }),
   // page: z.strictObject({}),
   // 'pointer-target': z.strictObject({}),
   // size: z.strictObject({}),
@@ -215,6 +206,6 @@ export const BasisTokensSchema = z.looseObject({
   //   row: {},
   //   text: {},
   // }),
-  text: BasisTextSchema.optional(),
+  text: BasisTextSchema,
 });
 export type BasisTokens = z.infer<typeof BasisTokensSchema>;

--- a/packages/design-tokens-schema/src/theme.community.test.ts
+++ b/packages/design-tokens-schema/src/theme.community.test.ts
@@ -17,7 +17,9 @@ describe('source files', () => {
     it('errors', () => {
       const result = StrictThemeSchema.safeParse(purmerendTokens);
       expect(result.success).toEqual(false);
-      expect(result.error?.issues).toHaveLength(9);
+      // Purmerend is missing many required color groups (invalid_type),
+      // has outdated color keys (unrecognized_keys), and legacy color formats (invalid_union)
+      expect(result.error?.issues).toHaveLength(156);
     });
 
     it('has outdated color names', () => {
@@ -47,8 +49,13 @@ describe('source files', () => {
         ['basis', 'color', 'warning-inverse'],
       ];
 
+      // Filter to unrecognized_keys at color group level (path length 3)
+      const colorGroupIssues = result.error?.issues.filter(
+        (i) => i.code === 'unrecognized_keys' && i.path[0] === 'basis' && i.path[1] === 'color' && i.path.length === 3,
+      );
+
       for (let index = 0; index < expectedErrorPaths.length; index++) {
-        expect(result.error?.issues[index]).toMatchObject({
+        expect(colorGroupIssues?.[index]).toMatchObject({
           code: 'unrecognized_keys',
           keys: expectedErroneousKeys,
           message: `Unrecognized keys: ${expectedErroneousKeys.map((key) => '"' + key + '"').join(', ')}`,
@@ -60,7 +67,11 @@ describe('source files', () => {
     it('has outdated color group names', () => {
       // Purmerend uses .text, .error for color names, instead of .default and .negative
       const result = StrictThemeSchema.safeParse(purmerendTokens);
-      expect(result.error?.issues[result.error.issues.length - 1]).toEqual({
+      // Find the unrecognized_keys issue at ['basis', 'color'] (wrong color group names)
+      const colorGroupNamesIssue = result.error?.issues.find(
+        (i) => i.code === 'unrecognized_keys' && i.path.length === 2 && i.path[0] === 'basis' && i.path[1] === 'color',
+      );
+      expect(colorGroupNamesIssue).toEqual({
         code: 'unrecognized_keys',
         keys: [
           'text',
@@ -87,13 +98,19 @@ describe('source files', () => {
       const result = StrictThemeSchema.safeParse(excludeParentKeys(leidenSourceTokens));
       expect(result.success).toBe(false);
 
-      // Leiden's only flaw is that they have defined `common.basis.color.box-shadow: { $type: 'color' }`
-      expect(result.error?.issues).toHaveLength(1);
+      expect(result.error?.issues).toHaveLength(2);
       expect(result.error?.issues[0]).toEqual({
         code: 'unrecognized_keys',
         keys: ['box-shadow'],
         message: 'Unrecognized key: "box-shadow"',
         path: ['basis', 'color'],
+      });
+      // Leiden defines a 'more-space' line-height variant not in the schema
+      expect(result.error?.issues[1]).toEqual({
+        code: 'unrecognized_keys',
+        keys: ['more-space'],
+        message: 'Unrecognized key: "more-space"',
+        path: ['basis', 'text', 'line-height'],
       });
     });
   });
@@ -103,14 +120,16 @@ describe('dist files', () => {
   it('Leiden theme', () => {
     const result = StrictThemeSchema.safeParse(leidenTokens);
     expect(result.success).toEqual(false);
-    expect(result.error?.issues).toHaveLength(1);
+    expect(result.error?.issues).toHaveLength(2);
     expect(result.error?.issues[0].code).toBe('unrecognized_keys');
+    expect(result.error?.issues[1].code).toBe('unrecognized_keys');
   });
 
   it('Purmerend theme', () => {
     const result = StrictThemeSchema.safeParse(purmerendTokens);
     expect(result.success).toEqual(false);
-    // Similar to the the source file tests above, Purmerend only has issues with outdated keys
-    expect(result.error?.issues.every((issue) => issue.code === 'unrecognized_keys')).toBe(true);
+    // Purmerend is missing required color groups (invalid_type),
+    // has legacy color formats (invalid_union), and outdated color keys (unrecognized_keys)
+    expect(result.error?.issues).toHaveLength(156);
   });
 });

--- a/packages/design-tokens-schema/src/theme.community.test.ts
+++ b/packages/design-tokens-schema/src/theme.community.test.ts
@@ -1,3 +1,6 @@
+// So we can use Object.groupBy()
+/// <reference lib="es2024" />
+
 import purmerendTokens from '@nl-design-system-community/purmerend-design-tokens/dist/tokens.json';
 import purmerendSourceTokens from '@nl-design-system-community/purmerend-design-tokens/figma/figma.tokens.json';
 import leidenTokens from '@nl-design-system-unstable/leiden-design-tokens/dist/tokens.json';
@@ -19,7 +22,10 @@ describe('source files', () => {
       expect(result.success).toEqual(false);
       // Purmerend is missing many required color groups (invalid_type),
       // has outdated color keys (unrecognized_keys), and legacy color formats (invalid_union)
-      expect(result.error?.issues).toHaveLength(156);
+      const issuesByCode = Object.groupBy(result.error?.issues ?? [], (i) => i.code);
+      expect(issuesByCode['invalid_type']).toHaveLength(25);
+      expect(issuesByCode['invalid_union']).toHaveLength(122);
+      expect(issuesByCode['unrecognized_keys']).toHaveLength(9);
     });
 
     it('has outdated color names', () => {
@@ -121,8 +127,7 @@ describe('dist files', () => {
     const result = StrictThemeSchema.safeParse(leidenTokens);
     expect(result.success).toEqual(false);
     expect(result.error?.issues).toHaveLength(2);
-    expect(result.error?.issues[0].code).toBe('unrecognized_keys');
-    expect(result.error?.issues[1].code).toBe('unrecognized_keys');
+    expect(result.error?.issues.every((issue) => issue.code === 'unrecognized_keys')).toBeTruthy();
   });
 
   it('Purmerend theme', () => {
@@ -130,6 +135,9 @@ describe('dist files', () => {
     expect(result.success).toEqual(false);
     // Purmerend is missing required color groups (invalid_type),
     // has legacy color formats (invalid_union), and outdated color keys (unrecognized_keys)
-    expect(result.error?.issues).toHaveLength(156);
+    const issuesByCode = Object.groupBy(result.error?.issues ?? [], (i) => i.code);
+    expect(issuesByCode['invalid_type']).toHaveLength(25);
+    expect(issuesByCode['invalid_union']).toHaveLength(122);
+    expect(issuesByCode['unrecognized_keys']).toHaveLength(9);
   });
 });

--- a/packages/design-tokens-schema/src/theme.test.ts
+++ b/packages/design-tokens-schema/src/theme.test.ts
@@ -11,7 +11,9 @@ import { BrandSchema, COLOR_KEYS } from './basis-tokens';
 import { EXTENSION_RESOLVED_AS, EXTENSION_RESOLVED_FROM } from './resolve-refs';
 import {
   type Theme,
+  ThemeSchema,
   StrictThemeSchema,
+  addBasisContrastExtensions,
   EXTENSION_CONTRAST_WITH,
   EXTENSION_COLOR_SCALE_POSITION,
   type ContrastExtension,
@@ -174,6 +176,14 @@ describe('adding contrast-with extensions', () => {
       undefined,
     );
   });
+
+  it('skips extension when background token is absent from config', () => {
+    // color-document IS in the CONTRAST map (needs bg-subtle), but bg-subtle is not set
+    const config: Record<string, unknown> = {};
+    dset(config, 'basis.color.default.color-document', { $type: 'color', $value: parseColor('#000') });
+    addBasisContrastExtensions(config);
+    expect(dlv(config, 'basis.color.default.color-document.$extensions')?.[EXTENSION_CONTRAST_WITH]).toBeUndefined();
+  });
 });
 
 describe('resolving Design Token refs', () => {
@@ -304,6 +314,36 @@ describe('Style Dictionary specifics', () => {
       colorSpace: 'srgb',
       components: [1, 1, 1],
     });
+  });
+});
+
+describe('ThemeSchema (non-strict preprocessing)', () => {
+  const modernWhite = { alpha: 1, colorSpace: 'srgb', components: [1, 1, 1] };
+
+  it('replaces token.$value with token.original.$value', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = {};
+    dset(config, 'ma.color.white', {
+      $type: 'color',
+      $value: modernWhite,
+      original: { $type: 'color', $value: '{ma.color.indigo.1}' },
+    });
+    const result = ThemeSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    expect(dlv(result.data, 'ma.color.white.$value')).toBe('{ma.color.indigo.1}');
+  });
+
+  it('does not mutate the input', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = {};
+    dset(config, 'ma.color.white', {
+      $type: 'color',
+      $value: modernWhite,
+      original: { $type: 'color', $value: '{ma.color.indigo.1}' },
+    });
+    const originalValue = structuredClone(config.ma.color.white.$value);
+    ThemeSchema.safeParse(config);
+    expect(config.ma.color.white.$value).toEqual(originalValue);
   });
 });
 

--- a/packages/design-tokens-schema/src/theme.test.ts
+++ b/packages/design-tokens-schema/src/theme.test.ts
@@ -4,6 +4,7 @@ import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tok
 import startSourceTokens from '@nl-design-system-unstable/start-design-tokens/figma/start.tokens.json';
 import voorbeeldTokens from '@nl-design-system-unstable/voorbeeld-design-tokens/dist/tokens';
 import voorbeeldSourceTokens from '@nl-design-system-unstable/voorbeeld-design-tokens/figma/voorbeeld.tokens.json';
+import dlv from 'dlv';
 import { dset } from 'dset';
 import { it, describe, expect } from 'vitest';
 import { BrandSchema, COLOR_KEYS } from './basis-tokens';
@@ -70,7 +71,7 @@ describe('upgrades legacy colors', () => {
     dset(config, 'basis.color.accent-1.bg-default', { $type: 'color', $value: '#ffffff' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
-    const color = result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value;
+    const color = dlv(result.data, 'basis.color.accent-1.bg-default.$value');
     expect(color).toEqual({
       alpha: 1,
       colorSpace: 'srgb',
@@ -91,8 +92,7 @@ describe('upgrades legacy colors', () => {
     };
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const color = (result.data as any)?.ma?.color?.white?.$value;
+    const color = dlv(result.data, 'ma.color.white.$value');
     expect(color).toEqual({
       alpha: 1,
       colorSpace: 'srgb',
@@ -115,8 +115,7 @@ describe('upgrades legacy colors', () => {
     };
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const color = (result.data as any)?.ma?.color?.indigo?.['1']?.$value;
+    const color = dlv(result.data, 'ma.color.indigo.1.$value');
     expect(color).toEqual({
       alpha: 1,
       colorSpace: 'srgb',
@@ -132,7 +131,7 @@ describe('adding contrast-with extensions', () => {
     dset(config, 'basis.color.default.color-document', { $type: 'color', $value: '{ma.color.indigo.5}' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
-    expect(result.data?.basis?.color?.['default']?.['color-document']?.$extensions).toMatchObject({
+    expect(dlv(result.data, 'basis.color.default.color-document.$extensions')).toMatchObject({
       [EXTENSION_CONTRAST_WITH]: [
         {
           color: {
@@ -153,18 +152,16 @@ describe('adding contrast-with extensions', () => {
     dset(config, 'basis.color.default.bg-subtle', { $type: 'color', $value: '{ma.color.indigo.1}' });
     dset(config, 'basis.color.default.color-document', {
       $extensions: {
-        [EXTENSION_CONTRAST_WITH]: [
-          { color: { $type: 'color', $value: '{ma.color.indigo.5}' }, ratio: 1 },
-        ],
+        [EXTENSION_CONTRAST_WITH]: [{ color: { $type: 'color', $value: '{ma.color.indigo.5}' }, ratio: 1 }],
       },
       $type: 'color',
       $value: '{ma.color.indigo.5}',
     });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
-    expect(
-      result.data?.basis?.color?.['default']?.['color-document']?.$extensions?.[EXTENSION_CONTRAST_WITH],
-    ).toHaveLength(2);
+    expect(dlv(result.data, 'basis.color.default.color-document.$extensions')?.[EXTENSION_CONTRAST_WITH]).toHaveLength(
+      2,
+    );
   });
 
   it('does not add extension when corresponding token does not exist', () => {
@@ -173,7 +170,7 @@ describe('adding contrast-with extensions', () => {
     dset(config, 'basis.color.default.color-subtle', { $type: 'color', $value: '{ma.color.indigo.5}' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
-    expect(result.data?.basis?.color?.['default']?.['color-subtle']?.$extensions?.[EXTENSION_CONTRAST_WITH]).toEqual(
+    expect(dlv(result.data, 'basis.color.default.color-subtle.$extensions')?.[EXTENSION_CONTRAST_WITH]).toEqual(
       undefined,
     );
   });
@@ -203,11 +200,11 @@ describe('resolving Design Token refs', () => {
       const result = StrictThemeSchema.safeParse(config);
       const expectedColor = brandConfig.ma.color.indigo[5];
       expect
-        .soft(result.data?.basis?.color?.['default']?.['bg-document'])
+        .soft(dlv(result.data, 'basis.color.default.bg-document'))
         .toMatchObject(config.basis.color.default['bg-document']);
 
       expect
-        .soft(result.data?.basis?.color?.['default']?.['bg-document']?.$extensions?.[EXTENSION_RESOLVED_AS])
+        .soft(dlv(result.data, 'basis.color.default.bg-document.$extensions')?.[EXTENSION_RESOLVED_AS])
         .toEqual(expectedColor.$value);
     });
   });
@@ -283,7 +280,7 @@ describe('Style Dictionary specifics', () => {
   it('replaces token.$value with token.original.$value', () => {
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
-    expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toBe('{ma.color.white}');
+    expect(dlv(result.data, 'basis.color.accent-1.bg-default.$value')).toBe('{ma.color.white}');
   });
 
   it('ignores incomplete `original` objects', () => {
@@ -291,7 +288,7 @@ describe('Style Dictionary specifics', () => {
     delete incompleteConfig.basis.color['accent-1']['bg-default'].original.$value;
     const result = StrictThemeSchema.safeParse(incompleteConfig);
     expect(result.success).toBe(true);
-    expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toEqual({
+    expect(dlv(result.data, 'basis.color.accent-1.bg-default.$value')).toEqual({
       alpha: 1,
       colorSpace: 'srgb',
       components: [1, 1, 1],
@@ -301,8 +298,8 @@ describe('Style Dictionary specifics', () => {
   it('adds resolved-as extension in StrictTheme', () => {
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
-    expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toBe('{ma.color.white}');
-    expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$extensions?.[EXTENSION_RESOLVED_AS]).toEqual({
+    expect(dlv(result.data, 'basis.color.accent-1.bg-default.$value')).toBe('{ma.color.white}');
+    expect(dlv(result.data, 'basis.color.accent-1.bg-default.$extensions')?.[EXTENSION_RESOLVED_AS]).toEqual({
       alpha: 1,
       colorSpace: 'srgb',
       components: [1, 1, 1],
@@ -619,7 +616,7 @@ describe('remove non-token properties', () => {
     });
     const result = StrictThemeSchema.safeParse(theme);
     expect(result.success).toBeTruthy();
-    const actual = result.data?.basis?.color?.['default']?.['bg-document'];
+    const actual = dlv(result.data, 'basis.color.default.bg-document');
     expect(actual?.$type).toBe('color');
     expect(actual?.$value).toEqual({
       colorSpace: 'srgb',
@@ -643,7 +640,7 @@ describe('remove non-token properties', () => {
     });
     const result = StrictThemeSchema.safeParse(theme);
     expect(result.success).toBeTruthy();
-    const extensions = result.data?.basis?.color?.['default']?.['bg-document']?.$extensions;
+    const extensions = dlv(result.data, 'basis.color.default.bg-document.$extensions');
     expect(Array.isArray(extensions?.[EXTENSION_CONTRAST_WITH])).toBeTruthy();
     expect(extensions?.[EXTENSION_CONTRAST_WITH]).toHaveLength(1);
     const extension = (extensions?.[EXTENSION_CONTRAST_WITH] as ContrastExtension[])[0];
@@ -682,9 +679,9 @@ describe('color scale position extension', () => {
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
 
-    const bgDocToken = result.data?.basis?.color?.['default']?.['bg-document'];
-    const colorHoverToken = result.data?.basis?.color?.['default']?.['color-hover'];
-    const borderDefaultToken = result.data?.basis?.color?.['default']?.['border-default'];
+    const bgDocToken = dlv(result.data, 'basis.color.default.bg-document');
+    const colorHoverToken = dlv(result.data, 'basis.color.default.color-hover');
+    const borderDefaultToken = dlv(result.data, 'basis.color.default.border-default');
 
     // Verify extensions are added for all known color names
     expect(bgDocToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION]).toBeDefined();
@@ -711,8 +708,8 @@ describe('color scale position extension', () => {
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
 
-    const bgActiveToken = result.data?.basis?.color?.['default']?.['bg-active'];
-    const colorHoverToken = result.data?.basis?.color?.['default']?.['color-hover'];
+    const bgActiveToken = dlv(result.data, 'basis.color.default.bg-active');
+    const colorHoverToken = dlv(result.data, 'basis.color.default.color-hover');
 
     // Both tokens should have the extension since they're both in COLOR_KEYS
     expect(bgActiveToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION]).toBeDefined();
@@ -724,10 +721,10 @@ describe('color scale position extension', () => {
 
     // Both indices should be within the COLOR_KEYS range
     const positionCount = COLOR_KEYS.length;
-    expect(bgActiveToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION] as number).toBeGreaterThanOrEqual(0);
-    expect(bgActiveToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION] as number).toBeLessThan(positionCount);
-    expect(colorHoverToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION] as number).toBeGreaterThanOrEqual(0);
-    expect(colorHoverToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION] as number).toBeLessThan(positionCount);
+    expect(bgActiveToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION]).toBeGreaterThanOrEqual(0);
+    expect(bgActiveToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION]).toBeLessThan(positionCount);
+    expect(colorHoverToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION]).toBeGreaterThanOrEqual(0);
+    expect(colorHoverToken?.$extensions?.[EXTENSION_COLOR_SCALE_POSITION]).toBeLessThan(positionCount);
   });
 });
 
@@ -1001,8 +998,7 @@ describe('line-height validations', () => {
       dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const token = (result.data?.basis?.text?.['line-height'] as any).md;
+      const token = dlv(result.data, 'basis.text.line-height.md');
       expect(token.$type).toEqual('number');
       expect(token.$value).toEqual(1.5);
       expect(token.$extensions?.[EXTENSION_TOKEN_SUBTYPE]).toEqual('line-height');
@@ -1013,8 +1009,7 @@ describe('line-height validations', () => {
       dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: '1.5' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const token = (result.data?.basis?.text?.['line-height'] as any).md;
+      const token = dlv(result.data, 'basis.text.line-height.md');
       expect(token.$type).toEqual('number');
       expect(token.$value).toEqual(1.5);
       expect(token.$extensions?.[EXTENSION_TOKEN_SUBTYPE]).toEqual('line-height');
@@ -1025,8 +1020,7 @@ describe('line-height validations', () => {
       dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: '150%' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const token = (result.data?.basis?.text?.['line-height'] as any).md;
+      const token = dlv(result.data, 'basis.text.line-height.md');
       expect(token.$type).toEqual('number');
       expect(token.$value).toEqual(1.5);
       expect(token.$extensions?.[EXTENSION_TOKEN_SUBTYPE]).toEqual('line-height');
@@ -1052,8 +1046,7 @@ describe('line-height validations', () => {
       dset(config, 'basis.text.line-height.sm', { $type: 'lineHeight', $value: '{basis.text.line-height.md}' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const token = (result.data?.basis?.text?.['line-height'] as any).sm;
+      const token = dlv(result.data, 'basis.text.line-height.sm');
       expect(token.$type).toEqual('number');
       expect(token.$extensions?.[EXTENSION_TOKEN_SUBTYPE]).toEqual('line-height');
     });

--- a/packages/design-tokens-schema/src/theme.test.ts
+++ b/packages/design-tokens-schema/src/theme.test.ts
@@ -9,7 +9,6 @@ import { it, describe, expect } from 'vitest';
 import { BrandSchema, COLOR_KEYS } from './basis-tokens';
 import { EXTENSION_RESOLVED_AS, EXTENSION_RESOLVED_FROM } from './resolve-refs';
 import {
-  ThemeSchema,
   type Theme,
   StrictThemeSchema,
   EXTENSION_CONTRAST_WITH,
@@ -21,6 +20,8 @@ import { parseColor, type ColorToken } from './tokens/color-token';
 import { EXTENSION_TOKEN_SUBTYPE } from './upgrade-legacy-tokens';
 import { ERROR_CODES, type ThemeValidationIssue } from './validation-issue';
 import { MINIMUM_LINE_HEIGHT } from './validations';
+
+const getBasis = () => structuredClone((startTokens as Record<string, unknown>)['basis']) as Record<string, unknown>;
 
 const createToken = (type: string, value: unknown, extensions?: Record<PropertyKey, unknown>) => {
   return {
@@ -65,18 +66,8 @@ const brandConfig = {
 
 describe('upgrades legacy colors', () => {
   it('converts legacy color strings in basis tokens', () => {
-    const config = {
-      basis: {
-        color: {
-          'accent-1': {
-            'bg-default': {
-              $type: 'color',
-              $value: '#ffffff',
-            },
-          },
-        },
-      },
-    };
+    const config = { basis: getBasis() };
+    dset(config, 'basis.color.accent-1.bg-default', { $type: 'color', $value: '#ffffff' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
     const color = result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value;
@@ -136,24 +127,9 @@ describe('upgrades legacy colors', () => {
 
 describe('adding contrast-with extensions', () => {
   it('adds contrast-with extensions for tokens that we know', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-subtle': {
-              $type: 'color',
-              $value: '{ma.color.indigo.1}',
-            },
-            'color-document': {
-              $type: 'color',
-              $value: `{ma.color.indigo.5}`,
-              // the transformation will add an $extension here
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    const config = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.bg-subtle', { $type: 'color', $value: '{ma.color.indigo.1}' });
+    dset(config, 'basis.color.default.color-document', { $type: 'color', $value: '{ma.color.indigo.5}' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
     expect(result.data?.basis?.color?.['default']?.['color-document']?.$extensions).toMatchObject({
@@ -161,7 +137,7 @@ describe('adding contrast-with extensions', () => {
         {
           color: {
             $extensions: {
-              [EXTENSION_RESOLVED_AS]: config.brand.ma.color.indigo['1'].$value,
+              [EXTENSION_RESOLVED_AS]: brandConfig.ma.color.indigo['1'].$value,
             },
             $type: 'color',
             $value: '{ma.color.indigo.1}',
@@ -173,35 +149,17 @@ describe('adding contrast-with extensions', () => {
   });
 
   it('contrast-with extensions do not mess with existing extensions', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-subtle': {
-              $type: 'color',
-              $value: '{ma.color.indigo.1}',
-            },
-            'color-document': {
-              $extensions: {
-                // the transformation will add an extra contrast color here
-                [EXTENSION_CONTRAST_WITH]: [
-                  {
-                    color: {
-                      $type: 'color',
-                      $value: '{ma.color.indigo.5}',
-                    },
-                    ratio: 1,
-                  },
-                ],
-              },
-              $type: 'color',
-              $value: `{ma.color.indigo.5}`,
-            },
-          },
-        },
+    const config = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.bg-subtle', { $type: 'color', $value: '{ma.color.indigo.1}' });
+    dset(config, 'basis.color.default.color-document', {
+      $extensions: {
+        [EXTENSION_CONTRAST_WITH]: [
+          { color: { $type: 'color', $value: '{ma.color.indigo.5}' }, ratio: 1 },
+        ],
       },
-      brand: brandConfig,
-    };
+      $type: 'color',
+      $value: '{ma.color.indigo.5}',
+    });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
     expect(
@@ -210,23 +168,12 @@ describe('adding contrast-with extensions', () => {
   });
 
   it('does not add extension when corresponding token does not exist', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'color-document': {
-              $type: 'color',
-              $value: `{ma.color.indigo.5}`,
-              // contrast-with extension would be added here but this object has no bg-subtle
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    // color-subtle has no entry in the CONTRAST map, so no contrast-with extension is added
+    const config = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.color-subtle', { $type: 'color', $value: '{ma.color.indigo.5}' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
-    expect(result.data?.basis?.color?.['default']?.['color-document']?.$extensions?.[EXTENSION_CONTRAST_WITH]).toEqual(
+    expect(result.data?.basis?.color?.['default']?.['color-subtle']?.$extensions?.[EXTENSION_CONTRAST_WITH]).toEqual(
       undefined,
     );
   });
@@ -234,19 +181,9 @@ describe('adding contrast-with extensions', () => {
 
 describe('resolving Design Token refs', () => {
   describe('resolve color ref', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-document': {
-              $type: 'color',
-              $value: `{ma.color.indigo.5}`,
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.bg-document', { $type: 'color', $value: `{ma.color.indigo.5}` });
 
     it('does not mutate the input config', () => {
       const originalConfig = structuredClone(config);
@@ -276,23 +213,11 @@ describe('resolving Design Token refs', () => {
   });
 
   it('marks as invalid if resolving to an nonexistent object', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-document': {
-              $type: 'color',
-              $value: `{non.existent.token}`,
-            },
-            'bg-subtle': {
-              $type: 'color',
-              $value: `{incomplete.ref`,
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = { basis: getBasis(), brand: brandConfig };
+    // Use tokens not involved in contrast pairs to avoid crashing the contrast checker with invalid refs
+    dset(config, 'basis.color.default.bg-document', { $type: 'color', $value: `{non.existent.token}` });
+    dset(config, 'basis.color.default.color-subtle', { $type: 'color', $value: `{incomplete.ref` });
 
     expect.soft(() => StrictThemeSchema.safeParse(config)).not.toThrowError();
     const result = StrictThemeSchema.safeParse(config);
@@ -300,19 +225,9 @@ describe('resolving Design Token refs', () => {
   });
 
   it('marks as invalid if resolving to an existing object without a $value property', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-document': {
-              $type: 'color',
-              $value: `{ma.color.indigo}`,
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.bg-document', { $type: 'color', $value: `{ma.color.indigo}` });
 
     expect(() => StrictThemeSchema.safeParse(config)).not.toThrowError();
     const result = StrictThemeSchema.safeParse(config);
@@ -329,18 +244,13 @@ describe('resolving Design Token refs', () => {
   });
 
   it('marks as invalid when a font-family token reference points to an existing non-font-family token', () => {
-    const config = {
-      basis: {
-        heading: {
-          'font-family': {
-            $type: 'fontFamily',
-            // this points to a color token instead of a fontFamily
-            $value: '{ma.color.indigo.5}',
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.heading.font-family', {
+      $type: 'fontFamily',
+      // this points to a color token instead of a fontFamily
+      $value: '{ma.color.indigo.5}',
+    });
 
     const result = StrictThemeSchema.safeParse(config);
     expect.soft(result.success).toEqual(false);
@@ -362,44 +272,26 @@ describe('Style Dictionary specifics', () => {
     components: [1, 1, 1],
   };
 
-  const config = {
-    basis: {
-      color: {
-        'accent-1': {
-          'bg-default': {
-            $type: 'color',
-            $value: modernWhite,
-            original: {
-              $type: 'color',
-              $value: '{ma.color.white}',
-            },
-          },
-        },
-      },
-    },
-    ma: {
-      color: {
-        white: {
-          $type: 'color',
-          $value: modernWhite,
-        },
-      },
-    },
-  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const config: any = { basis: getBasis(), ma: { color: { white: { $type: 'color', $value: modernWhite } } } };
+  dset(config, 'basis.color.accent-1.bg-default', {
+    $type: 'color',
+    $value: modernWhite,
+    original: { $type: 'color', $value: '{ma.color.white}' },
+  });
 
   it('replaces token.$value with token.original.$value', () => {
-    const result = ThemeSchema.safeParse(config);
+    const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBe(true);
-    expect((result.data as Theme)?.basis?.color?.['accent-1']?.['bg-default']?.$value).toBe('{ma.color.white}');
+    expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toBe('{ma.color.white}');
   });
 
   it('ignores incomplete `original` objects', () => {
     const incompleteConfig = structuredClone(config);
-    // @ts-expect-error what we're doing here is unexpeced, type-wise
     delete incompleteConfig.basis.color['accent-1']['bg-default'].original.$value;
-    const result = ThemeSchema.safeParse(incompleteConfig);
+    const result = StrictThemeSchema.safeParse(incompleteConfig);
     expect(result.success).toBe(true);
-    expect((result.data as Theme)?.basis?.color?.['accent-1']?.['bg-default']?.$value).toEqual({
+    expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toEqual({
       alpha: 1,
       colorSpace: 'srgb',
       components: [1, 1, 1],
@@ -425,29 +317,16 @@ describe('validating color contrast', () => {
   const lightGray = { $type: 'color', $value: parseColor('#ccc') } satisfies ColorToken;
 
   describe('basis tokens', () => {
-    const config = {
-      basis: {
-        color: {
-          // This is where each test case will write their own needs
-          default: Object.create(null),
-        },
-      },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config: any = {
+      basis: getBasis(),
       brand: {
         ma: {
-          name: {
-            $type: 'text',
-            $value: 'Mooi & Anders',
-          },
-          color: {
-            black,
-            gray: {
-              2: lightGray,
-            },
-            white,
-          },
+          name: { $type: 'text', $value: 'Mooi & Anders' },
+          color: { black, gray: { 2: lightGray }, white },
         },
       },
-    } satisfies Theme;
+    };
 
     it('passes when contrast is sufficient', () => {
       const testConfig = structuredClone(config);
@@ -624,7 +503,7 @@ describe('validating color contrast', () => {
     });
 
     it('fails when contrast is insufficient (ref values)', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.color.default.color-subtle', lightGray);
       dset(config, 'basis.color.default.bg-default', white);
       dset(config, 'clippy.button.color', { $type: 'color', $value: '{basis.color.default.color-subtle}' });
@@ -692,37 +571,21 @@ it('finds both ref and contrast issues at once', () => {
   const white = parseColor('#ffffff');
   const lightGray = parseColor('#cccccc');
 
-  const themeWithBothErrors: Theme = {
-    basis: {
+  const testBrand = {
+    test: {
+      name: { $type: 'text', $value: 'Test' },
       color: {
-        default: {
-          // Invalid ref - this token doesn't exist
-          'bg-document': {
-            $type: 'color',
-            $value: '{test.color.nonexistent}',
-          },
-          // Insufficient contrast - gray on white is too low
-          'bg-subtle': {
-            $type: 'color',
-            $value: '{test.color.white}',
-          },
-          'color-document': {
-            $type: 'color',
-            $value: '{test.color.gray}',
-          },
-        },
-      },
-    },
-    brand: {
-      test: {
-        name: { $type: 'text', $value: 'Test' },
-        color: {
-          gray: { $type: 'color', $value: lightGray },
-          white: { $type: 'color', $value: white },
-        },
+        gray: { $type: 'color', $value: lightGray },
+        white: { $type: 'color', $value: white },
       },
     },
   };
+  const themeWithBothErrors = { basis: getBasis(), brand: testBrand };
+  // Invalid ref - this token doesn't exist
+  dset(themeWithBothErrors, 'basis.color.default.bg-document', { $type: 'color', $value: '{test.color.nonexistent}' });
+  // Insufficient contrast - gray on white is too low
+  dset(themeWithBothErrors, 'basis.color.default.bg-subtle', { $type: 'color', $value: '{test.color.white}' });
+  dset(themeWithBothErrors, 'basis.color.default.color-document', { $type: 'color', $value: '{test.color.gray}' });
 
   const result = StrictThemeSchema.safeParse(themeWithBothErrors);
   expect(result.success).toBe(false);
@@ -741,39 +604,19 @@ it('finds both ref and contrast issues at once', () => {
 
 describe('remove non-token properties', () => {
   it('removes Style Dictionary metadata', () => {
-    const theme = {
-      basis: {
-        color: {
-          default: {
-            'bg-document': {
-              $type: 'color',
-              $value: {
-                colorSpace: 'srgb',
-                components: [0, 0, 0],
-              },
-              // object
-              attributes: {
-                category: 'basis',
-                item: 'default',
-                type: 'color',
-              },
-              // string
-              filePath: 'tokens.json',
-              // boolean
-              isSource: true,
-              // object with tokens inside
-              original: {
-                $type: 'color',
-                $value: {
-                  colorSpace: 'srgb',
-                  components: [0, 0, 0],
-                },
-              },
-            },
-          },
-        },
-      },
-    } satisfies Theme;
+    const theme = { basis: getBasis() };
+    dset(theme, 'basis.color.default.bg-document', {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      // object
+      attributes: { category: 'basis', item: 'default', type: 'color' },
+      // string
+      filePath: 'tokens.json',
+      // boolean
+      isSource: true,
+      // object with tokens inside
+      original: { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+    });
     const result = StrictThemeSchema.safeParse(theme);
     expect(result.success).toBeTruthy();
     const actual = result.data?.basis?.color?.['default']?.['bg-document'];
@@ -790,32 +633,14 @@ describe('remove non-token properties', () => {
   });
 
   it('does not remove information from $extensions (which could hold any sort of data)', () => {
-    const theme = {
-      basis: {
-        color: {
-          default: {
-            'bg-document': {
-              $extensions: {
-                [EXTENSION_CONTRAST_WITH]: [
-                  {
-                    color: {
-                      $type: 'color',
-                      $value: parseColor('#fff'),
-                    },
-                    expectedRatio: 4.5,
-                  },
-                ],
-              },
-              $type: 'color',
-              $value: {
-                colorSpace: 'srgb',
-                components: [0, 0, 0],
-              },
-            },
-          },
-        },
+    const theme = { basis: getBasis() };
+    dset(theme, 'basis.color.default.bg-document', {
+      $extensions: {
+        [EXTENSION_CONTRAST_WITH]: [{ color: { $type: 'color', $value: parseColor('#fff') }, expectedRatio: 4.5 }],
       },
-    } satisfies Theme;
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+    });
     const result = StrictThemeSchema.safeParse(theme);
     expect(result.success).toBeTruthy();
     const extensions = result.data?.basis?.color?.['default']?.['bg-document']?.$extensions;
@@ -849,27 +674,11 @@ describe('remove non-token properties', () => {
 
 describe('color scale position extension', () => {
   it('adds color-scale-position extensions for tokens with known color names', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-document': {
-              $type: 'color',
-              $value: parseColor('#ffffff'),
-            },
-            'border-default': {
-              $type: 'color',
-              $value: parseColor('#cccccc'),
-            },
-            'color-hover': {
-              $type: 'color',
-              $value: parseColor('#000000'),
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    const config = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.bg-document', { $type: 'color', $value: parseColor('#ffffff') });
+    // Use black for border-default to maintain sufficient contrast vs bg-default (#f1f1f1 from startTokens)
+    dset(config, 'basis.color.default.border-default', { $type: 'color', $value: parseColor('#000000') });
+    dset(config, 'basis.color.default.color-hover', { $type: 'color', $value: parseColor('#000000') });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
 
@@ -896,23 +705,9 @@ describe('color scale position extension', () => {
   });
 
   it('only adds extensions to tokens with names in COLOR_KEYS', () => {
-    const config = {
-      basis: {
-        color: {
-          default: {
-            'bg-active': {
-              $type: 'color',
-              $value: parseColor('#ffffff'),
-            },
-            'color-hover': {
-              $type: 'color',
-              $value: parseColor('#000000'),
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-    };
+    const config = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.color.default.bg-active', { $type: 'color', $value: parseColor('#ffffff') });
+    dset(config, 'basis.color.default.color-hover', { $type: 'color', $value: parseColor('#000000') });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
 
@@ -938,30 +733,9 @@ describe('color scale position extension', () => {
 
 describe('validate minimum font-size', () => {
   it('passes refs', () => {
-    const config = {
-      basis: {
-        text: {
-          'font-size': {
-            md: {
-              $type: 'dimension',
-              $value: {
-                unit: 'px',
-                value: 18,
-              },
-            },
-          },
-        },
-      },
-      brand: brandConfig,
-      nl: {
-        button: {
-          'font-size': {
-            $type: 'dimension',
-            $value: '{basis.text.font-size.md}',
-          },
-        },
-      },
-    };
+    const config = { basis: getBasis(), brand: brandConfig };
+    dset(config, 'basis.text.font-size.md', { $type: 'dimension', $value: { unit: 'px', value: 18 } });
+    dset(config, 'nl.button.font-size', { $type: 'dimension', $value: '{basis.text.font-size.md}' });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toEqual(true);
   });
@@ -1034,103 +808,41 @@ describe('validate minimum font-size', () => {
         message: 'Font-size should be 14px or 0.875rem minimum (got: "10px")',
         minimum: '14px / 0.875rem',
         origin: 'number',
-        path: ['basis', 'text', 'font-size', 'xs', '$value'],
+        path: ['basis', 'text', 'font-size', 'md', '$value'],
       },
     ];
 
     it('flags modern syntax', () => {
-      const config = {
-        basis: {
-          text: {
-            'font-size': {
-              sm: {
-                $type: 'dimension',
-                $value: {
-                  unit: 'rem',
-                  value: 0.8,
-                },
-              },
-              xs: {
-                $type: 'dimension',
-                $value: {
-                  unit: 'px',
-                  value: 10,
-                },
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.font-size.sm', { $type: 'dimension', $value: { unit: 'rem', value: 0.8 } });
+      dset(config, 'basis.text.font-size.md', { $type: 'dimension', $value: { unit: 'px', value: 10 } });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues).toEqual(expectedErrors);
     });
 
     it('flags legacy syntax ($type=dimension, $value=string)', () => {
-      const config = {
-        basis: {
-          text: {
-            'font-size': {
-              sm: {
-                $type: 'dimension',
-                $value: '0.8rem',
-              },
-              xs: {
-                $type: 'dimension',
-                $value: '10px',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.font-size.sm', { $type: 'dimension', $value: '0.8rem' });
+      dset(config, 'basis.text.font-size.md', { $type: 'dimension', $value: '10px' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues).toEqual(expectedErrors);
     });
 
     it('flags legacy syntax ($type=fontSize, $value=string)', () => {
-      const config = {
-        basis: {
-          text: {
-            'font-size': {
-              sm: {
-                $type: 'fontSize',
-                $value: '0.8rem',
-              },
-              xs: {
-                $type: 'fontSize',
-                $value: '10px',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.font-size.sm', { $type: 'fontSize', $value: '0.8rem' });
+      dset(config, 'basis.text.font-size.md', { $type: 'fontSize', $value: '10px' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues).toEqual(expectedErrors);
     });
 
     it('allows legacy syntax ($type=fontSize, $value=string)', () => {
-      const config = {
-        basis: {
-          text: {
-            'font-size': {
-              sm: {
-                $type: 'fontSize',
-                $value: '1rem',
-              },
-              xs: {
-                $type: 'fontSize',
-                $value: '16px',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.font-size.sm', { $type: 'fontSize', $value: '1rem' });
+      dset(config, 'basis.text.font-size.md', { $type: 'fontSize', $value: '16px' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
     });
@@ -1140,59 +852,24 @@ describe('validate minimum font-size', () => {
 describe('line-height validations', () => {
   describe('validate unitless line-height preference', () => {
     it('Does not report line-heights that use a unitless number', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 1.5,
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
     });
 
     it('Does not report line-heights that are a ref', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 1.5,
-              },
-              sm: {
-                $type: 'lineHeight',
-                $value: '{basis.text.line-height.md}',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1.5 });
+      dset(config, 'basis.text.line-height.sm', { $type: 'lineHeight', $value: '{basis.text.line-height.md}' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
     });
 
     it('flags line-heights that use units', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: '20px',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: '20px' });
+      dset(config, 'basis.form-control.line-height', { $type: 'number', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues).toEqual([
@@ -1207,14 +884,9 @@ describe('line-height validations', () => {
     });
 
     it('flags line-heights that use dimensions', () => {
-      const config = {};
-      dset(config, 'basis.text.line-height.md', {
-        $type: 'dimension',
-        $value: {
-          unit: 'px',
-          value: 20,
-        },
-      });
+      const config = { basis: getBasis() };
+      dset(config, 'basis.text.line-height.md', { $type: 'dimension', $value: { unit: 'px', value: 20 } });
+      dset(config, 'basis.form-control.line-height', { $type: 'number', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues).toEqual([
@@ -1260,59 +932,23 @@ describe('line-height validations', () => {
 
   describe('validate minimum line-height preference', () => {
     it('Does not report line-heights that comply', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 1.5,
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
     });
 
     it('Does not report line-heights that are a ref', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 1.5,
-              },
-              sm: {
-                $type: 'lineHeight',
-                $value: '{basis.text.line-height.md}',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1.5 });
+      dset(config, 'basis.text.line-height.sm', { $type: 'lineHeight', $value: '{basis.text.line-height.md}' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
     });
 
     it('flags line-heights that are too small', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 1,
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues).toEqual([
@@ -1361,19 +997,8 @@ describe('line-height validations', () => {
 
   describe('upgrades legacy line-heights', () => {
     it('leaves lineHeights that are already numbers intact', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 1.5,
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1384,19 +1009,8 @@ describe('line-height validations', () => {
     });
 
     it('converts stringified numbers to numbers', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: '1.5',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: '1.5' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1407,19 +1021,8 @@ describe('line-height validations', () => {
     });
 
     it('coverts percentages to numbers', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: '150%',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: '150%' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1430,19 +1033,9 @@ describe('line-height validations', () => {
     });
 
     it('converts dimension strings to dimension', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: '20px',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: '20px' });
+      dset(config, 'basis.form-control.line-height', { $type: 'number', $value: 1.5 });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(false);
       expect(result.error?.issues.length).toBe(1);
@@ -1454,23 +1047,9 @@ describe('line-height validations', () => {
     });
 
     it('sets the correct type based on what token a reference points to', () => {
-      const config = {
-        basis: {
-          text: {
-            'line-height': {
-              md: {
-                $type: 'lineHeight',
-                $value: 2,
-              },
-              sm: {
-                $type: 'lineHeight',
-                $value: '{basis.text.line-height.md}',
-              },
-            },
-          },
-        },
-        brand: brandConfig,
-      };
+      const config = { basis: getBasis(), brand: brandConfig };
+      dset(config, 'basis.text.line-height.md', { $type: 'lineHeight', $value: 2 });
+      dset(config, 'basis.text.line-height.sm', { $type: 'lineHeight', $value: '{basis.text.line-height.md}' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toEqual(true);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1489,7 +1068,7 @@ describe('line-height validations', () => {
     };
 
     it('invalid line-height: $type=dimension; px/px', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.text.font-size.sm', createDimension(16, 'px'));
       dset(config, 'basis.text.line-height.sm', createDimension(16, 'px'));
 
@@ -1505,7 +1084,7 @@ describe('line-height validations', () => {
     });
 
     it('invalid line-height: $type=dimension; px/rem', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.text.font-size.sm', createDimension(16, 'px'));
       dset(config, 'basis.text.line-height.sm', createDimension(1, 'rem'));
 
@@ -1521,7 +1100,7 @@ describe('line-height validations', () => {
     });
 
     it('invalid line-height: $type=dimension; rem/px', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.text.font-size.sm', createDimension(1, 'rem'));
       dset(config, 'basis.text.line-height.sm', createDimension(16, 'px'));
 
@@ -1537,7 +1116,7 @@ describe('line-height validations', () => {
     });
 
     it('valid line-height: $type=dimension; rem/px', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.text.font-size.sm', createDimension(1, 'rem'));
       dset(config, 'basis.text.line-height.sm', createDimension(24, 'px'));
 
@@ -1548,13 +1127,14 @@ describe('line-height validations', () => {
     });
 
     it('valid line-height: $type=dimension; rem/px; with font-size ref', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.text.font-size.sm', createDimension(1, 'rem'));
       dset(config, 'basis.text.font-size.md', {
         $type: 'dimension',
         $value: '{basis.text.font-size.sm}',
       });
       dset(config, 'basis.text.line-height.md', createDimension(24, 'px'));
+      dset(config, 'basis.form-control.line-height', { $type: 'number', $value: 1.5 });
 
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toBe(false);
@@ -1563,13 +1143,14 @@ describe('line-height validations', () => {
     });
 
     it('valid line-height: $type=dimension; rem/px; with line-height ref', () => {
-      const config = {};
+      const config = { basis: getBasis() };
       dset(config, 'basis.text.font-size.md', createDimension(1, 'rem'));
       dset(config, 'basis.text.line-height.sm', createDimension(24, 'px'));
       dset(config, 'basis.text.line-height.md', {
         $type: 'dimension',
         $value: '{basis.text.line-height.sm}',
       });
+      dset(config, 'basis.form-control.line-height', { $type: 'number', $value: 1.5 });
 
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toBe(false);

--- a/packages/design-tokens-schema/src/tokens/color-token.test.ts
+++ b/packages/design-tokens-schema/src/tokens/color-token.test.ts
@@ -1,4 +1,6 @@
 import Color from 'colorjs.io';
+import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tokens';
+import { dset } from 'dset';
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import { StrictThemeSchema } from '../theme';
 import {
@@ -91,22 +93,14 @@ describe('color token validation', () => {
 
   describe('legacy color preprocessing (via theme schema)', () => {
     it('upgrade legacy color to modern (via theme)', () => {
-      const config = {
-        basis: {
-          color: {
-            'accent-1': {
-              'bg-default': {
-                $type: 'color',
-                $value: '#f00',
-              },
-            },
-          },
-        },
-      };
+      // Use disabled group (skips basis contrast validation).
+      // Use only the basis portion to avoid component-token contrast checks.
+      const config = { basis: structuredClone((startTokens as Record<string, unknown>)['basis']) };
+      dset(config, 'basis.color.disabled.bg-default', { $type: 'color', $value: '#f00' });
       const result = StrictThemeSchema.safeParse(config);
 
       expect(result.success).toBeTruthy();
-      expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toEqual({
+      expect(result.data?.basis?.color?.['disabled']?.['bg-default']?.$value).toEqual({
         alpha: 1,
         colorSpace: 'srgb',
         components: [1, 0, 0],
@@ -114,21 +108,12 @@ describe('color token validation', () => {
     });
 
     it('convert `transparent` to fully transparent black (via theme)', () => {
-      const config = {
-        basis: {
-          color: {
-            'accent-1': {
-              'bg-default': {
-                $type: 'color',
-                $value: 'transparent',
-              },
-            },
-          },
-        },
-      };
+      // Use disabled group which skips contrast validation
+      const config = structuredClone(startTokens);
+      dset(config, 'basis.color.disabled.bg-default', { $type: 'color', $value: 'transparent' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toBeTruthy();
-      expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toEqual({
+      expect(result.data?.basis?.color?.['disabled']?.['bg-default']?.$value).toEqual({
         alpha: 0,
         colorSpace: 'srgb',
         components: [0, 0, 0],
@@ -136,21 +121,12 @@ describe('color token validation', () => {
     });
 
     it('convert `rgba(0, 0, 0, 0)` to fully transparent black (via theme)', () => {
-      const config = {
-        basis: {
-          color: {
-            'accent-1': {
-              'bg-default': {
-                $type: 'color',
-                $value: 'rgba(0, 0, 0, 0)',
-              },
-            },
-          },
-        },
-      };
+      // Use disabled group which skips contrast validation
+      const config = structuredClone(startTokens);
+      dset(config, 'basis.color.disabled.bg-default', { $type: 'color', $value: 'rgba(0, 0, 0, 0)' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toBeTruthy();
-      expect(result.data?.basis?.color?.['accent-1']?.['bg-default']?.$value).toEqual({
+      expect(result.data?.basis?.color?.['disabled']?.['bg-default']?.$value).toEqual({
         alpha: 0,
         colorSpace: 'srgb',
         components: [0, 0, 0],

--- a/packages/design-tokens-schema/src/tokens/color-token.test.ts
+++ b/packages/design-tokens-schema/src/tokens/color-token.test.ts
@@ -1,5 +1,6 @@
-import Color from 'colorjs.io';
 import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tokens';
+import Color from 'colorjs.io';
+import dlv from 'dlv';
 import { dset } from 'dset';
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import { StrictThemeSchema } from '../theme';
@@ -100,7 +101,7 @@ describe('color token validation', () => {
       const result = StrictThemeSchema.safeParse(config);
 
       expect(result.success).toBeTruthy();
-      expect(result.data?.basis?.color?.['disabled']?.['bg-default']?.$value).toEqual({
+      expect(dlv(result.data, 'basis.color.disabled.bg-default.$value')).toEqual({
         alpha: 1,
         colorSpace: 'srgb',
         components: [1, 0, 0],
@@ -113,7 +114,7 @@ describe('color token validation', () => {
       dset(config, 'basis.color.disabled.bg-default', { $type: 'color', $value: 'transparent' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toBeTruthy();
-      expect(result.data?.basis?.color?.['disabled']?.['bg-default']?.$value).toEqual({
+      expect(dlv(result.data, 'basis.color.disabled.bg-default.$value')).toEqual({
         alpha: 0,
         colorSpace: 'srgb',
         components: [0, 0, 0],
@@ -126,7 +127,7 @@ describe('color token validation', () => {
       dset(config, 'basis.color.disabled.bg-default', { $type: 'color', $value: 'rgba(0, 0, 0, 0)' });
       const result = StrictThemeSchema.safeParse(config);
       expect(result.success).toBeTruthy();
-      expect(result.data?.basis?.color?.['disabled']?.['bg-default']?.$value).toEqual({
+      expect(dlv(result.data, 'basis.color.disabled.bg-default.$value')).toEqual({
         alpha: 0,
         colorSpace: 'srgb',
         components: [0, 0, 0],

--- a/packages/design-tokens-schema/src/tokens/fontfamily-token.test.ts
+++ b/packages/design-tokens-schema/src/tokens/fontfamily-token.test.ts
@@ -1,3 +1,5 @@
+import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tokens';
+import { dset } from 'dset';
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import { StrictThemeSchema } from '../theme';
 import {
@@ -47,16 +49,11 @@ it('accepts modern token', () => {
 
 describe('legacy token format preprocessing (via theme schema)', () => {
   it('upgrades legacy fontFamilies token', () => {
-    const config = {
-      basis: {
-        heading: {
-          'font-family': {
-            $type: 'fontFamilies',
-            $value: 'Source Sans Pro, Helvetica, Arial, sans-serif',
-          },
-        },
-      },
-    };
+    const config = structuredClone(startTokens);
+    dset(config, 'basis.heading.font-family', {
+      $type: 'fontFamilies',
+      $value: 'Source Sans Pro, Helvetica, Arial, sans-serif',
+    });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBeTruthy();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,16 +63,11 @@ describe('legacy token format preprocessing (via theme schema)', () => {
   });
 
   it('upgrades fontFamily token with legacy string value', () => {
-    const config = {
-      basis: {
-        heading: {
-          'font-family': {
-            $type: 'fontFamily',
-            $value: 'IBM Plex Sans, monospace',
-          },
-        },
-      },
-    };
+    const config = structuredClone(startTokens);
+    dset(config, 'basis.heading.font-family', {
+      $type: 'fontFamily',
+      $value: 'IBM Plex Sans, monospace',
+    });
     const result = StrictThemeSchema.safeParse(config);
     expect(result.success).toBeTruthy();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/theme-wizard-app/src/lib/Theme/__snapshots__/index.test.ts.snap
+++ b/packages/theme-wizard-app/src/lib/Theme/__snapshots__/index.test.ts.snap
@@ -19461,8 +19461,6 @@ exports[`Theme > can export to JSON token file 1`] = `
       },
       "font-size": {
         "key": "{basis.form-control.font-size}",
-        "$type": "dimension",
-        "$value": "1rem",
         "$extensions": {
           "studio.tokens": {
             "originalType": "fontSizes"
@@ -19473,9 +19471,9 @@ exports[`Theme > can export to JSON token file 1`] = `
             "unit": "rem"
           }
         },
+        "$type": "dimension",
+        "$value": "1rem",
         "original": {
-          "$type": "dimension",
-          "$value": "{basis.text.font-size.md}",
           "$extensions": {
             "studio.tokens": {
               "originalType": "fontSizes"
@@ -19486,6 +19484,8 @@ exports[`Theme > can export to JSON token file 1`] = `
               "unit": "rem"
             }
           },
+          "$type": "dimension",
+          "$value": "{basis.text.font-size.md}",
           "key": "{basis.form-control.font-size}"
         },
         "name": "font-size",
@@ -19498,8 +19498,6 @@ exports[`Theme > can export to JSON token file 1`] = `
       },
       "font-weight": {
         "key": "{basis.form-control.font-weight}",
-        "$type": "fontWeight",
-        "$value": 400,
         "$extensions": {
           "studio.tokens": {
             "originalType": "fontWeights"
@@ -19507,9 +19505,9 @@ exports[`Theme > can export to JSON token file 1`] = `
           "nl.nldesignsystem.token-subtype": "font-weight",
           "nl.nldesignsystem.value-resolved-as": 400
         },
+        "$type": "fontWeight",
+        "$value": 400,
         "original": {
-          "$type": "fontWeight",
-          "$value": "{basis.text.font-weight.default}",
           "$extensions": {
             "studio.tokens": {
               "originalType": "fontWeights"
@@ -19517,6 +19515,8 @@ exports[`Theme > can export to JSON token file 1`] = `
             "nl.nldesignsystem.token-subtype": "font-weight",
             "nl.nldesignsystem.value-resolved-as": 400
           },
+          "$type": "fontWeight",
+          "$value": "{basis.text.font-weight.default}",
           "key": "{basis.form-control.font-weight}"
         },
         "name": "font-weight",
@@ -19529,8 +19529,6 @@ exports[`Theme > can export to JSON token file 1`] = `
       },
       "line-height": {
         "key": "{basis.form-control.line-height}",
-        "$type": "lineHeight",
-        "$value": 1.5,
         "$extensions": {
           "studio.tokens": {
             "originalType": "lineHeights"
@@ -19538,9 +19536,9 @@ exports[`Theme > can export to JSON token file 1`] = `
           "nl.nldesignsystem.token-subtype": "line-height",
           "nl.nldesignsystem.value-resolved-as": 1.5
         },
+        "$type": "lineHeight",
+        "$value": 1.5,
         "original": {
-          "$type": "lineHeight",
-          "$value": "{basis.text.line-height.md}",
           "$extensions": {
             "studio.tokens": {
               "originalType": "lineHeights"
@@ -19548,6 +19546,8 @@ exports[`Theme > can export to JSON token file 1`] = `
             "nl.nldesignsystem.token-subtype": "line-height",
             "nl.nldesignsystem.value-resolved-as": 1.5
           },
+          "$type": "lineHeight",
+          "$value": "{basis.text.line-height.md}",
           "key": "{basis.form-control.line-height}"
         },
         "name": "line-height",
@@ -19556,45 +19556,6 @@ exports[`Theme > can export to JSON token file 1`] = `
           "basis",
           "form-control",
           "line-height"
-        ]
-      },
-      "accent-color": {
-        "key": "{basis.form-control.accent-color}",
-        "$extensions": {
-          "nl.nldesignsystem.value-resolved-as": {
-            "alpha": 1,
-            "colorSpace": "srgb",
-            "components": [
-              0.10588235294117647,
-              0.34901960784313724,
-              0.6431372549019608
-            ]
-          }
-        },
-        "$type": "color",
-        "$value": "#1b59a4",
-        "original": {
-          "$extensions": {
-            "nl.nldesignsystem.value-resolved-as": {
-              "alpha": 1,
-              "colorSpace": "srgb",
-              "components": [
-                0.10588235294117647,
-                0.34901960784313724,
-                0.6431372549019608
-              ]
-            }
-          },
-          "$type": "color",
-          "$value": "{basis.color.action-1.color-default}",
-          "key": "{basis.form-control.accent-color}"
-        },
-        "name": "accent-color",
-        "attributes": {},
-        "path": [
-          "basis",
-          "form-control",
-          "accent-color"
         ]
       },
       "background-color": {
@@ -19721,46 +19682,6 @@ exports[`Theme > can export to JSON token file 1`] = `
         ]
       },
       "active": {
-        "accent-color": {
-          "key": "{basis.form-control.active.accent-color}",
-          "$extensions": {
-            "nl.nldesignsystem.value-resolved-as": {
-              "alpha": 1,
-              "colorSpace": "srgb",
-              "components": [
-                0,
-                0.23137254901960785,
-                0.5058823529411764
-              ]
-            }
-          },
-          "$type": "color",
-          "$value": "#003b81",
-          "original": {
-            "$extensions": {
-              "nl.nldesignsystem.value-resolved-as": {
-                "alpha": 1,
-                "colorSpace": "srgb",
-                "components": [
-                  0,
-                  0.23137254901960785,
-                  0.5058823529411764
-                ]
-              }
-            },
-            "$type": "color",
-            "$value": "{basis.color.action-1.color-active}",
-            "key": "{basis.form-control.active.accent-color}"
-          },
-          "name": "accent-color",
-          "attributes": {},
-          "path": [
-            "basis",
-            "form-control",
-            "active",
-            "accent-color"
-          ]
-        },
         "background-color": {
           "key": "{basis.form-control.active.background-color}",
           "$extensions": {
@@ -19887,6 +19808,46 @@ exports[`Theme > can export to JSON token file 1`] = `
             "color"
           ]
         },
+        "accent-color": {
+          "key": "{basis.form-control.active.accent-color}",
+          "$type": "color",
+          "$value": "#003b81",
+          "$extensions": {
+            "nl.nldesignsystem.value-resolved-as": {
+              "alpha": 1,
+              "colorSpace": "srgb",
+              "components": [
+                0,
+                0.23137254901960785,
+                0.5058823529411764
+              ]
+            }
+          },
+          "original": {
+            "$type": "color",
+            "$value": "{basis.color.action-1.color-active}",
+            "$extensions": {
+              "nl.nldesignsystem.value-resolved-as": {
+                "alpha": 1,
+                "colorSpace": "srgb",
+                "components": [
+                  0,
+                  0.23137254901960785,
+                  0.5058823529411764
+                ]
+              }
+            },
+            "key": "{basis.form-control.active.accent-color}"
+          },
+          "name": "accent-color",
+          "attributes": {},
+          "path": [
+            "basis",
+            "form-control",
+            "active",
+            "accent-color"
+          ]
+        },
         "border-width": {
           "key": "{basis.form-control.active.border-width}",
           "$type": "dimension",
@@ -19921,46 +19882,6 @@ exports[`Theme > can export to JSON token file 1`] = `
         }
       },
       "disabled": {
-        "accent-color": {
-          "key": "{basis.form-control.disabled.accent-color}",
-          "$extensions": {
-            "nl.nldesignsystem.value-resolved-as": {
-              "alpha": 1,
-              "colorSpace": "srgb",
-              "components": [
-                0.9450980392156862,
-                0.9450980392156862,
-                0.9450980392156862
-              ]
-            }
-          },
-          "$type": "color",
-          "$value": "#f1f1f1",
-          "original": {
-            "$extensions": {
-              "nl.nldesignsystem.value-resolved-as": {
-                "alpha": 1,
-                "colorSpace": "srgb",
-                "components": [
-                  0.9450980392156862,
-                  0.9450980392156862,
-                  0.9450980392156862
-                ]
-              }
-            },
-            "$type": "color",
-            "$value": "{basis.color.disabled.bg-default}",
-            "key": "{basis.form-control.disabled.accent-color}"
-          },
-          "name": "accent-color",
-          "attributes": {},
-          "path": [
-            "basis",
-            "form-control",
-            "disabled",
-            "accent-color"
-          ]
-        },
         "background-color": {
           "key": "{basis.form-control.disabled.background-color}",
           "$extensions": {
@@ -20085,6 +20006,46 @@ exports[`Theme > can export to JSON token file 1`] = `
             "form-control",
             "disabled",
             "color"
+          ]
+        },
+        "accent-color": {
+          "key": "{basis.form-control.disabled.accent-color}",
+          "$type": "color",
+          "$value": "#f1f1f1",
+          "$extensions": {
+            "nl.nldesignsystem.value-resolved-as": {
+              "alpha": 1,
+              "colorSpace": "srgb",
+              "components": [
+                0.9450980392156862,
+                0.9450980392156862,
+                0.9450980392156862
+              ]
+            }
+          },
+          "original": {
+            "$type": "color",
+            "$value": "{basis.color.disabled.bg-default}",
+            "$extensions": {
+              "nl.nldesignsystem.value-resolved-as": {
+                "alpha": 1,
+                "colorSpace": "srgb",
+                "components": [
+                  0.9450980392156862,
+                  0.9450980392156862,
+                  0.9450980392156862
+                ]
+              }
+            },
+            "key": "{basis.form-control.disabled.accent-color}"
+          },
+          "name": "accent-color",
+          "attributes": {},
+          "path": [
+            "basis",
+            "form-control",
+            "disabled",
+            "accent-color"
           ]
         }
       },
@@ -20249,46 +20210,6 @@ exports[`Theme > can export to JSON token file 1`] = `
         }
       },
       "hover": {
-        "accent-color": {
-          "key": "{basis.form-control.hover.accent-color}",
-          "$extensions": {
-            "nl.nldesignsystem.value-resolved-as": {
-              "alpha": 1,
-              "colorSpace": "srgb",
-              "components": [
-                0.01568627450980392,
-                0.28627450980392155,
-                0.6039215686274509
-              ]
-            }
-          },
-          "$type": "color",
-          "$value": "#04499a",
-          "original": {
-            "$extensions": {
-              "nl.nldesignsystem.value-resolved-as": {
-                "alpha": 1,
-                "colorSpace": "srgb",
-                "components": [
-                  0.01568627450980392,
-                  0.28627450980392155,
-                  0.6039215686274509
-                ]
-              }
-            },
-            "$type": "color",
-            "$value": "{basis.color.action-1.color-hover}",
-            "key": "{basis.form-control.hover.accent-color}"
-          },
-          "name": "accent-color",
-          "attributes": {},
-          "path": [
-            "basis",
-            "form-control",
-            "hover",
-            "accent-color"
-          ]
-        },
         "background-color": {
           "key": "{basis.form-control.hover.background-color}",
           "$extensions": {
@@ -20413,6 +20334,46 @@ exports[`Theme > can export to JSON token file 1`] = `
             "form-control",
             "hover",
             "color"
+          ]
+        },
+        "accent-color": {
+          "key": "{basis.form-control.hover.accent-color}",
+          "$type": "color",
+          "$value": "#04499a",
+          "$extensions": {
+            "nl.nldesignsystem.value-resolved-as": {
+              "alpha": 1,
+              "colorSpace": "srgb",
+              "components": [
+                0.01568627450980392,
+                0.28627450980392155,
+                0.6039215686274509
+              ]
+            }
+          },
+          "original": {
+            "$type": "color",
+            "$value": "{basis.color.action-1.color-hover}",
+            "$extensions": {
+              "nl.nldesignsystem.value-resolved-as": {
+                "alpha": 1,
+                "colorSpace": "srgb",
+                "components": [
+                  0.01568627450980392,
+                  0.28627450980392155,
+                  0.6039215686274509
+                ]
+              }
+            },
+            "key": "{basis.form-control.hover.accent-color}"
+          },
+          "name": "accent-color",
+          "attributes": {},
+          "path": [
+            "basis",
+            "form-control",
+            "hover",
+            "accent-color"
           ]
         },
         "border-width": {
@@ -20780,6 +20741,45 @@ exports[`Theme > can export to JSON token file 1`] = `
           ]
         }
       },
+      "accent-color": {
+        "key": "{basis.form-control.accent-color}",
+        "$type": "color",
+        "$value": "#1b59a4",
+        "$extensions": {
+          "nl.nldesignsystem.value-resolved-as": {
+            "alpha": 1,
+            "colorSpace": "srgb",
+            "components": [
+              0.10588235294117647,
+              0.34901960784313724,
+              0.6431372549019608
+            ]
+          }
+        },
+        "original": {
+          "$type": "color",
+          "$value": "{basis.color.action-1.color-default}",
+          "$extensions": {
+            "nl.nldesignsystem.value-resolved-as": {
+              "alpha": 1,
+              "colorSpace": "srgb",
+              "components": [
+                0.10588235294117647,
+                0.34901960784313724,
+                0.6431372549019608
+              ]
+            }
+          },
+          "key": "{basis.form-control.accent-color}"
+        },
+        "name": "accent-color",
+        "attributes": {},
+        "path": [
+          "basis",
+          "form-control",
+          "accent-color"
+        ]
+      },
       "border-radius": {
         "key": "{basis.form-control.border-radius}",
         "$type": "dimension",
@@ -20983,41 +20983,6 @@ exports[`Theme > can export to JSON token file 1`] = `
       }
     },
     "heading": {
-      "font-family": {
-        "key": "{basis.heading.font-family}",
-        "$extensions": {
-          "studio.tokens": {
-            "originalType": "fontFamilies"
-          },
-          "nl.nldesignsystem.value-resolved-as": [
-            "IBM Plex Sans",
-            "sans-serif"
-          ]
-        },
-        "$type": "fontFamily",
-        "$value": "\\"IBM Plex Sans\\",sans-serif",
-        "original": {
-          "$extensions": {
-            "studio.tokens": {
-              "originalType": "fontFamilies"
-            },
-            "nl.nldesignsystem.value-resolved-as": [
-              "IBM Plex Sans",
-              "sans-serif"
-            ]
-          },
-          "$type": "fontFamily",
-          "$value": "{basis.text.font-family.default}",
-          "key": "{basis.heading.font-family}"
-        },
-        "name": "font-family",
-        "attributes": {},
-        "path": [
-          "basis",
-          "heading",
-          "font-family"
-        ]
-      },
       "color": {
         "key": "{basis.heading.color}",
         "$extensions": {
@@ -21059,10 +21024,43 @@ exports[`Theme > can export to JSON token file 1`] = `
           "color"
         ]
       },
+      "font-family": {
+        "key": "{basis.heading.font-family}",
+        "$extensions": {
+          "studio.tokens": {
+            "originalType": "fontFamilies"
+          },
+          "nl.nldesignsystem.value-resolved-as": [
+            "IBM Plex Sans",
+            "sans-serif"
+          ]
+        },
+        "$type": "fontFamily",
+        "$value": "\\"IBM Plex Sans\\",sans-serif",
+        "original": {
+          "$extensions": {
+            "studio.tokens": {
+              "originalType": "fontFamilies"
+            },
+            "nl.nldesignsystem.value-resolved-as": [
+              "IBM Plex Sans",
+              "sans-serif"
+            ]
+          },
+          "$type": "fontFamily",
+          "$value": "{basis.text.font-family.default}",
+          "key": "{basis.heading.font-family}"
+        },
+        "name": "font-family",
+        "attributes": {},
+        "path": [
+          "basis",
+          "heading",
+          "font-family"
+        ]
+      },
       "font-weight": {
         "key": "{basis.heading.font-weight}",
-        "$type": "fontWeight",
-        "$value": 700,
         "$extensions": {
           "studio.tokens": {
             "originalType": "fontWeights"
@@ -21070,9 +21068,9 @@ exports[`Theme > can export to JSON token file 1`] = `
           "nl.nldesignsystem.token-subtype": "font-weight",
           "nl.nldesignsystem.value-resolved-as": 700
         },
+        "$type": "fontWeight",
+        "$value": 700,
         "original": {
-          "$type": "fontWeight",
-          "$value": "{basis.text.font-weight.bold}",
           "$extensions": {
             "studio.tokens": {
               "originalType": "fontWeights"
@@ -21080,6 +21078,8 @@ exports[`Theme > can export to JSON token file 1`] = `
             "nl.nldesignsystem.token-subtype": "font-weight",
             "nl.nldesignsystem.value-resolved-as": 700
           },
+          "$type": "fontWeight",
+          "$value": "{basis.text.font-weight.bold}",
           "key": "{basis.heading.font-weight}"
         },
         "name": "font-weight",

--- a/packages/theme-wizard-website/e2e/validate-tokens.spec.ts
+++ b/packages/theme-wizard-website/e2e/validate-tokens.spec.ts
@@ -30,9 +30,10 @@ test.describe('interactive', () => {
   });
 
   test('Marks invalid files invalid', async ({ validateTokensPage }) => {
-    await validateTokensPage.selectFile(
-      JSON.stringify({ basis: { color: { 'box-shadow': { $type: 'color', $value: '#000000' } } } }),
-    );
+    const tokens = { basis: structuredClone(maTokens.basis) };
+    // @ts-expect-error We're doing something illegal here, so an error is expected
+    tokens.basis.color['box-shadow'] = { $type: 'color', $value: '#000000' };
+    await validateTokensPage.selectFile(JSON.stringify(tokens));
     await validateTokensPage.validate();
 
     await expect(validateTokensPage.resultOutput).toBeVisible();


### PR DESCRIPTION
- Maak alle basis-tokens (die we tot nu toe valideren!) verplicht ipv stilletjes toe te staan dat er basis-tokens missen
- Tests moeten updaten zodat ze nu een volledig pakket basis-tokens bevatten en voor testdoeleinden met `dset()` moedwillig een token instellen om te testen
- Handjevol test files aangepast om `dlv(result.data, 'basis.color.default.color-default')` te doen ipv `result.data?.basis?.color?.default?.['color-default']`. 
- Ook een handjevol andere tests aangepast om met `dset()` tokens in te stellen
- Bovenstaande levert ook een paar honderd regels 'winst' op: minder regels om te reviewen en het leest een _stuk_ makkelijker.

refs #756