### PR TITLE
fix: clear pre-existing `EXTENSION_CONTRAST_WITH` extensions colors

### DIFF
--- a/packages/design-tokens-schema/src/theme.test.ts
+++ b/packages/design-tokens-schema/src/theme.test.ts
@@ -604,6 +604,45 @@ describe('validating color contrast', () => {
       expect(result.success).toBe(false);
       expect(result.error!.issues).toEqual(expectedIssues);
     });
+
+    it('does not crash when re-validating pre-processed tokens with hex-string contrast extensions', () => {
+      // Regression test: toTokensJSON calls toLegacyTokens which converts ColorJS $value
+      // objects back to hex strings, including inside contrast extension color objects.
+      // When that downloaded JSON is re-uploaded, the stale hex-string contrast extension
+      // must not reach superRefine as-is — it would crash with "color.components is undefined".
+      const downloadedJson = {};
+      dset(downloadedJson, 'clippy.button.color', {
+        $extensions: {
+          [EXTENSION_CONTRAST_WITH]: [
+            {
+              // Stale contrast extension from a previous preprocessing run,
+              // as serialized by toLegacyTokens: $value converted back to hex string.
+              color: {
+                $extensions: {
+                  [EXTENSION_RESOLVED_FROM]: '{clippy.button.background-color}',
+                },
+                $type: 'color',
+                $value: '#ffffff', // hex, not a ColorJS object — stale from toLegacyTokens
+              },
+              expectedRatio: 4.5,
+            },
+          ],
+        },
+        $type: 'color',
+        $value: '#cccccc', // lightGray
+      });
+      dset(downloadedJson, 'clippy.button.background-color', {
+        $type: 'color',
+        $value: '#ffffff', // white — insufficient contrast with lightGray
+      });
+
+      // Must not throw TypeError: "can't access property 'map', color.components is undefined"
+      expect(() => StrictThemeSchema.safeParse(downloadedJson)).not.toThrow();
+
+      const result = StrictThemeSchema.safeParse(downloadedJson);
+      expect(result.success).toBe(false);
+      expect(result.error!.issues).toEqual(expectedIssues);
+    });
   });
 });
 

--- a/packages/design-tokens-schema/src/theme.ts
+++ b/packages/design-tokens-schema/src/theme.ts
@@ -133,6 +133,19 @@ export type ContrastExtension = {
 };
 
 /**
+ * Remove previously computed contrast extensions (identified by EXTENSION_RESOLVED_FROM on the
+ * embedded color) so that re-running the adder functions is idempotent. User-provided contrast
+ * extensions (no EXTENSION_RESOLVED_FROM) are left intact.
+ */
+const clearComputedContrastExtensions = (token: ColorToken) => {
+  const existing = token.$extensions?.[EXTENSION_CONTRAST_WITH] as ContrastExtension[] | undefined;
+  if (!Array.isArray(existing)) return;
+  token.$extensions![EXTENSION_CONTRAST_WITH] = existing.filter(
+    (ext) => !ext.color?.$extensions?.[EXTENSION_RESOLVED_FROM],
+  );
+};
+
+/**
  * Add "nl.nldesignsystem.contrast-with" to color $extensions for known background/foreground colors in basis tokens
  */
 export const addBasisContrastExtensions = (rootConfig: Record<string, unknown>) => {
@@ -150,14 +163,15 @@ export const addBasisContrastExtensions = (rootConfig: Record<string, unknown>) 
     const parentPath = path.at(-2);
     if (parentPath !== undefined && SKIP_CONTRAST_EXTENSION.has(parentPath)) return;
 
+    clearComputedContrastExtensions(color);
+
     // Loop over the expected ratios:
     for (const [backgroundName, expectedRatio] of Object.entries(CONTRAST[lastPath])) {
       // Build the path to the background color relative to where we found the foreground
-      // path.slice(1, -1) removes the first element (basis) and last element (the color name)
-      const refPath = `${path.slice(1, -1).join('.')}.${backgroundName}`;
+      // path.slice(0, -1) removes the last element (the color name)
+      const lookupPath = `${path.slice(0, -1).join('.')}.${backgroundName}`;
 
       // Look for background in the same location as foreground (basis at root)
-      const lookupPath = `basis.${refPath}`;
       const background = dlv(rootConfig, lookupPath);
       if (!background) continue;
 
@@ -217,6 +231,8 @@ export const addComponentContrastExtensions = (rootConfig: Record<string, unknow
 
       const foregroundColor = obj['color'];
       const bgColor = obj['background-color'];
+
+      clearComputedContrastExtensions(foregroundColor);
 
       const contrastExtension = {
         color: {

--- a/packages/design-tokens-schema/src/walker.test.ts
+++ b/packages/design-tokens-schema/src/walker.test.ts
@@ -294,7 +294,7 @@ describe('walkTokens', () => {
     expect(calls).toBe(1);
   });
 
-  it("does not recurse into a token's $extensions", () => {
+  it("recurses into a token's $extensions", () => {
     let calls = 0;
     const root = {
       color: {
@@ -314,7 +314,7 @@ describe('walkTokens', () => {
     walkTokens(root, () => {
       calls++;
     });
-    expect(calls).toBe(1);
+    expect(calls).toBe(2);
   });
 });
 

--- a/packages/design-tokens-schema/src/walker.ts
+++ b/packages/design-tokens-schema/src/walker.ts
@@ -112,8 +112,5 @@ export const walkTokens = (
   root: unknown,
   callback: (token: BaseDesignToken, path: string[]) => void | typeof SKIP,
 ): void => {
-  walkObject<BaseDesignToken>(root, isTokenLike, (token, path) => {
-    callback(token, path);
-    return SKIP;
-  });
+  walkObject<BaseDesignToken>(root, isTokenLike, callback);
 };


### PR DESCRIPTION
supersedes #791
partially reverts #787

## Steps to reproduce:

- Ga naar theme wizard
- download je tokens.json
- ga naar /validate-tokens
- gebruik je gedownloade JSON om te valideren
- 💥 Error: cannot read property 'components' of undefined

## Oorzaak

PR #787 maakte de wijziging dat `walkTokens()` stopte op het eerste token-level, waardoor de walker nooit meer bij nested tokens kwam die bijv. in `$extensions` zitten, zoals onze `contrast-with`, `resolved-from`, `resolved-as` extensions. Bij het upgraden van legacy tokens werden die nested tokens niet meer bezocht en draait de validator in de soep omdat die alleen moderne token types ondersteunt.

**TL;DR; Cache. It's always cache.**