### PR TITLE
Optie om extra HTTP headers aan de CSS scraper mee te geven

### DIFF
--- a/packages/css-scraper/src/get-css.test.ts
+++ b/packages/css-scraper/src/get-css.test.ts
@@ -1,6 +1,14 @@
 import { expect, describe, vi, beforeEach, Mock, it } from 'vitest';
 import { ForbiddenError, NotFoundError, ConnectionRefusedError, InvalidUrlError, TimeoutError } from './errors';
-import { getCssFromHtml, getImportUrls, getCssFile, getCssResources, getCss, getDesignTokens } from './get-css';
+import {
+  getCssFromHtml,
+  getImportUrls,
+  getCssFile,
+  getCssResources,
+  getCss,
+  getDesignTokens,
+  USER_AGENT,
+} from './get-css';
 
 const CSS_FILE_REPONSE_MOCK = {
   headers: new Headers({ 'Content-Type': 'text/css' }),
@@ -293,7 +301,7 @@ describe('getCss', () => {
 
     const callArgs = (fetch as Mock).mock.calls[0];
     expect((callArgs[0] as URL).href).toBe('https://example.com/style.css');
-    expect(callArgs[1].headers['User-Agent']).toBe(customUserAgent);
+    expect((callArgs[1].headers as Headers).get('User-Agent')).toBe(customUserAgent);
   });
 
   it('accepts custom timeout option', async () => {
@@ -324,7 +332,7 @@ describe('getCss', () => {
 
     const callArgs = (fetch as Mock).mock.calls[0];
     expect((callArgs[0] as URL).href).toBe('https://example.com/style.css');
-    expect(callArgs[1].headers['User-Agent']).toBe(customUserAgent);
+    expect((callArgs[1].headers as Headers).get('User-Agent')).toBe(customUserAgent);
   });
 
   it('uses default user agent when no custom option is provided', async () => {
@@ -333,7 +341,7 @@ describe('getCss', () => {
 
     const callArgs = (fetch as Mock).mock.calls[0];
     expect((callArgs[0] as URL).href).toBe('https://example.com/style.css');
-    expect(callArgs[1].headers['User-Agent']).toBe('NL Design System CSS Scraper/1.0');
+    expect((callArgs[1].headers as Headers).get('User-Agent')).toBe('NL Design System CSS Scraper/1.0');
   });
 
   it('respects custom user agent in linked stylesheets', async () => {
@@ -364,11 +372,35 @@ describe('getCss', () => {
 
     // First call should be the HTML fetch with custom user agent
     const firstCall = (fetch as Mock).mock.calls[0];
-    expect(firstCall[1].headers['User-Agent']).toBe(customUserAgent);
+    expect((firstCall[1].headers as Headers).get('User-Agent')).toBe(customUserAgent);
 
     // Second call should be the CSS file fetch with custom user agent
     const secondCall = (fetch as Mock).mock.calls[1];
-    expect(secondCall[1].headers['User-Agent']).toBe(customUserAgent);
+    expect((secondCall[1].headers as Headers).get('User-Agent')).toBe(customUserAgent);
+  });
+
+  it('passes extraHeaders to fetch', async () => {
+    (fetch as Mock).mockResolvedValueOnce(CSS_FILE_REPONSE_MOCK);
+    await getCss('https://example.com/style.css', { extraHeaders: { 'X-Custom': 'value' } });
+    const callArgs = (fetch as Mock).mock.calls[0];
+    expect((callArgs[1].headers as Headers).get('X-Custom')).toBe('value');
+  });
+
+  it('extraHeaders User-Agent overrides deprecated userAgent option', async () => {
+    (fetch as Mock).mockResolvedValueOnce(CSS_FILE_REPONSE_MOCK);
+    await getCss('https://example.com/style.css', {
+      extraHeaders: { 'User-Agent': 'New Agent/2.0' },
+      userAgent: 'Old Agent/1.0',
+    });
+    const callArgs = (fetch as Mock).mock.calls[0];
+    expect((callArgs[1].headers as Headers).get('User-Agent')).toBe('New Agent/2.0');
+  });
+
+  it('accepts a Headers instance as extraHeaders', async () => {
+    (fetch as Mock).mockResolvedValueOnce(CSS_FILE_REPONSE_MOCK);
+    await getCss('https://example.com/style.css', { extraHeaders: new Headers({ 'X-Token': 'abc' }) });
+    const callArgs = (fetch as Mock).mock.calls[0];
+    expect((callArgs[1].headers as Headers).get('X-Token')).toBe('abc');
   });
 });
 
@@ -701,11 +733,6 @@ describe('getCssFile', () => {
     vi.clearAllMocks();
   });
 
-  const REQUEST_HEADERS = {
-    Accept: 'text/css,*/*;q=0.1',
-    'User-Agent': 'NL Design System CSS Scraper/1.0',
-  };
-
   it('fetches CSS content successfully', async () => {
     const mockResponse = 'body { margin: 0; }';
     (fetch as Mock).mockResolvedValueOnce({
@@ -715,10 +742,10 @@ describe('getCssFile', () => {
 
     const controller = new AbortController();
     const result = await getCssFile('http://example.com/style.css', controller.signal);
-    expect(fetch).toHaveBeenCalledWith('http://example.com/style.css', {
-      headers: REQUEST_HEADERS,
-      signal: controller.signal,
-    });
+    const callArgs = (fetch as Mock).mock.calls[0];
+    const headers = callArgs[1].headers as Headers;
+    expect(headers.get('Accept')).toBe('text/css,*/*;q=0.1');
+    expect(headers.get('User-Agent')).toBe('NL Design System CSS Scraper/1.0');
     expect(result).toEqual(mockResponse);
   });
 
@@ -740,6 +767,14 @@ describe('getCssFile', () => {
 
     const result = await getCssFile('http://example.com/style.css', controller.signal);
     expect(result).toEqual('');
+  });
+
+  it('sends extraHeaders in the request', async () => {
+    (fetch as Mock).mockResolvedValueOnce({ ok: true, text: async () => '' });
+    const controller = new AbortController();
+    await getCssFile('http://example.com/style.css', controller.signal, USER_AGENT, { 'X-Custom': 'value' });
+    const headers = (fetch as Mock).mock.calls[0][1].headers as Headers;
+    expect(headers.get('X-Custom')).toBe('value');
   });
 });
 

--- a/packages/css-scraper/src/get-css.ts
+++ b/packages/css-scraper/src/get-css.ts
@@ -19,6 +19,7 @@ import {
 import { resolveUrl } from './resolve-url.js';
 import { isWaybackUrl, removeWaybackToolbar } from './strip-wayback.js';
 
+// IMPORTANT: When updating this, we need to inform other parties involved about this change.
 export const USER_AGENT = 'NL Design System CSS Scraper/1.0';
 
 const unquote = (input: string = ''): string => {

--- a/packages/css-scraper/src/get-css.ts
+++ b/packages/css-scraper/src/get-css.ts
@@ -70,13 +70,23 @@ const handleFetchError = (error: unknown, url: UrlLike, timeout: number) => {
   }
 };
 
-export const getCssFile = async (url: string | URL, abortSignal: AbortSignal, userAgent: string = USER_AGENT) => {
+export const getCssFile = async (
+  url: string | URL,
+  abortSignal: AbortSignal,
+  userAgent: string = USER_AGENT,
+  extraHeaders: HeadersInit = {},
+) => {
   try {
+    const headers = new Headers({
+      Accept: 'text/css,*/*;q=0.1',
+      'User-Agent': userAgent,
+    });
+    // We allow User-Agent to be overridden here, because we want people to use extraHeaders instead of userAgent
+    for (const [key, value] of new Headers(extraHeaders)) {
+      headers.set(key, value);
+    }
     const response = await fetch(url, {
-      headers: {
-        Accept: 'text/css,*/*;q=0.1',
-        'User-Agent': userAgent,
-      },
+      headers,
       // If aborted early try to return an empty string so we can continue with just the content we have
       signal: abortSignal,
     });
@@ -176,14 +186,18 @@ export const getCssFromHtml = (
   return resources;
 };
 
-const fetchHtml = async (url: string | URL, signal: AbortSignal, userAgent: string = USER_AGENT) => {
-  const response = await fetch(url, {
-    headers: {
-      Accept: 'text/html,*/*;q=0.1',
-      'User-Agent': userAgent,
-    },
-    signal,
-  });
+const fetchHtml = async (
+  url: string | URL,
+  signal: AbortSignal,
+  /** @deprecated use extraHeaders to set the user agent */
+  userAgent: string = USER_AGENT,
+  extraHeaders: HeadersInit = {},
+) => {
+  const headers = new Headers({ Accept: 'text/html,*/*;q=0.1', 'User-Agent': userAgent });
+  for (const [key, value] of new Headers(extraHeaders)) {
+    headers.set(key, value);
+  }
+  const response = await fetch(url, { headers, signal });
 
   if (!response.ok) {
     throw new Error(response.statusText);
@@ -199,19 +213,20 @@ const processResources = async (
   resources: (PartialCSSLinkResource | CSSLinkResource | CSSStyleTagResource | CSSInlineStyleResource)[],
   abortSignal: AbortSignal,
   userAgent: string = USER_AGENT,
+  extraHeaders: HeadersInit = {},
 ) => {
   const result: (CSSLinkResource | CSSImportResource | CSSStyleTagResource | CSSInlineStyleResource)[] = [];
 
   for (const resource of resources) {
     if (resource.type === 'link' && !resource.css) {
-      resource.css = await getCssFile(resource.url, abortSignal, userAgent);
+      resource.css = await getCssFile(resource.url, abortSignal, userAgent, extraHeaders);
       result.push(resource as CSSLinkResource);
     } else {
       result.push(resource);
     }
 
     for (const importUrl of getImportUrls(resource.css as string)) {
-      const css = await getCssFile(importUrl, abortSignal, userAgent);
+      const css = await getCssFile(importUrl, abortSignal, userAgent, extraHeaders);
       result.push({
         css,
         href: importUrl,
@@ -224,9 +239,16 @@ const processResources = async (
   return result;
 };
 
+export interface GetCssOptions {
+  extraHeaders?: HeadersInit;
+  timeout?: number;
+  /** @deprecated Use `extraHeaders` with the `User-Agent` key instead. */
+  userAgent?: string;
+}
+
 export const getCssResources = async (
   url: string,
-  { timeout = 10000, userAgent = USER_AGENT } = {},
+  { extraHeaders = {}, timeout = 10000, userAgent = USER_AGENT }: GetCssOptions = {},
 ): Promise<CSSResource[]> => {
   const resolvedUrl = resolveUrl(url);
 
@@ -237,7 +259,7 @@ export const getCssResources = async (
   const signal = AbortSignal.timeout(timeout);
 
   try {
-    const response = await fetchHtml(resolvedUrl, signal, userAgent);
+    const response = await fetchHtml(resolvedUrl, signal, userAgent, extraHeaders);
     let body = response.body;
 
     if (response.contentType?.includes('text/css')) {
@@ -255,22 +277,18 @@ export const getCssResources = async (
     }
 
     const resources = getCssFromHtml(body, resolvedUrl);
-    return processResources(resources, signal, userAgent);
+    return processResources(resources, signal, userAgent, extraHeaders);
   } catch (error: unknown) {
     handleFetchError(error, resolvedUrl, timeout);
     return [];
   }
 };
 
-export { ScrapingError } from './errors.js';
-
-export const getCss = async (
-  url: string,
-  { timeout, userAgent }: { timeout?: number; userAgent?: string } = {},
-): Promise<string> => {
-  const resources = await getCssResources(url, { timeout, userAgent });
+export const getCss = async (url: string, options: GetCssOptions = {}): Promise<string> => {
+  const resources = await getCssResources(url, options);
   return resources.map(({ css }) => css).join('');
 };
 
 export * from './design-tokens.js';
+export { ScrapingError } from './errors.js';
 export { resolveUrl } from './resolve-url.js';

--- a/packages/theme-wizard-server/src/index.test.ts
+++ b/packages/theme-wizard-server/src/index.test.ts
@@ -1,5 +1,5 @@
 import * as cssScraper from '@nl-design-system-community/css-scraper';
-import { it, expect, describe, vi, beforeEach } from 'vitest';
+import { it, expect, describe, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('@vercel/related-projects', () => ({
   withRelatedProject: vi.fn(),
@@ -122,6 +122,33 @@ describe('/api/v1', () => {
 
       const poweredBy = response.headers.get('X-Powered-By');
       expect.soft(poweredBy).toBeNull();
+    });
+  });
+
+  describe('OPEN_ONLINE_TOKEN', () => {
+    const endpoints = ['/api/v1/css', '/api/v1/css-design-tokens'];
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      delete process.env['OPEN_ONLINE_TOKEN'];
+    });
+
+    it.each(endpoints)('sends X-Theme-Wizard-Token header when env var is set (%s)', async (endpoint) => {
+      process.env['OPEN_ONLINE_TOKEN'] = 'my-token';
+      const spy = vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
+      await app.request(`${endpoint}?url=example.com`);
+      const extraHeaders = spy.mock.calls[0][1]?.extraHeaders as Headers;
+      expect(extraHeaders.get('X-Theme-Wizard-Token')).toBe('my-token');
+    });
+
+    it.each(endpoints)('omits X-Theme-Wizard-Token header when env var is not set (%s)', async (endpoint) => {
+      const spy = vi.spyOn(cssScraper, 'getCss').mockResolvedValueOnce(mockedGetCssData);
+      await app.request(`${endpoint}?url=example.com`);
+      const extraHeaders = spy.mock.calls[0][1]?.extraHeaders as Headers;
+      expect(extraHeaders.get('X-Theme-Wizard-Token')).toBeNull();
     });
   });
 

--- a/packages/theme-wizard-server/src/index.ts
+++ b/packages/theme-wizard-server/src/index.ts
@@ -19,6 +19,9 @@ import { clientErrorSchema } from './schemas/client-error.js';
 import { type ServerError, serverErrorSchema } from './schemas/server-error.js';
 import { withScrapingErrorHandler } from './scraping-error-handler.js';
 
+const OPEN_ONLINE_TOKEN = 'OPEN_ONLINE_TOKEN';
+const X_THEME_WIZARD_TOKEN_HEADER_NAME = 'X-Theme-Wizard-Token';
+
 // This tricks Vercel into deploying this as a HonoJS app
 /* @__PURE__ */ import('hono');
 
@@ -125,7 +128,11 @@ app.openapi(
     const url = c.req.query('url')!;
 
     startTime(c, 'scraping', 'Scraping CSS');
-    const css = await getCss(url);
+    const extraHeaders = new Headers();
+    if (process.env[OPEN_ONLINE_TOKEN]) {
+      extraHeaders.set(X_THEME_WIZARD_TOKEN_HEADER_NAME, process.env[OPEN_ONLINE_TOKEN]);
+    }
+    const css = await getCss(url, { extraHeaders });
     endTime(c, 'scraping');
 
     c.res.headers.set('content-type', 'text/css; charset=utf-8');
@@ -193,7 +200,11 @@ app.openapi(
     const url = c.req.query('url')!;
 
     startTime(c, 'scraping', 'Scraping CSS');
-    const css = await getCss(url);
+    const extraHeaders = new Headers();
+    if (process.env[OPEN_ONLINE_TOKEN]) {
+      extraHeaders.set(X_THEME_WIZARD_TOKEN_HEADER_NAME, process.env[OPEN_ONLINE_TOKEN]);
+    }
+    const css = await getCss(url, { extraHeaders });
     const tokens = getDesignTokens(css);
     endTime(c, 'scraping');
 


### PR DESCRIPTION
- voeg `extraHeaders` optie toe aan `getCss()` en onderliggende functies om custom HTTP headers mee te kunnen sturen
- maak `userAgent` optie deprecated: met `extraHeaders` kunnen we hetzelfde bereiken
- laat theme-wizard-server op runtime een `X-Theme-Wizard-Token` header meegeven aan de scraper, mits environment variable `'OPEN_ONLINE_TOKEN'` gevuld is.

refs #762