### PR TITLE
tokens-schema: utilities voor clippy-combobox

### DIFF
--- a/packages/design-tokens-schema/src/resolve-refs.test.ts
+++ b/packages/design-tokens-schema/src/resolve-refs.test.ts
@@ -42,18 +42,46 @@ describe('resolveRef', () => {
     const root = {
       color: { base: { $type: 'color', $value: '#aabbcc' } },
     };
-    expect(resolveRef(root, '{color.base}')).toEqual({ $type: 'color', $value: '#aabbcc' });
+    expect(resolveRef(root, '{color.base}')).toEqual(root.color.base);
   });
 
-  it('returns non-token-like value directly', () => {
+  it('returns undefined when resolved value is not a token', () => {
     const root = {
       color: { raw: 'not-a-token' },
     };
-    expect(resolveRef(root, '{color.raw}')).toBe('not-a-token');
+    expect(resolveRef(root, '{color.raw}')).toBeUndefined();
   });
 
   it('returns undefined when ref not found', () => {
     expect(resolveRef({}, '{nonexistent.token}')).toBeUndefined();
+  });
+
+  it('returns undefined on direct self-reference (circular)', () => {
+    const root = {
+      color: { a: { $type: 'color', $value: '{color.a}' } },
+    };
+    expect(resolveRef(root, '{color.a}')).toBeUndefined();
+  });
+
+  it('returns undefined on two-token cycle (a → b → a)', () => {
+    const root = {
+      color: {
+        a: { $type: 'color', $value: '{color.b}' },
+        b: { $type: 'color', $value: '{color.a}' },
+      },
+    };
+    expect(resolveRef(root, '{color.a}')).toBeUndefined();
+  });
+
+  it('returns undefined on longer cycle (a → b → c → a)', () => {
+    const root = {
+      color: {
+        a: { $type: 'color', $value: '{color.b}' },
+        b: { $type: 'color', $value: '{color.c}' },
+        c: { $type: 'color', $value: '{color.a}' },
+      },
+    };
+    expect(resolveRef(root, '{color.a}')).toBeUndefined();
   });
 });
 

--- a/packages/design-tokens-schema/src/resolve-refs.ts
+++ b/packages/design-tokens-schema/src/resolve-refs.ts
@@ -22,8 +22,17 @@ export type ResolvedToken = BaseDesignToken & {
   };
 };
 
