### PR TITLE
Functies voor `reuseBasisTokens` en `findReusableCandidates` toegevoegd

### DIFF
--- a/packages/design-tokens-schema/src/index.ts
+++ b/packages/design-tokens-schema/src/index.ts
@@ -10,6 +10,7 @@ export * from './basis-tokens';
 export * from './extensions';
 export * from './remove-non-token-properties';
 export * from './resolve-refs';
+export * from './reuse-tokens';
 export * from './theme';
 export * from './upgrade-legacy-tokens';
 export * from './walker';

--- a/packages/design-tokens-schema/src/reuse-tokens.test.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+import { applyReusableCandidates, findReusableCandidates, reuseBasisTokens } from './reuse-tokens';
+import { EXTENSION_TOKEN_SUBTYPE } from './upgrade-legacy-tokens';
+
+const SUBTYPE = EXTENSION_TOKEN_SUBTYPE;
+
+const createDimensionToken = (value: number, unit: string, subtype: string) => ({
+  $extensions: { [SUBTYPE]: subtype },
+  $type: 'dimension',
+  $value: { unit, value },
+});
+
+const basisToken = (value: number, unit: string, subtype: string) => createDimensionToken(value, unit, subtype);
+
+describe('findReusableCandidates', () => {
+  it('returns empty when no basis tokens', () => {
+    const theme = {
+      utrecht: { button: { 'padding-block': createDimensionToken(4, 'px', 'space-block') } },
+    };
+    expect(findReusableCandidates(theme)).toEqual([]);
+  });
+
+  it('returns empty when component token is already a ref', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: {
+        button: {
+          'padding-block': {
+            $extensions: { [SUBTYPE]: 'space-block' },
+            $type: 'dimension',
+            $value: '{basis.space.block.xs}',
+          },
+        },
+      },
+    };
+    expect(findReusableCandidates(theme)).toEqual([]);
+  });
+
+  it('returns empty when component token has no subtype', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: {
+        button: {
+          'padding-block': { $type: 'dimension', $value: { unit: 'px', value: 4 } },
+        },
+      },
+    };
+    expect(findReusableCandidates(theme)).toEqual([]);
+  });
+
+  it('returns empty when value does not match any basis token', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: { button: { 'padding-block': createDimensionToken(8, 'px', 'space-block') } },
+    };
+    expect(findReusableCandidates(theme)).toEqual([]);
+  });
+
+  it('returns empty when subtype does not match', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: { button: { 'padding-inline': createDimensionToken(4, 'px', 'space-inline') } },
+    };
+    expect(findReusableCandidates(theme)).toEqual([]);
+  });
+
+  it('finds a matching component token', () => {
+    const basisXs = basisToken(4, 'px', 'space-block');
+    const componentToken = createDimensionToken(4, 'px', 'space-block');
+    const theme = {
+      basis: { space: { block: { xs: basisXs } } },
+      utrecht: { button: { 'padding-block': componentToken } },
+    };
+
+    const candidates = findReusableCandidates(theme);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      path: ['utrecht', 'button', 'padding-block'],
+      suggestion: {
+        path: ['basis', 'space', 'block', 'xs'],
+      },
+    });
+    expect(candidates[0].suggestion.token).toBe(basisXs);
+    expect(candidates[0].token).toBe(componentToken);
+    expect(candidates[0].token.$value).toEqual(basisXs.$value);
+  });
+
+  it('finds multiple component tokens matching the same basis token', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: {
+        button: { 'padding-block': createDimensionToken(4, 'px', 'space-block') },
+        link: { 'padding-block': createDimensionToken(4, 'px', 'space-block') },
+      },
+    };
+
+    const candidates = findReusableCandidates(theme);
+    expect(candidates).toHaveLength(2);
+  });
+
+  it('returns first basis token when multiple basis tokens share same subtype+value', () => {
+    const theme = {
+      basis: {
+        space: {
+          block: {
+            none: basisToken(0, 'px', 'border-radius'),
+            xs: basisToken(0, 'px', 'border-radius'),
+          },
+        },
+      },
+      utrecht: { button: { 'border-radius': createDimensionToken(0, 'px', 'border-radius') } },
+    };
+
+    const candidates = findReusableCandidates(theme);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].suggestion.path).toEqual(['basis', 'space', 'block', 'none']);
+  });
+
+  it('finds a matching color token', () => {
+    const colorValue = { colorSpace: 'srgb', components: [0.2, 0.4, 0.6] };
+    const basisColor = { $extensions: { [SUBTYPE]: 'background-color' }, $type: 'color', $value: colorValue };
+    const componentColor = { $extensions: { [SUBTYPE]: 'background-color' }, $type: 'color', $value: colorValue };
+    const theme = {
+      basis: { color: { action: { basisColor } } },
+      utrecht: { button: { color: componentColor } },
+    };
+
+    const candidates = findReusableCandidates(theme);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].path).toEqual(['utrecht', 'button', 'color']);
+    expect(candidates[0].suggestion.path).toEqual(['basis', 'color', 'action', 'basisColor']);
+  });
+
+  it('finds a matching font-family token', () => {
+    const fontFamilyValue = ['Arial', 'sans-serif'];
+    const basisFontFamily = { $type: 'fontFamily', $value: fontFamilyValue };
+    const componentFontFamily = { $type: 'fontFamily', $value: fontFamilyValue };
+    const theme = {
+      basis: { 'font-family': { sans: basisFontFamily } },
+      utrecht: { button: { 'font-family': componentFontFamily } },
+    };
+
+    const candidates = findReusableCandidates(theme);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].path).toEqual(['utrecht', 'button', 'font-family']);
+    expect(candidates[0].suggestion.path).toEqual(['basis', 'font-family', 'sans']);
+  });
+
+  it('ignores basis tokens whose $value is a ref', () => {
+    const theme = {
+      basis: {
+        space: {
+          block: {
+            alias: { $extensions: { [SUBTYPE]: 'space-block' }, $type: 'dimension', $value: '{basis.space.block.xs}' },
+            xs: basisToken(4, 'px', 'space-block'),
+          },
+        },
+      },
+      utrecht: { button: { 'padding-block': createDimensionToken(4, 'px', 'space-block') } },
+    };
+
+    const candidates = findReusableCandidates(theme);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].suggestion.path).toEqual(['basis', 'space', 'block', 'xs']);
+  });
+
+  it('does not return basis tokens themselves as candidates', () => {
+    const theme = {
+      basis: {
+        space: {
+          block: {
+            sm: basisToken(4, 'px', 'space-block'),
+            xs: basisToken(4, 'px', 'space-block'),
+          },
+        },
+      },
+    };
+    expect(findReusableCandidates(theme)).toEqual([]);
+  });
+});
+
+describe('applyReusableCandidates', () => {
+  it('replaces $value with a ref for each candidate', () => {
+    const basisXs = basisToken(4, 'px', 'space-block');
+    const componentToken = createDimensionToken(4, 'px', 'space-block');
+    const theme = {
+      basis: { space: { block: { xs: basisXs } } },
+      utrecht: { button: { 'padding-block': componentToken } },
+    };
+
+    const candidates = findReusableCandidates(theme);
+    const result = applyReusableCandidates(theme, candidates);
+
+    expect(result['utrecht']).toMatchObject({
+      button: { 'padding-block': { $value: '{basis.space.block.xs}' } },
+    });
+  });
+
+  it('does not mutate the input', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: { button: { 'padding-block': createDimensionToken(4, 'px', 'space-block') } },
+    };
+    const candidates = findReusableCandidates(theme);
+    applyReusableCandidates(theme, candidates);
+
+    expect(theme.utrecht.button['padding-block'].$value).toEqual({ unit: 'px', value: 4 });
+  });
+
+  it('returns input unchanged when candidates is empty', () => {
+    const theme = { utrecht: { button: { 'padding-block': createDimensionToken(4, 'px', 'space-block') } } };
+    const result = applyReusableCandidates(theme, []);
+    expect(result).toEqual(theme);
+  });
+});
+
+describe('reuseBasisTokens', () => {
+  it('returns input unchanged when no matches exist', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: { button: { 'padding-block': createDimensionToken(8, 'px', 'space-block') } },
+    };
+
+    expect(reuseBasisTokens(theme)).toEqual(theme);
+  });
+
+  it('replaces hardcoded values with basis refs end-to-end', () => {
+    const theme = {
+      basis: { space: { block: { xs: basisToken(4, 'px', 'space-block') } } },
+      utrecht: { button: { 'padding-block': createDimensionToken(4, 'px', 'space-block') } },
+    };
+
+    const result = reuseBasisTokens(theme);
+
+    expect(result['utrecht']).toMatchObject({
+      button: { 'padding-block': { $value: '{basis.space.block.xs}' } },
+    });
+  });
+});

