### PR TITLE
ci: rename Issues environment to Maintenance

### DIFF
--- a/.github/workflows/periodic-e2e.yml
+++ b/.github/workflows/periodic-e2e.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   test-e2e:
     runs-on: ubuntu-latest
-    environment: Issues
+    environment: Maintenance
     permissions:
       contents: read
 
@@ -73,7 +73,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     needs: test-e2e
-    environment: Issues
+    environment: Maintenance
     permissions:
       contents: read
 


### PR DESCRIPTION
This name is more suitable for its purpose.

Note: https://github.com/nl-design-system/terraform/pull/616 needs to be merged first.

And then the environment secrets `ADD_TO_PROJECT_GITHUB_TOKEN` and `SLACK_BOT_TOKEN` need to be moved.  Unfortunately I didn't realize environments [couldn't be renamed](https://github.com/orgs/community/discussions/64081) otherwise I wouldn't have bothered with this.  Ping me when this is merged.
