### PR TITLE
design-tokens-schema: prevent some prototype pollution methods

### DIFF
--- a/packages/design-tokens-schema/src/extensions.test.ts
+++ b/packages/design-tokens-schema/src/extensions.test.ts
@@ -32,22 +32,24 @@ describe('single value', () => {
 });
 
 describe('prototype pollution prevention', () => {
+  // setExtensions pollution guard fires before $extensions is initialised — $extensions must stay absent
+
   it('ignores __proto__ key', () => {
     const token: BaseDesignToken = { $type: 'number', $value: 1 };
     setExtension(token, '__proto__', { polluted: true });
-    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(token.$extensions).toBeUndefined();
   });
 
   it('ignores constructor key', () => {
     const token: BaseDesignToken = { $type: 'number', $value: 1 };
     setExtension(token, 'constructor', { polluted: true });
-    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(token.$extensions).toBeUndefined();
   });
 
   it('ignores prototype key', () => {
     const token: BaseDesignToken = { $type: 'number', $value: 1 };
     setExtension(token, 'prototype', { polluted: true });
-    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(token.$extensions).toBeUndefined();
   });
 });
 

--- a/packages/design-tokens-schema/src/extensions.test.ts
+++ b/packages/design-tokens-schema/src/extensions.test.ts
@@ -31,6 +31,26 @@ describe('single value', () => {
   });
 });
 