--- a/packages/design-tokens-schema/src/reuse-tokens.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.ts
@@ -1,0 +1,111 @@
+/**
+ * Basis token reuse — find and apply replacement suggestions.
+ *
+ * Component tokens with hard-coded values (e.g. `{ value: 4, unit: 'px' }`) that
+ * match a basis token should instead reference it (`{basis.space.block.xs}`), so
+ * the component inherits future basis scale changes automatically.
+ *
+ * **Pre-condition:** input must have passed through `preprocessThemeStrict()` —
+ * refs resolved, legacy formats upgraded, subtypes assigned.
+ *
+ * **Matching:** two tokens are equivalent when their *match key* and `$value` agree.
+ * The match key is `EXTENSION_TOKEN_SUBTYPE` when set (more specific than `$type`
+ * alone — a `'space-block'` and a `'font-size'` dimension must never be swapped),
+ * falling back to `$type` for types that never receive a subtype (e.g. `fontFamily`).
+ * When multiple basis tokens share the same key + value, the first walk-order hit wins.
+ */
+
+import { dequal } from 'dequal';
+import { dset } from 'dset';
+import { BaseDesignToken, TokenPath } from './tokens/base-token';
+import { isRef, createReference } from './tokens/token-reference';
+import { EXTENSION_TOKEN_SUBTYPE } from './upgrade-legacy-tokens';
+import { walkTokens } from './walker';
+
+/**
+ * A component token paired with the basis token it could reference instead.
+ * `path` / `suggestion.path` are absolute paths in the tree.
+ */
+type TokenCandidate = {
+  path: TokenPath;
+  token: BaseDesignToken;
+  suggestion: {
+    path: TokenPath;
+    token: BaseDesignToken;
+  };
+};
+
+/** Basis token with its absolute path, used as the candidate pool. */
+type BasisEntry = { path: TokenPath; token: BaseDesignToken };
+
+/** Subtype when set, otherwise `$type` as fallback (e.g. for `fontFamily`). */
+const matchKey = (token: BaseDesignToken): string =>
+  (token.$extensions?.[EXTENSION_TOKEN_SUBTYPE] as string | undefined) ?? token.$type;
+
+/** Collects all basis tokens with resolved (non-ref) values into a flat list. */
+const collectBasisTokens = (root: Record<string, unknown>): BasisEntry[] => {
+  const entries: BasisEntry[] = [];
+  const basis = root['basis'];
+  if (!basis || typeof basis !== 'object') return entries;
+
+  walkTokens(basis, (token, path) => {
+    if (isRef(token.$value)) {
+      return; // do not attempt to re-use refs
+    }
+    entries.push({ path: ['basis', ...path], token });
+  });
+
+  return entries;
+};
+
+/**
+ * Returns component tokens whose hard-coded `$value` matches a basis token.
+ * Skips basis-namespace tokens and tokens whose `$value` is already a reference.
+ * Does not mutate `tokens`.
+ */
+export const findReusableCandidates = (tokens: Record<string, unknown>): TokenCandidate[] => {
+  const basisEntries = collectBasisTokens(tokens);
+  const candidates: TokenCandidate[] = [];
+
+  walkTokens(tokens, (token, path) => {
+    if (path[0] === 'basis') {
+      return; // do not optimize basis itself
+    }
+    if (isRef(token.$value)) {
+      return; // nothing to suggest
+    }
+
+    const key = matchKey(token);
+    const match = basisEntries.find(
+      ({ token: basisToken }) => matchKey(basisToken) === key && dequal(basisToken.$value, token.$value),
+    );
+    if (match === undefined) {
+      return; // values are not a match
+    }
+
+    candidates.push({ path: [...path], suggestion: match, token });
+  });
+
+  return candidates;
+};
+
+/**
+ * Replaces each candidate's hard-coded `$value` with a reference to the suggested
+ * basis token. Returns a deep clone — `tokens` is never mutated.
+ */
+export const applyReusableCandidates = (
+  tokens: Record<string, unknown>,
+  candidates: TokenCandidate[],
+): Record<string, unknown> => {
+  const result = structuredClone(tokens);
+  for (const { path, suggestion } of candidates) {
+    dset(result, [...path, '$value'], createReference(suggestion.path));
+  }
+  return result;
+};
+
+/** Shorthand for `applyReusableCandidates(tokens, findReusableCandidates(tokens))`. */
+export const reuseBasisTokens = (tokens: Record<string, unknown>): Record<string, unknown> => {
+  const candidates = findReusableCandidates(tokens);
+  return applyReusableCandidates(tokens, candidates);
+};

