### PR TITLE
chore: refactor validated tokens download button to `<a download="">`

### DIFF
--- a/packages/theme-wizard-app/src/components/wizard-token-validation-form/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-validation-form/index.ts
@@ -59,19 +59,8 @@ export class WizardTokenValidationForm extends LitElement {
       : { error: parsed.error.issues, success: false };
   };
 
-  private readonly downloadTokens = () => {
-    if (!this.result?.success) return;
-    const data = this.result.data;
-    const encoded = encodeURIComponent(JSON.stringify(data));
-    const href = `data:application/json,${encoded}`;
-    const anchor = document.createElement('a');
-    anchor.download = 'tokens.json';
-    anchor.href = href;
-    anchor.click();
-    anchor.remove();
-  };
-
   private renderResult(result: Exclude<Result, null>) {
+    const json = JSON.stringify(result.success ? result.data : result.error, null, 2);
     return html`
       <output>
         <div
@@ -95,16 +84,20 @@ export class WizardTokenValidationForm extends LitElement {
               id="validation-result"
               aria-describedby="validation-error-msg"
               aria-invalid=${result.success ? nothing : true}
-              .value=${JSON.stringify(result.success ? result.data : result.error, null, 2)}
+              .value=${json}
             ></textarea>
           </div>
         </div>
       </output>
       ${result.success
         ? html`
-            <button type="button" class="nl-button nl-button--secondary" @click=${this.downloadTokens}>
+            <a
+              href=${`data:application/json;charset=utf-8,${encodeURIComponent(json)}`}
+              download="tokens.json"
+              class="nl-button nl-button--secondary"
+            >
               ${t('tokenValidationForm.downloadTokens')}
-            </button>
+            </a>
           `
         : nothing}
     `;

--- a/packages/theme-wizard-website/e2e/pages/ValidateTokensPage.ts
+++ b/packages/theme-wizard-website/e2e/pages/ValidateTokensPage.ts
@@ -28,7 +28,7 @@ export class ValidateTokensPage {
   }
 
   get downloadButton(): Locator {
-    return this.page.getByRole('button', { name: 'Download thema (JSON)' });
+    return this.page.getByRole('link', { name: 'Download thema (JSON)' });
   }
 
   async selectFile(contents: string) {


### PR DESCRIPTION
- replace `<button>` with JS-only behaviour with a plain `<a href="data:" download="">` link
- less code, less brittle, more web standards
- allows to CMD/Shift click to skip download and view in new window (nice affordance in firefox to look at the JSON with the built-in JSON tree viewer)
- couldn't replace other wizard download buttons because they're tied to the wizard-dialog logic of confirm/cancel behaviour