+describe('prototype pollution prevention', () => {
+  it('ignores __proto__ key', () => {
+    const token: BaseDesignToken = { $type: 'number', $value: 1 };
+    setExtension(token, '__proto__', { polluted: true });
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
+  it('ignores constructor key', () => {
+    const token: BaseDesignToken = { $type: 'number', $value: 1 };
+    setExtension(token, 'constructor', { polluted: true });
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
+  it('ignores prototype key', () => {
+    const token: BaseDesignToken = { $type: 'number', $value: 1 };
+    setExtension(token, 'prototype', { polluted: true });
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+});
+
 describe('extension arrays', () => {
   it('sets an extension when no extension is on the object yet', () => {
     const token: BaseDesignToken = {

--- a/packages/design-tokens-schema/src/extensions.test.ts
+++ b/packages/design-tokens-schema/src/extensions.test.ts
@@ -38,18 +38,21 @@ describe('prototype pollution prevention', () => {
     const token: BaseDesignToken = { $type: 'number', $value: 1 };
     setExtension(token, '__proto__', { polluted: true });
     expect(token.$extensions).toBeUndefined();
+    expect(({} as Record<PropertyKey, unknown>)['polluted']).toBeUndefined();
   });
 
   it('ignores constructor key', () => {
     const token: BaseDesignToken = { $type: 'number', $value: 1 };
     setExtension(token, 'constructor', { polluted: true });
     expect(token.$extensions).toBeUndefined();
+    expect(({} as Record<PropertyKey, unknown>)['polluted']).toBeUndefined();
   });
 
   it('ignores prototype key', () => {
     const token: BaseDesignToken = { $type: 'number', $value: 1 };
     setExtension(token, 'prototype', { polluted: true });
     expect(token.$extensions).toBeUndefined();
+    expect(({} as Record<PropertyKey, unknown>)['polluted']).toBeUndefined();
   });
 });
 

--- a/packages/design-tokens-schema/src/extensions.ts
+++ b/packages/design-tokens-schema/src/extensions.ts
@@ -1,10 +1,13 @@
 import { dequal } from 'dequal';
 import type { BaseDesignToken } from './tokens/base-token';
 
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Set a value for an extension. Warning: overwrites existing values if present.
  */
 export const setExtension = (token: BaseDesignToken, key: string, value: unknown): void => {
+  if (PROTO_KEYS.has(key)) return;
   // Make sure $extensions exists
   token['$extensions'] ??= {};
 

--- a/packages/design-tokens-schema/src/reuse-tokens.test.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.test.ts
@@ -216,6 +216,32 @@ describe('applyReusableTokens', () => {
     const result = applyReusableTokens(theme, []);
     expect(result).toEqual(theme);
   });
+
+  it('skips candidates with __proto__ in path', () => {
+    const basis = basisToken(4, 'px', 'space-block');
+    const theme = { basis: { space: { xs: basis } } };
+    applyReusableTokens(theme, [
+      {
+        path: ['__proto__', 'polluted'] as string[],
+        suggestion: { path: ['basis', 'space', 'xs'], token: basis },
+        token: basisToken(4, 'px', 'space-block'),
+      },
+    ]);
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
+  it('skips candidates with constructor in path', () => {
+    const basis = basisToken(4, 'px', 'space-block');
+    const theme = { basis: { space: { xs: basis } } };
+    applyReusableTokens(theme, [
+      {
+        path: ['constructor', 'polluted'] as string[],
+        suggestion: { path: ['basis', 'space', 'xs'], token: basis },
+        token: basisToken(4, 'px', 'space-block'),
+      },
+    ]);
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
 });
 
 describe('reuseBasisTokens', () => {

--- a/packages/design-tokens-schema/src/reuse-tokens.test.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.test.ts
@@ -224,7 +224,7 @@ describe('applyReusableTokens', () => {
     // our guard must prevent even that partial write.
     const result = applyReusableTokens(theme, [
       {
-        path: ['newKey', '__proto__'] as string[],
+        path: ['newKey', '__proto__'],
         suggestion: { path: ['basis', 'space', 'xs'], token: basis },
         token: basisToken(4, 'px', 'space-block'),
       },
@@ -237,7 +237,7 @@ describe('applyReusableTokens', () => {
     const theme = { basis: { space: { xs: basis } } };
     const result = applyReusableTokens(theme, [
       {
-        path: ['newKey', 'constructor'] as string[],
+        path: ['newKey', 'constructor'],
         suggestion: { path: ['basis', 'space', 'xs'], token: basis },
         token: basisToken(4, 'px', 'space-block'),
       },

--- a/packages/design-tokens-schema/src/reuse-tokens.test.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.test.ts
@@ -217,30 +217,32 @@ describe('applyReusableTokens', () => {
     expect(result).toEqual(theme);
   });
 
-  it('skips candidates with __proto__ in path', () => {
+  it('skips candidates with __proto__ in path without partial mutation', () => {
     const basis = basisToken(4, 'px', 'space-block');
     const theme = { basis: { space: { xs: basis } } };
-    applyReusableTokens(theme, [
+    // dset breaks on __proto__ but still creates the ancestor key before breaking;
+    // our guard must prevent even that partial write.
+    const result = applyReusableTokens(theme, [
       {
-        path: ['__proto__', 'polluted'] as string[],
+        path: ['newKey', '__proto__'] as string[],
         suggestion: { path: ['basis', 'space', 'xs'], token: basis },
         token: basisToken(4, 'px', 'space-block'),
       },
     ]);
-    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(result).toEqual(theme);
   });
 
-  it('skips candidates with constructor in path', () => {
+  it('skips candidates with constructor in path without partial mutation', () => {
     const basis = basisToken(4, 'px', 'space-block');
     const theme = { basis: { space: { xs: basis } } };
-    applyReusableTokens(theme, [
+    const result = applyReusableTokens(theme, [
       {
-        path: ['constructor', 'polluted'] as string[],
+        path: ['newKey', 'constructor'] as string[],
         suggestion: { path: ['basis', 'space', 'xs'], token: basis },
         token: basisToken(4, 'px', 'space-block'),
       },
     ]);
-    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(result).toEqual(theme);
   });
 });
 

--- a/packages/design-tokens-schema/src/reuse-tokens.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.ts
@@ -17,6 +17,8 @@
 
 import { dequal } from 'dequal';
 import { dset } from 'dset';
+
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 import { BaseDesignToken, TokenPath } from './tokens/base-token';
 import { isRef, createReference } from './tokens/token-reference';
 import { EXTENSION_TOKEN_SUBTYPE } from './upgrade-legacy-tokens';
@@ -99,6 +101,7 @@ export const applyReusableTokens = (
 ): Record<string, unknown> => {
   const result = structuredClone(tokens);
   for (const { path, suggestion } of candidates) {
+    if (path.some((segment) => PROTO_KEYS.has(segment))) continue;
     dset(result, [...path, '$value'], createReference(suggestion.path));
   }
   return result;

--- a/packages/design-tokens-schema/src/reuse-tokens.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.ts
@@ -101,7 +101,9 @@ export const applyReusableTokens = (
 ): Record<string, unknown> => {
   const result = structuredClone(tokens);
   for (const { path, suggestion } of candidates) {
-    if (path.some((segment) => PROTO_KEYS.has(segment))) continue;
+    if (path.some((segment) => PROTO_KEYS.has(segment))) {
+      continue;
+    }
     dset(result, [...path, '$value'], createReference(suggestion.path));
   }
   return result;

--- a/packages/design-tokens-schema/src/walker.test.ts
+++ b/packages/design-tokens-schema/src/walker.test.ts
@@ -74,6 +74,20 @@ describe('walkObject', () => {
     const isNumber = (v: unknown): v is number => typeof v === 'number';
     expect(() => walkObject({ a: 1 }, isNumber)).not.toThrow();
   });
+
+  it('does not traverse inherited prototype properties', () => {
+    const paths: string[][] = [];
+    const isString = (v: unknown): v is string => typeof v === 'string';
+    const proto = { inherited: 'should-not-visit' };
+    const obj = Object.create(proto) as Record<string, unknown>;
+    obj['own'] = 'visited';
+    walkObject(obj, isString, (_, path) => {
+      paths.push(path);
+    });
+    const visited = paths.map((p) => p[0]);
+    expect(visited).toContain('own');
+    expect(visited).not.toContain('inherited');
+  });
 });
 
 describe('walkColors', () => {

--- a/packages/design-tokens-schema/src/walker.ts
+++ b/packages/design-tokens-schema/src/walker.ts
@@ -38,7 +38,7 @@ export const walkObject = <T = unknown>(
       if (visited.has(currentData)) return;
       visited.add(currentData);
 
-      for (const key in currentData) {
+      for (const key of Object.keys(currentData)) {
         traverse((currentData as Record<string, unknown>)[key], [...path, key]);
       }
     }


### PR DESCRIPTION
Extra maatregelen voor het (onwaarschijnlijke) scenario dat iemand een _prototype pollution attack_ zou kunnen uitvoeren op basis van de design-tokens-schema package.