--- a/packages/design-tokens-schema/src/theme.community.test.ts
+++ b/packages/design-tokens-schema/src/theme.community.test.ts
@@ -2,8 +2,10 @@ import purmerendTokens from '@nl-design-system-community/purmerend-design-tokens
 import purmerendSourceTokens from '@nl-design-system-community/purmerend-design-tokens/figma/figma.tokens.json';
 import leidenTokens from '@nl-design-system-unstable/leiden-design-tokens/dist/tokens.json';
 import leidenSourceTokens from '@nl-design-system-unstable/leiden-design-tokens/figma/leiden.tokens.json';
+import startTokens from '@nl-design-system-unstable/start-design-tokens/figma/start.tokens.json';
 import { describe, it, expect } from 'vitest';
-import { excludeParentKeys, StrictThemeSchema } from './theme';
+import { findReusableCandidates } from './reuse-tokens';
+import { excludeParentKeys, preprocessThemeStrict, StrictThemeSchema } from './theme';
 
 // NOTE!
 //
@@ -145,6 +147,43 @@ describe('dist files', () => {
         expect.objectContaining({ code: 'unrecognized_keys' }),
         expect.objectContaining({ code: 'invalid_type' }),
         expect.objectContaining({ code: 'invalid_union' }),
+      ]),
+    );
+  });
+});
+
+describe('reuse basis tokens suggestions', () => {
+  it('Start', () => {
+    const suggestions = findReusableCandidates(preprocessThemeStrict(excludeParentKeys(startTokens)));
+    expect(suggestions.length).toBeGreaterThanOrEqual(1);
+    expect(suggestions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ['ams', 'tabs', 'button', 'cursor'],
+          suggestion: expect.objectContaining({
+            path: ['basis', 'action', 'activate', 'cursor'],
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('Purmerend', () => {
+    const suggestions = findReusableCandidates(preprocessThemeStrict(excludeParentKeys(purmerendTokens)));
+    expect(suggestions).toHaveLength(0);
+  });
+
+  it('Leiden', () => {
+    const suggestions = findReusableCandidates(preprocessThemeStrict(excludeParentKeys(leidenSourceTokens)));
+    expect(suggestions.length).toBeGreaterThanOrEqual(1);
+    expect(suggestions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ['utrecht', 'drawer', 'border-radius'],
+          suggestion: expect.objectContaining({
+            path: ['basis', 'border-radius', 'none'],
+          }),
+        }),
       ]),
     );
   });

--- a/packages/design-tokens-schema/src/theme.ts
+++ b/packages/design-tokens-schema/src/theme.ts
@@ -27,7 +27,7 @@ import { setExtension } from './extensions';
 import { removeNonTokenProperties } from './remove-non-token-properties';
 import { validateRefs, resolveRefs, EXTENSION_RESOLVED_FROM, EXTENSION_RESOLVED_AS } from './resolve-refs';
 import { ColorValue, compareContrast, type ColorToken } from './tokens/color-token';
-import { TokenReference, extractRef, isRef, isValueObject } from './tokens/token-reference';
+import { TokenReference, createReference, extractRef, isRef, isValueObject } from './tokens/token-reference';
 import { EXTENSION_TOKEN_SUBTYPE, upgradeLegacyTokens } from './upgrade-legacy-tokens';
 import {
   ERROR_CODES,
@@ -221,7 +221,7 @@ export const addComponentContrastExtensions = (rootConfig: Record<string, unknow
       const contrastExtension = {
         color: {
           $extensions: {
-            [EXTENSION_RESOLVED_FROM]: `{${[...path, 'background-color'].join('.')}}`,
+            [EXTENSION_RESOLVED_FROM]: createReference([...path, 'background-color']),
           },
           $type: 'color',
           $value: getActualValue(bgColor),
@@ -290,7 +290,7 @@ const preprocessTheme = (input: unknown): Record<string, unknown> => {
  * Strict preprocessing pipeline: includes all preprocessing for validation.
  * Clones input to avoid mutating the original object.
  */
-const preprocessThemeStrict = (input: unknown): Record<string, unknown> => {
+export const preprocessThemeStrict = (input: unknown): Record<string, unknown> => {
   let data = structuredClone(input as Record<string, unknown>);
 
   // Get `$extensions['original']['$value'] from Style Dictionary and place it in $value

--- a/packages/design-tokens-schema/src/tokens/base-token.ts
+++ b/packages/design-tokens-schema/src/tokens/base-token.ts
@@ -33,13 +33,13 @@ export type TokenPath = BaseDesignTokenIdentifier[];
 
 export const BaseDesignTokenSchema = z.looseObject({
   /** @see 5.2.4 Deprecated https://www.designtokens.org/tr/drafts/format/#deprecated */
-  $deprecated: z.union([z.boolean(), z.string()]).optional(),
+  $deprecated: z.union([z.boolean(), z.string().trim()]).optional(),
   /** @see 5.2.1 Description https://www.designtokens.org/tr/drafts/format/#description */
-  $description: z.string().optional(),
+  $description: z.string().trim().optional(),
   /** @see 5.2.3 Extensions https://www.designtokens.org/tr/drafts/format/#extensions */
   $extensions: ExtensionsSchema.optional(),
   /** @see 5.2.2 Type https://www.designtokens.org/tr/drafts/format/#type-0 */
-  $type: z.string().nonoptional(),
+  $type: z.string().trim().nonoptional(),
   $value: z.unknown().nonoptional(), // refine exact shape in concrete token types
 });
 export type BaseDesignToken = z.infer<typeof BaseDesignTokenSchema>;

--- a/packages/design-tokens-schema/src/tokens/token-reference.ts
+++ b/packages/design-tokens-schema/src/tokens/token-reference.ts
@@ -1,6 +1,6 @@
 import dlv from 'dlv';
 import * as z from 'zod';
-import { BaseDesignTokenIdentifierSchema, type BaseDesignToken } from './base-token';
+import { BaseDesignTokenIdentifierSchema, TokenPath, type BaseDesignToken } from './base-token';
 
 // A Design Token ref:
 // - Starts with {
@@ -23,6 +23,10 @@ export const TokenReferenceSchema = z
 
 // Not inferring the type from the zod schema because that would be a plain string
 export type TokenReference = `{${string}}`;
+
+export const createReference = (path: TokenPath): TokenReference => {
+  return `{${path.join('.')}}`;
+};
 
 export const isValueObject = (obj: unknown): obj is Record<string, unknown> => {
   return obj !== null && typeof obj === 'object';

--- a/packages/design-tokens-schema/src/upgrade-legacy-tokens.ts
+++ b/packages/design-tokens-schema/src/upgrade-legacy-tokens.ts
@@ -161,7 +161,7 @@ const upgradeNumberToken = (token: BaseDesignToken, path: string[]): void => {
  */
 const upgradeLegacyFontFamiliesToken = (token: BaseDesignToken): void => {
   token.$type = 'fontFamily';
-  if (typeof token.$value === 'string') {
+  if (typeof token.$value === 'string' && !isRef(token.$value)) {
     token.$value = splitFontFamily(token.$value);
   }
 };


### PR DESCRIPTION
refs #696

Voegt de volgende high-level functies toe voor de herbruikbarheid van basis-tokens:
- `findReusableCandidates` gaat door je tokens heen en maakt een lijst van tokens die een basis-token hadden kunnen zijn ipv een 'harde' waarde
- `applyReusableCandidates` past die lijst (of een subset daarvan!) toe op je tokens, waardoor sommige tokens niet meer een 'eigen' `$value` hebben, maar een ref worden naar een basis-token
- `reuseBasisTokens` doet beide bovenstaande in een keer

## Niet in deze PR

- Geen updates in design-tokens-lint en theme-wizard-app: die komen in volgende PR's

---

sfeerimpressie van wat we in Start thema vinden aan suggesties:

```shell
stdout | src/theme.community.test.ts > reuse basis tokens suggestions > Start
[
  {
    path: [ 'ams', 'file-input', 'border-style' ],
    suggestion: '{basis.focus.outline-style}',
    value: 'dashed'
  },
  {
    path: [ 'ams', 'tabs', 'button', 'cursor' ],
    suggestion: '{basis.action.activate.cursor}',
    value: 'pointer'
  },
  {
    path: [ 'ams', 'page-header', 'wide', 'padding-inline' ],
    suggestion: '{basis.space.inline.max.5xl}',
    value: { value: 96, unit: 'px' }
  },
  {
    path: [ 'ams', 'page-footer', 'menu', 'wide', 'padding-inline' ],
    suggestion: '{basis.space.inline.max.5xl}',
    value: { value: 96, unit: 'px' }
  },
  {
    path: [ 'denhaag', 'tabs', 'tab', 'cursor' ],
    suggestion: '{basis.action.activate.cursor}',
    value: 'pointer'
  }
]
```
