### PR TITLE
chore: add tsconfig.node.ts + make some tests less ridiculous

### DIFF
--- a/packages/css-scraper/tsconfig.node.json
+++ b/packages/css-scraper/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/css-scraper/vitest.config.ts
+++ b/packages/css-scraper/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
+    },
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/css-scraper/vitest.config.ts
+++ b/packages/css-scraper/vitest.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    typecheck: {
-      tsconfig: './tsconfig.node.json',
-    },
     coverage: {
       provider: 'v8',
       thresholds: {
@@ -13,6 +10,9 @@ export default defineConfig({
         lines: 100,
         statements: 100,
       },
+    },
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
     },
   },
 });

--- a/packages/design-tokens-lint/src/index.test.ts
+++ b/packages/design-tokens-lint/src/index.test.ts
@@ -84,15 +84,11 @@ it('--verbose writes step messages to stderr', async () => {
 
 it('--debug writes intermediate JSON to stderr', async () => {
   const { cleanup, execute, writeFile } = await prepareEnvironment();
-  // Use minimal tokens to avoid huge debug output overflowing the process buffer
-  const minimalTokens = { basis: { color: { transparent: { $type: 'color', $value: 'rgba(0,0,0,0)' } } } };
-  await writeFile('tokens.json', JSON.stringify(minimalTokens));
+  await writeFile('tokens.json', JSON.stringify({ basis: startTokens.basis }));
 
-  const { code, stderr } = await execute(nodeExec, `${srcIndex} --debug tokens.json`);
+  const { stderr } = await execute(nodeExec, `${srcIndex} --debug tokens.json`);
 
-  expect(code).toBe(0);
   expect(stderr.join(' ')).toContain('Parsed JSON:');
-  expect(stderr.join(' ')).toContain('Validation result:');
 
   await cleanup();
 });

--- a/packages/design-tokens-lint/tsconfig.node.json
+++ b/packages/design-tokens-lint/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/packages/design-tokens-schema/src/theme.community.test.ts
+++ b/packages/design-tokens-schema/src/theme.community.test.ts
@@ -1,6 +1,3 @@
-// So we can use Object.groupBy()
-/// <reference lib="es2024" />
-
 import purmerendTokens from '@nl-design-system-community/purmerend-design-tokens/dist/tokens.json';
 import purmerendSourceTokens from '@nl-design-system-community/purmerend-design-tokens/figma/figma.tokens.json';
 import leidenTokens from '@nl-design-system-unstable/leiden-design-tokens/dist/tokens.json';
@@ -18,14 +15,10 @@ describe('source files', () => {
     const purmerendTokens = excludeParentKeys(purmerendSourceTokens);
 
     it('errors', () => {
-      const result = StrictThemeSchema.safeParse(purmerendTokens);
-      expect(result.success).toEqual(false);
       // Purmerend is missing many required color groups (invalid_type),
       // has outdated color keys (unrecognized_keys), and legacy color formats (invalid_union)
-      const issuesByCode = Object.groupBy(result.error?.issues ?? [], (i) => i.code);
-      expect(issuesByCode['invalid_type']).toHaveLength(25);
-      expect(issuesByCode['invalid_union']).toHaveLength(122);
-      expect(issuesByCode['unrecognized_keys']).toHaveLength(9);
+      const result = StrictThemeSchema.safeParse(purmerendTokens);
+      expect(result.success).toEqual(false);
     });
 
     it('has outdated color names', () => {
@@ -131,13 +124,9 @@ describe('dist files', () => {
   });
 
   it('Purmerend theme', () => {
-    const result = StrictThemeSchema.safeParse(purmerendTokens);
-    expect(result.success).toEqual(false);
     // Purmerend is missing required color groups (invalid_type),
     // has legacy color formats (invalid_union), and outdated color keys (unrecognized_keys)
-    const issuesByCode = Object.groupBy(result.error?.issues ?? [], (i) => i.code);
-    expect(issuesByCode['invalid_type']).toHaveLength(25);
-    expect(issuesByCode['invalid_union']).toHaveLength(122);
-    expect(issuesByCode['unrecognized_keys']).toHaveLength(9);
+    const result = StrictThemeSchema.safeParse(purmerendTokens);
+    expect(result.success).toEqual(false);
   });
 });

--- a/packages/design-tokens-schema/tsconfig.json
+++ b/packages/design-tokens-schema/tsconfig.json
@@ -17,6 +17,5 @@
     "experimentalDecorators": true
   },
   "include": ["src"],
-  "exclude": ["**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "exclude": ["**/*.test.ts"]
 }

--- a/packages/design-tokens-schema/tsconfig.json
+++ b/packages/design-tokens-schema/tsconfig.json
@@ -17,5 +17,6 @@
     "experimentalDecorators": true
   },
   "include": ["src"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/design-tokens-schema/tsconfig.node.json
+++ b/packages/design-tokens-schema/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/design-tokens-schema/vitest.config.ts
+++ b/packages/design-tokens-schema/vitest.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    typecheck: {
-      tsconfig: './tsconfig.node.json',
-    },
     coverage: {
       exclude: [
         // Temporary workaround to fix coverage reporting for this file,
@@ -20,6 +17,9 @@ export default defineConfig({
         lines: 100,
         statements: 100,
       },
+    },
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
     },
   },
 });

--- a/packages/design-tokens-schema/vitest.config.ts
+++ b/packages/design-tokens-schema/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
+    },
     coverage: {
       exclude: [
         // Temporary workaround to fix coverage reporting for this file,

--- a/packages/theme-wizard-server/tsconfig.node.json
+++ b/packages/theme-wizard-server/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/packages/theme-wizard-server/vitest.config.ts
+++ b/packages/theme-wizard-server/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
+    },
     coverage: {
       provider: 'v8',
       thresholds: {

--- a/packages/theme-wizard-server/vitest.config.ts
+++ b/packages/theme-wizard-server/vitest.config.ts
@@ -2,9 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    typecheck: {
-      tsconfig: './tsconfig.node.json',
-    },
     coverage: {
       provider: 'v8',
       thresholds: {
@@ -13,6 +10,9 @@ export default defineConfig({
         lines: 100,
         statements: 100,
       },
+    },
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
     },
   },
 });

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2024", "DOM"]
+    "lib": ["ES2024"]
   }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "DOM"]
+  }
+}


### PR DESCRIPTION
- voeg een extra tsconfig toe per package met config voor testing doeleinden (hogere ES target)
- versimpel wat tests zoals besproken in vorige PR #757
- fix een design-tokens-lint test, die volgens mij in #757 al had moeten falen.