-export const resolveRef = (root: object, path: TokenReference): unknown => {
+export const resolveRef = (
+  root: object,
+  path: TokenReference,
+  visited = new Set<string>(),
+): BaseDesignToken | undefined => {
   const refPath = extractRef(path);
+
+  // Keep track of visited paths to prevent infinite loops on circular references
+  if (visited.has(refPath)) return undefined;
+  visited.add(refPath);
+
   // Look up path.to.ref in root or in `brand` because NL Design System tokens don't always include the `.brand` part
   const resolved = dlv(root, refPath) || dlv(root, `brand.${refPath}`);
 
@@ -31,11 +40,12 @@ export const resolveRef = (root: object, path: TokenReference): unknown => {
     const tokenValue = resolved.$value;
     // If the resolved value is a token object with a $value that is itself a reference, recursively resolve it
     if (typeof tokenValue === 'string' && isRef(tokenValue)) {
-      return resolveRef(root, tokenValue);
+      return resolveRef(root, tokenValue, visited);
     }
+    return resolved;
   }
 
-  return resolved;
+  return undefined;
 };
 
 /**

--- a/packages/design-tokens-schema/src/tokens/fontfamily-token.ts
+++ b/packages/design-tokens-schema/src/tokens/fontfamily-token.ts
@@ -69,7 +69,7 @@ export const stringifyFontFamily = (value: FontFamilyValue): string => {
  * //=> `"Roboto Sans", sans-serif`
  * ```
  */
-export const legacyToModernFontFamily = z.codec(z.string(), ModernFontFamilyValueSchema, {
+export const legacyToModernFontFamily = z.codec(z.string().trim(), ModernFontFamilyValueSchema, {
   decode: (value) => {
     const array = splitFontFamily(value);
     return array.length === 1 ? array[0] : array;

--- a/packages/design-tokens-schema/src/tokens/token-reference.ts
+++ b/packages/design-tokens-schema/src/tokens/token-reference.ts
@@ -73,7 +73,7 @@ const isTokenWithRefLike = (obj: unknown): obj is TokenWithRefLike => {
 
 export type TokenRefError = {
   code: 'ref_not_found' | 'ref_not_a_token' | 'ref_type_mismatch';
-  path: string[];
+  path: TokenPath;
   referencedPath: string;
   referencedToken: unknown;
   message: string;
@@ -90,7 +90,7 @@ export type TokenRefError = {
 export const isTokenWithRef = (
   token: unknown,
   root: Record<string, unknown>,
-  path: string[],
+  path: TokenPath,
   onError: (error: TokenRefError) => void,
 ): token is TokenWithRefLike => {
   // Check that we're dealing with a token-like object with a ref in the $value

--- a/packages/design-tokens-schema/src/upgrade-legacy-tokens.ts
+++ b/packages/design-tokens-schema/src/upgrade-legacy-tokens.ts
@@ -1,5 +1,5 @@
 import { parse_dimension } from '@projectwallace/css-parser';
-import type { BaseDesignToken } from './tokens/base-token';
+import type { BaseDesignToken, TokenPath } from './tokens/base-token';
 import { setExtension } from './extensions';
 import { resolveRef } from './resolve-refs';
 import { parseColor } from './tokens/color-token';
@@ -63,7 +63,7 @@ const upgradeDimensionToken = (token: BaseDesignToken): void => {
   token.$value = parseDimensionValue(token.$value);
 };
 
-const addDimensionSubType = (token: BaseDesignToken, tokenPath: string[]): void => {
+const addDimensionSubType = (token: BaseDesignToken, tokenPath: TokenPath): void => {
   const path = tokenPath.join('.');
 
   if (path.includes('font-size')) {
@@ -148,7 +148,7 @@ const upgradeColorToken = (token: BaseDesignToken): void => {
 /**
  * @description Upgrade a number token (set line-height subtype if applicable)
  */
-const upgradeNumberToken = (token: BaseDesignToken, path: string[]): void => {
+const upgradeNumberToken = (token: BaseDesignToken, path: TokenPath): void => {
   if (path.includes('line-height')) {
     setExtension(token, EXTENSION_TOKEN_SUBTYPE, 'line-height');
   } else if (path.includes('font-weight')) {
@@ -175,7 +175,7 @@ const upgradeFontFamilyTokenWithLegacyValue = (token: BaseDesignToken): void => 
   }
 };
 
-const addColorSubType = (token: BaseDesignToken, tokenPath: string[]): void => {
+const addColorSubType = (token: BaseDesignToken, tokenPath: TokenPath): void => {
   const path = tokenPath.join('.');
 
   if (path.includes('.bg-') || path.endsWith('.background-color')) {

--- a/packages/design-tokens-schema/src/validation-issue.ts
+++ b/packages/design-tokens-schema/src/validation-issue.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { TokenPath } from './tokens/base-token';
 import { MINIMUM_LINE_HEIGHT } from './validations';
 
 export const ERROR_CODES = {
@@ -13,7 +14,7 @@ export type ContrastIssue = z.core.$ZodSuperRefineIssue & {
   ERROR_CODE: typeof ERROR_CODES.INSUFFICIENT_CONTRAST;
   actual: number;
   tokens: [string] | [string, string];
-  path: string[];
+  path: TokenPath;
   code: 'too_small';
   message: 'Insufficient contrast';
   minimum: number;
@@ -30,14 +31,14 @@ export type LineHeightUnitIssue = z.core.$ZodSuperRefineIssue & {
   ERROR_CODE: typeof ERROR_CODES.UNEXPECTED_UNIT;
   code: 'invalid_type';
   message: string;
-  path: string[];
+  path: TokenPath;
 };
 
 export type MinimumLineHeightIssue = z.core.$ZodSuperRefineIssue & {
   ERROR_CODE: typeof ERROR_CODES.LINE_HEIGHT_TOO_SMALL;
   code: 'too_small';
   message: string;
-  path: string[];
+  path: TokenPath;
   minimum: number;
   expected: 'number';
   input: number;
@@ -48,7 +49,7 @@ export const createMinLineHeightIssue = ({
   actual,
   path,
 }: {
-  path: string[];
+  path: TokenPath;
   actual: number;
 }): MinimumLineHeightIssue => {
   return {
@@ -69,7 +70,7 @@ export type MinFontSizeIssue = z.core.$ZodSuperRefineIssue & {
   code: 'custom';
   message: string;
   actual: string;
-  path: string[];
+  path: TokenPath;
   minimum: string;
 };
 
@@ -90,7 +91,7 @@ export const createContrastIssue = ({
 }: {
   actual: number;
   tokens: [string] | [string, string];
-  path: string[];
+  path: TokenPath;
   minimum: number;
 }): ContrastIssue => {
   return {

--- a/packages/design-tokens-schema/src/walker.test.ts
+++ b/packages/design-tokens-schema/src/walker.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EXTENSION_TOKEN_SUBTYPE } from './upgrade-legacy-tokens';
-import { SKIP, walkObject, walkColors, walkDimensions, walkLineHeights, walkTokens, walkTokensWithRef } from './walker';
+import {
+  SKIP,
+  walkObject,
+  walkColors,
+  walkDimensions,
+  walkFontFamilies,
+  walkLineHeights,
+  walkTokens,
+  walkTokensWithRef,
+} from './walker';
 
 describe('walkObject', () => {
   it('calls callback when predicate matches', () => {
@@ -237,6 +246,67 @@ describe('walkLineHeights', () => {
   it('stops recursing when callback returns SKIP', () => {
     let calls = 0;
     walkLineHeights({ lh: lineHeightToken }, () => {
+      calls++;
+      return SKIP;
+    });
+    expect(calls).toBe(1);
+  });
+});
+
+describe('walkFontFamilies', () => {
+  const singleToken = { $type: 'fontFamily', $value: 'Inter' };
+  const arrayToken = { $type: 'fontFamily', $value: ['Inter', 'sans-serif'] };
+  const refToken = { $type: 'fontFamily', $value: '{brand.font}' };
+
+  it('finds font family token with single string $value', () => {
+    const found: unknown[] = [];
+    walkFontFamilies({ font: singleToken }, (token) => {
+      found.push(token);
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0]).toEqual(singleToken);
+  });
+
+  it('finds font family token with array $value', () => {
+    const found: unknown[] = [];
+    walkFontFamilies({ font: arrayToken }, (token) => {
+      found.push(token);
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0]).toEqual(arrayToken);
+  });
+
+  it('finds font family token with ref $value', () => {
+    const found: unknown[] = [];
+    walkFontFamilies({ font: refToken }, (token) => {
+      found.push(token);
+    });
+    expect(found).toHaveLength(1);
+  });
+
+  it('skips non-fontFamily tokens', () => {
+    const callback = vi.fn();
+    walkFontFamilies({ size: { $type: 'dimension', $value: { unit: 'px', value: 16 } } }, callback);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('skips tokens with comma in font name', () => {
+    const callback = vi.fn();
+    walkFontFamilies({ font: { $type: 'fontFamily', $value: 'Inter, sans-serif' } }, callback);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('passes correct path to callback', () => {
+    const paths: string[][] = [];
+    walkFontFamilies({ typography: { body: singleToken } }, (_, path) => {
+      paths.push(path);
+    });
+    expect(paths).toContainEqual(['typography', 'body']);
+  });
+
+  it('stops recursing when callback returns SKIP', () => {
+    let calls = 0;
+    walkFontFamilies({ font: singleToken }, () => {
       calls++;
       return SKIP;
     });

--- a/packages/design-tokens-schema/src/walker.ts
+++ b/packages/design-tokens-schema/src/walker.ts
@@ -1,6 +1,7 @@
-import { BaseDesignToken } from './tokens/base-token';
+import { BaseDesignToken, TokenPath } from './tokens/base-token';
 import { ColorToken } from './tokens/color-token';
 import { DimensionToken, DimensionTokenSchema } from './tokens/dimension-token';
+import { FontFamilyToken, FontFamilyTokenSchema } from './tokens/fontfamily-token';
 import {
   isRef,
   isTokenLike,
@@ -21,12 +22,12 @@ export const SKIP = Symbol('skip');
  */
 export const walkObject = <T = unknown>(
   root: unknown,
-  predicate: (data: unknown, path: string[]) => data is T,
-  callback?: (data: T, path: string[]) => void | typeof SKIP,
+  predicate: (data: unknown, path: TokenPath) => data is T,
+  callback?: (data: T, path: TokenPath) => void | typeof SKIP,
 ): void => {
   const visited = new WeakSet();
 
-  function traverse(currentData: unknown, path: string[]): void {
+  function traverse(currentData: unknown, path: TokenPath): void {
     // Check if current data matches
     if (predicate(currentData, path)) {
       if (callback?.(currentData, path) === SKIP) return;
@@ -65,7 +66,7 @@ export const isColorToken = (token: unknown): token is ColorToken => {
 
 export const walkColors = (
   root: unknown,
-  callback: (token: ColorToken, path: string[]) => void | typeof SKIP,
+  callback: (token: ColorToken, path: TokenPath) => void | typeof SKIP,
 ): void => {
   walkObject<ColorToken>(root, isColorToken, callback);
 };
@@ -73,7 +74,7 @@ export const walkColors = (
 export const walkTokensWithRef = (
   root: unknown,
   config: Record<string, unknown>,
-  callback: (token: TokenWithRefLike, path: string[]) => void | typeof SKIP,
+  callback: (token: TokenWithRefLike, path: TokenPath) => void | typeof SKIP,
   onError: (error: TokenRefError) => void = () => {},
 ): void => {
   walkObject<TokenWithRefLike>(
@@ -89,7 +90,7 @@ const isLineHeightToken = (token: unknown): token is BaseDesignToken => {
 
 export const walkLineHeights = (
   root: unknown,
-  callback: (token: BaseDesignToken, path: string[]) => void | typeof SKIP,
+  callback: (token: BaseDesignToken, path: TokenPath) => void | typeof SKIP,
 ): void => {
   walkObject<BaseDesignToken>(root, isLineHeightToken, callback);
 };
@@ -100,7 +101,7 @@ const isDimensionToken = (token: unknown): token is DimensionToken => {
 
 export const walkDimensions = (
   root: unknown,
-  callback: (token: DimensionToken, path: string[]) => void | typeof SKIP,
+  callback: (token: DimensionToken, path: TokenPath) => void | typeof SKIP,
 ): void => {
   walkObject<DimensionToken>(root, isDimensionToken, (token, path) => {
     const dimension = DimensionTokenSchema.safeParse(token);
@@ -108,9 +109,23 @@ export const walkDimensions = (
   });
 };
 
+const isFontFamilyToken = (token: unknown): token is FontFamilyToken => {
+  return isTokenLike(token) && FontFamilyTokenSchema.safeParse(token).success;
+};
+
+export const walkFontFamilies = (
+  root: unknown,
+  callback: (token: FontFamilyToken, path: TokenPath) => void | typeof SKIP,
+): void => {
+  walkObject<FontFamilyToken>(root, isFontFamilyToken, (token, path) => {
+    const fontFamily = FontFamilyTokenSchema.safeParse(token);
+    return callback(fontFamily.data!, path);
+  });
+};
+
 export const walkTokens = (
   root: unknown,
-  callback: (token: BaseDesignToken, path: string[]) => void | typeof SKIP,
+  callback: (token: BaseDesignToken, path: TokenPath) => void | typeof SKIP,
 ): void => {
   walkObject<BaseDesignToken>(root, isTokenLike, callback);
 };


### PR DESCRIPTION
- `resolveRef()` return nu `BaseDesignToken | undefined` ipv `unknown`. Dit is een restrictie tov voorheen, want dan werkte het ook als je een ref had naar een token group zoals bv `basis.color`.
- `resolveRef()` blijft niet meer hangen op circular references (a → b → c → a)
- pas `TokenPath` consistent toe ipv `string[]`
- voeg `walkFontFamilies()` toe voor gebruiksgemak in de cliipy combobox voor font-families