### PR TITLE
Verbeter clippy-combobox target size voor de opties en alignment

### DIFF
--- a/.changeset/honest-roses-boil.md
+++ b/.changeset/honest-roses-boil.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/clippy-components': patch
+---
+
+- clippy-combobox option tap size and paddings

--- a/packages/clippy-components/src/clippy-color-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-color-combobox/styles.ts
@@ -4,6 +4,9 @@ export default css`
   .clippy-color-combobox__option {
     align-items: center;
     display: flex;
-    gap: var(--clippy-color-combobox-option-gap, var(--basis-space-inline-md));
+    gap: var(
+      --clippy-color-combobox-option-gap,
+      var(--utrecht-textbox-padding-inline-end, var(--utrecht-form-control-padding-inline-end, initial))
+    );
   }
 `;

--- a/packages/clippy-components/src/clippy-combobox/index.ts
+++ b/packages/clippy-components/src/clippy-combobox/index.ts
@@ -432,7 +432,7 @@ export class ClippyCombobox<T extends Option = Option> extends FormElement<T['va
                   'utrecht-listbox__option--selected': selected,
                 };
                 return html`<li
-                  class="clippy-combobox__option utrecht-listbox__option utrecht-listbox__option--html-li ${classMap(
+                  class="clippy-combobox__option | utrecht-listbox__option utrecht-listbox__option--html-li ${classMap(
                     interactionClasses,
                   )}"
                   role="option"

--- a/packages/clippy-components/src/clippy-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-combobox/styles.ts
@@ -73,14 +73,18 @@ export default css`
 
   /**
    * Stretches the input to fill the available width.
-   * TODO: refactor double selector for double specificity to override utrecht-customizable-text-input styles.
+   * 1. Specificity 0,2,0 instead of 0,1,0 to override utrecht-customizable-text-input styles.
+   *    TODO: needs refactoring
    */
-  .clippy-combobox__input.clippy-combobox__input {
+  .clippy-combobox__input[class] /* [1] */ {
     inline-size: 100%;
     inline-size: stretch;
   }
 
   /**
+   * Current option
+   * Styled to look the same as and placed on top of the input.
+
    * TODO: this reuses a lot from utrecht-textbox. Best option is just to use the utrecht-textbox classes directly.
    * But currently that creates a specificity battle.
    * 1. utrecht-root sets a font-size-adjust, but is overridden on the input element by user-agent styles in the shadow DOM.
@@ -116,8 +120,11 @@ export default css`
     display: none;
   }
 
-  /* added specificity to override the align-items now that the flex direction changes */
-  .clippy-combobox__option.clippy-combobox__option {
+  /**
+   * 1. Specificity 0,2,0 instead of 0,1,0 to override utrecht-listbox__option styles.
+   *    TODO: needs refactoring
+   */
+  .clippy-combobox__option[class] /* [1] */ {
     --utrecht-listbox-option-padding-inline-start: var(
       --utrecht-textbox-padding-inline-start,
       var(--utrecht-form-control-padding-inline-start, initial)

--- a/packages/clippy-components/src/clippy-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-combobox/styles.ts
@@ -126,10 +126,11 @@ export default css`
       --utrecht-textbox-padding-inline-end,
       var(--utrecht-form-control-padding-inline-end, initial)
     );
+
     align-items: unset;
     display: flex;
     flex-direction: column;
-    min-block-size: var(--basis-pointer-target-min-block-size, 44px);
     justify-content: center;
+    min-block-size: var(--basis-pointer-target-min-block-size, 44px);
   }
 `;

--- a/packages/clippy-components/src/clippy-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-combobox/styles.ts
@@ -117,9 +117,19 @@ export default css`
   }
 
   /* added specificity to override the align-items now that the flex direction changes */
-  .clippy-combobox__option[class] {
+  .clippy-combobox__option.clippy-combobox__option {
+    --utrecht-listbox-option-padding-inline-start: var(
+      --utrecht-textbox-padding-inline-start,
+      var(--utrecht-form-control-padding-inline-start, initial)
+    );
+    --utrecht-listbox-option-padding-inline-end: var(
+      --utrecht-textbox-padding-inline-end,
+      var(--utrecht-form-control-padding-inline-end, initial)
+    );
     align-items: unset;
     display: flex;
     flex-direction: column;
+    min-block-size: var(--basis-pointer-target-min-block-size, 44px);
+    justify-content: center;
   }
 `;

--- a/packages/clippy-components/src/clippy-token-combobox/styles.ts
+++ b/packages/clippy-components/src/clippy-token-combobox/styles.ts
@@ -8,7 +8,10 @@ export default css`
   .clippy-token-combobox__option {
     align-items: center;
     display: flex;
-    gap: var(--clippy-token-combobox-option-gap, var(--basis-space-inline-md));
+    gap: var(
+      --clippy-token-combobox-option-gap,
+      var(--utrecht-textbox-padding-inline-end, var(--utrecht-form-control-padding-inline-end, initial))
+    );
   }
 
   .clippy-token-combobox__preview--font-family,


### PR DESCRIPTION
Deze PR zorgt er voor dat de options:
- Voldoen aan de ideal pointer target size
- De juiste padding hebben om deze goed te alignen met de input en de previews. 

<img width="408" height="357" alt="Screenshot 2026-06-03 at 17 07 28" src="https://github.com/user-attachments/assets/361318e9-3c00-43d4-94fc-9c14593af49d" />

<img width="408" height="355" alt="Screenshot 2026-06-03 at 17 06 41" src="https://github.com/user-attachments/assets/12a9fc9f-3a53-4204-a064-1e980a5045a6" />

<img width="340" height="160" alt="Screenshot 2026-06-03 at 17 06 10" src="https://github.com/user-attachments/assets/f8b2ada1-cd97-4aab-b38d-1ac5b8df84c5" />

<img width="410" height="381" alt="Screenshot 2026-06-03 at 17 04 31" src="https://github.com/user-attachments/assets/28f324b3-4cb5-4f5f-b19c-9ecd1cbe55c5" />
