### PR TITLE
refactor: drawer font-family token combobox (741)

### DIFF
--- a/packages/clippy-components/src/clippy-token-combobox/index.ts
+++ b/packages/clippy-components/src/clippy-token-combobox/index.ts
@@ -235,7 +235,9 @@ export class ClippyTokenCombobox extends LocalizationMixin(C) {
     return html`
       <span class="clippy-token-combobox__option">
         ${preview ? this.renderPreview(option) : nothing}
-        <span class=${classMap(labelClasses)}>${isRef(label) ? extractRef(label) : label}</span>
+        <span data-testid="option-label" class=${classMap(labelClasses)}
+          >${isRef(label) ? extractRef(label) : label}</span
+        >
       </span>
       ${description && index !== undefined ? html`<div>${description}</div>` : nothing}
     `;

--- a/packages/clippy-components/src/clippy-token-combobox/index.ts
+++ b/packages/clippy-components/src/clippy-token-combobox/index.ts
@@ -11,6 +11,7 @@ import {
   type FontFamilyToken,
   type ResolvedToken,
   NumberToken,
+  extractRef,
 } from '@nl-design-system-community/design-tokens-schema';
 import { ClippyCombobox } from '@src/clippy-combobox';
 import Color from 'colorjs.io';
@@ -234,7 +235,7 @@ export class ClippyTokenCombobox extends LocalizationMixin(C) {
     return html`
       <span class="clippy-token-combobox__option">
         ${preview ? this.renderPreview(option) : nothing}
-        <span class=${classMap(labelClasses)}>${label}</span>
+        <span class=${classMap(labelClasses)}>${isRef(label) ? extractRef(label) : label}</span>
       </span>
       ${description && index !== undefined ? html`<div>${description}</div>` : nothing}
     `;

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.test.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.test.ts
@@ -55,7 +55,7 @@ describe(`<${tag}>`, () => {
     await component.updateComplete;
 
     const shadowRoot = component.shadowRoot!;
-    const input = shadowRoot.querySelector('clippy-font-combobox')!;
+    const input = shadowRoot.querySelector('clippy-token-combobox')!;
 
     expect(input.getAttribute('aria-invalid')).not.toBe(null);
   });
@@ -71,7 +71,7 @@ describe(`<${tag}>`, () => {
     await component.updateComplete;
 
     const shadowRoot = component.shadowRoot!;
-    const input = shadowRoot.querySelector('clippy-font-combobox')!;
+    const input = shadowRoot.querySelector('clippy-token-combobox')!;
 
     expect(input.getAttribute('aria-invalid')).toBe(null);
   });

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -1,23 +1,69 @@
 import { consume } from '@lit/context';
 import '@nl-design-system-community/clippy-components/clippy-font-combobox';
-import { ClippyFontCombobox } from '@nl-design-system-community/clippy-components/clippy-font-combobox';
-import { ModernFontFamilyToken } from '@nl-design-system-community/design-tokens-schema';
+import '@nl-design-system-community/clippy-components/clippy-token-combobox';
+import { ClippyTokenCombobox, type Option } from '@nl-design-system-community/clippy-components/clippy-token-combobox';
+import {
+  EXTENSION_RESOLVED_AS,
+  isRef,
+  ModernFontFamilyToken,
+  resolveRef,
+  setExtension,
+  walkTokens,
+} from '@nl-design-system-community/design-tokens-schema';
 import { html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { scrapedTokensContext } from '../../contexts/scraped-tokens';
+import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
+import Theme from '../../lib/Theme';
 import { EXTENSION_TOKEN_STAGED, StagedDesignToken } from '../../utils';
 import { WizardTokenInput } from '../wizard-token-input';
 
 export type FontOption = { label: string; value: ModernFontFamilyToken['$value'] };
 
-export const DEFAULT_FONT_OPTIONS: FontOption[] = [
-  { label: 'System UI', value: ['system-ui', 'sans-serif'] },
-  { label: 'Arial', value: ['Arial', 'sans-serif'] },
-  { label: 'Georgia', value: ['Georgia', 'serif'] },
-  { label: 'Times New Roman', value: ['Times New Roman', 'serif'] },
-  { label: 'Courier New', value: ['Courier New', 'monospace'] },
-  { label: 'Verdana', value: ['Verdana', 'sans-serif'] },
+export const DEFAULT_FONT_OPTIONS: Option[] = [
+  {
+    label: 'System UI',
+    value: {
+      $type: 'fontFamily',
+      $value: ['system-ui', 'sans-serif'],
+    },
+  },
+  {
+    label: 'Arial',
+    value: {
+      $type: 'fontFamily',
+      $value: ['Arial', 'sans-serif'],
+    },
+  },
+  {
+    label: 'Georgia',
+    value: {
+      $type: 'fontFamily',
+      $value: ['Georgia', 'serif'],
+    },
+  },
+  {
+    label: 'Times New Roman',
+    value: {
+      $type: 'fontFamily',
+      $value: ['Times New Roman', 'serif'],
+    },
+  },
+  {
+    label: 'Courier New',
+    value: {
+      $type: 'fontFamily',
+      $value: ['Courier New', 'monospace'],
+    },
+  },
+  {
+    label: 'Verdana',
+    value: {
+      $type: 'fontFamily',
+      $value: ['Verdana', 'sans-serif'],
+    },
+  },
 ];
 
 const tag = 'wizard-font-input';
@@ -32,15 +78,20 @@ declare global {
 export class WizardFontInput extends WizardTokenInput {
   @property() defaultOptionsLabel = 'Standaardopties';
   @property() optionsLabel = 'Opties';
-  @property({ type: Array }) options: FontOption[] = [];
+  @property({ type: Array }) options: Option[] = [];
+
   readonly #token: ModernFontFamilyToken = {
     $type: 'fontFamily',
-    $value: '',
+    $value: [],
   };
 
   @consume({ context: scrapedTokensContext, subscribe: true })
   @property({ attribute: false })
   scrapedTokens: StagedDesignToken[] = [];
+
+  @consume({ context: themeContext, subscribe: true })
+  @property({ attribute: false })
+  private readonly theme!: Theme;
 
   override get value() {
     return this.#token.$value;
@@ -55,25 +106,45 @@ export class WizardFontInput extends WizardTokenInput {
 
   readonly #handleChange = (event: Event) => {
     const target = event.target;
-    if (!(target instanceof ClippyFontCombobox)) return;
-    this.value = target.value ?? '';
+    if (!(target instanceof ClippyTokenCombobox)) return;
+    this.value = target?.value?.$value ?? '';
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   };
 
   override render() {
-    const value = Array.isArray(this.value) ? this.value : [this.value];
-    const options: FontOption[] = [
-      ...this.scrapedTokens.reduce<FontOption[]>((acc, token) => {
+    const themeTokens: ModernFontFamilyToken[] = [];
+    walkTokens(this.theme.tokens['basis'], (token) => {
+      if (token.$type === 'fontFamily' && !isRef(token.$value)) {
+        themeTokens.push(token as ModernFontFamilyToken);
+      }
+    });
+
+    const options: Option[] = [
+      ...this.scrapedTokens.reduce<Option[]>((acc, token) => {
         if (token.$extensions?.[EXTENSION_TOKEN_STAGED] === true && token.$type === 'fontFamily') {
           acc.push({
             label: token.$value[0],
-            value: token.$value.slice(0, 1),
+            value: token,
           });
         }
         return acc;
       }, []),
+      ...themeTokens.map((token) => ({
+        label: token.$value[0],
+        value: token,
+      })),
       ...DEFAULT_FONT_OPTIONS,
     ];
+
+    const resolvedValueToken: ModernFontFamilyToken = { $type: 'fontFamily', $value: this.value };
+    const resolvedRef = this.value;
+    if (isRef(resolvedRef)) {
+      const resolvedToken = resolveRef(this.theme.tokens, resolvedRef) as ModernFontFamilyToken;
+
+      if (resolvedToken) {
+        setExtension(resolvedValueToken, EXTENSION_RESOLVED_AS, resolvedToken.$value);
+      }
+    }
 
     return html`
       <div class="utrecht-form-field__input">
@@ -83,15 +154,16 @@ export class WizardFontInput extends WizardTokenInput {
               ${t(`validation.error.${error.code}.compact`, error)}
             </div>`,
         )}
-        <clippy-font-combobox
+        <clippy-token-combobox
+          type="fontFamily"
           hidden-label="${this.label}"
           name=${this.name}
           @change=${this.#handleChange}
-          .value=${value}
+          .value=${resolvedValueToken}
           .options=${options}
           aria-invalid=${this.hasErrors ? 'true' : nothing}
           aria-errormessage=${this.hasErrors ? this.errors.map((error) => error.id).join(' ') : nothing}
-        ></clippy-font-combobox>
+        ></clippy-token-combobox>
       </div>
     `;
   }

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -3,6 +3,7 @@ import '@nl-design-system-community/clippy-components/clippy-font-combobox';
 import '@nl-design-system-community/clippy-components/clippy-token-combobox';
 import { ClippyTokenCombobox, type Option } from '@nl-design-system-community/clippy-components/clippy-token-combobox';
 import {
+  BaseDesignToken,
   EXTENSION_RESOLVED_AS,
   isRef,
   ModernFontFamilyToken,
@@ -11,15 +12,13 @@ import {
   walkTokens,
 } from '@nl-design-system-community/design-tokens-schema';
 import { html, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { scrapedTokensContext } from '../../contexts/scraped-tokens';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
 import Theme from '../../lib/Theme';
 import { EXTENSION_TOKEN_STAGED, StagedDesignToken } from '../../utils';
 import { WizardTokenInput } from '../wizard-token-input';
-
-export type FontOption = { label: string; value: ModernFontFamilyToken['$value'] };
 
 export const DEFAULT_FONT_OPTIONS: Option[] = [
   {
@@ -80,6 +79,8 @@ export class WizardFontInput extends WizardTokenInput {
   @property() optionsLabel = 'Opties';
   @property({ type: Array }) options: Option[] = [];
 
+  #options: Option[] = [];
+
   readonly #token: ModernFontFamilyToken = {
     $type: 'fontFamily',
     $value: [],
@@ -111,31 +112,41 @@ export class WizardFontInput extends WizardTokenInput {
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   };
 
-  override render() {
-    const themeTokens: ModernFontFamilyToken[] = [];
-    walkTokens(this.theme.tokens['basis'], (token) => {
+  /**
+   *
+   */
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    // Collect basis tokens and convert them to options
+    const basisTokens = this.theme.tokens['basis'];
+    const basisOptions: Option[] = [];
+    walkTokens(basisTokens, (token) => {
       if (token.$type === 'fontFamily' && !isRef(token.$value)) {
-        themeTokens.push(token as ModernFontFamilyToken);
+        basisOptions.push({
+          label: token.$value[0],
+          value: token,
+        });
       }
     });
 
-    const options: Option[] = [
-      ...this.scrapedTokens.reduce<Option[]>((acc, token) => {
-        if (token.$extensions?.[EXTENSION_TOKEN_STAGED] === true && token.$type === 'fontFamily') {
-          acc.push({
-            label: token.$value[0],
-            value: token,
-          });
-        }
-        return acc;
-      }, []),
-      ...themeTokens.map((token) => ({
-        label: token.$value[0],
-        value: token,
-      })),
-      ...DEFAULT_FONT_OPTIONS,
-    ];
+    // Collect scraped tokens and convert them to options
+    const scrapedOptions = this.scrapedTokens.reduce<Option[]>((acc, token) => {
+      if (token.$extensions?.[EXTENSION_TOKEN_STAGED] === true && token.$type === 'fontFamily') {
+        acc.push({
+          label: token.$value[0],
+          value: token,
+        });
+      }
+      return acc;
+    }, []);
 
+    // Combine all options
+    this.#options = [...this.options, ...scrapedOptions, ...basisOptions, ...DEFAULT_FONT_OPTIONS];
+  }
+
+  override render() {
+    // Check if the value is a reference and resolve it
     const resolvedValueToken: ModernFontFamilyToken = { $type: 'fontFamily', $value: this.value };
     const resolvedRef = this.value;
     if (isRef(resolvedRef)) {
@@ -160,7 +171,7 @@ export class WizardFontInput extends WizardTokenInput {
           name=${this.name}
           @change=${this.#handleChange}
           .value=${resolvedValueToken}
-          .options=${options}
+          .options=${this.#options}
           aria-invalid=${this.hasErrors ? 'true' : nothing}
           aria-errormessage=${this.hasErrors ? this.errors.map((error) => error.id).join(' ') : nothing}
         ></clippy-token-combobox>

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -3,16 +3,15 @@ import '@nl-design-system-community/clippy-components/clippy-font-combobox';
 import '@nl-design-system-community/clippy-components/clippy-token-combobox';
 import { ClippyTokenCombobox, type Option } from '@nl-design-system-community/clippy-components/clippy-token-combobox';
 import {
-  BaseDesignToken,
   EXTENSION_RESOLVED_AS,
   isRef,
   ModernFontFamilyToken,
   resolveRef,
   setExtension,
-  walkTokens,
+  walkFontFamilies,
 } from '@nl-design-system-community/design-tokens-schema';
 import { html, nothing } from 'lit';
-import { customElement, property, state } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { scrapedTokensContext } from '../../contexts/scraped-tokens';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
@@ -121,8 +120,8 @@ export class WizardFontInput extends WizardTokenInput {
     // Collect basis tokens and convert them to options
     const basisTokens = this.theme.tokens['basis'];
     const basisOptions: Option[] = [];
-    walkTokens(basisTokens, (token) => {
-      if (token.$type === 'fontFamily' && !isRef(token.$value)) {
+    walkFontFamilies(basisTokens, (token) => {
+      if (!isRef(token.$value)) {
         basisOptions.push({
           label: token.$value[0],
           value: token,

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -118,7 +118,7 @@ export class WizardFontInput extends WizardTokenInput {
     super.connectedCallback();
 
     // Collect basis tokens and convert them to options
-    const basisTokens = this.theme.tokens['basis'];
+    const basisTokens = this.theme?.tokens['basis'] || [];
     const basisOptions: Option[] = [];
     walkFontFamilies(basisTokens, (token) => {
       if (!isRef(token.$value)) {

--- a/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-font-input/index.ts
@@ -145,11 +145,11 @@ export class WizardFontInput extends WizardTokenInput {
   }
 
   override render() {
-    // Check if the value is a reference and resolve it
+    // By default put the value into token format
     const resolvedValueToken: ModernFontFamilyToken = { $type: 'fontFamily', $value: this.value };
-    const resolvedRef = this.value;
-    if (isRef(resolvedRef)) {
-      const resolvedToken = resolveRef(this.theme.tokens, resolvedRef) as ModernFontFamilyToken;
+    // Check if the value is a reference and resolve it
+    if (isRef(this.value)) {
+      const resolvedToken = resolveRef(this.theme.tokens, this.value);
 
       if (resolvedToken) {
         setExtension(resolvedValueToken, EXTENSION_RESOLVED_AS, resolvedToken.$value);

--- a/packages/theme-wizard-website/e2e/pages/BasisTokensPage.ts
+++ b/packages/theme-wizard-website/e2e/pages/BasisTokensPage.ts
@@ -69,10 +69,12 @@ export class BasisTokensPage {
     return Promise.all(stops.map((stop) => stop.getAttribute('data-value')));
   }
 
-  async getInputOptions(label: string, value = '') {
+  async getInputOptions(label: string) {
     const input = this.page.getByLabel(label);
-    await input.fill(value); // trigger the dropdown with options
-    return this.page.getByRole('option');
+    const field = this.page.locator(`[label="${label}"]`);
+
+    await input.focus(); // trigger the dropdown with options
+    return field.getByRole('option');
   }
 
   getErrorAlert(): Locator {

--- a/packages/theme-wizard-website/e2e/wizard.spec.ts
+++ b/packages/theme-wizard-website/e2e/wizard.spec.ts
@@ -29,7 +29,11 @@ test.describe('change fonts', () => {
     await basisTokensPage.goto();
     await page.getByRole('button', { name: 'Typografie' }).click();
     const options = await basisTokensPage.getInputOptions('Koppen');
-    const optionFamilies = (await options.allTextContents()).map((s) => s.trim());
+    const optionFamilies = await Promise.all(
+      (await options.all()).map(async (s) => {
+        return (await s.getByTestId('option-label').textContent())?.trim();
+      }),
+    );
 
     expect(optionFamilies).toEqual(expect.arrayContaining(stagedFamilies));
   });


### PR DESCRIPTION
Deze PR vervangt de clippy-font-comboboxes op de basis-tokens pagina met de clippy-token-combobox met fontFamily type. 

Van dit: 
<img width="370" height="323" alt="Screenshot 2026-06-08 at 15 18 41" src="https://github.com/user-attachments/assets/caaa1e7b-4c96-45c5-9a36-9945929da165" />

Naar dit: 
<img width="362" height="326" alt="Screenshot 2026-06-08 at 15 18 48" src="https://github.com/user-attachments/assets/3ce0019a-463a-4f33-9318-42d8662470f8" />

Fixes part of #741 