### PR TITLE
chore: upgrade pnpm to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -75,13 +68,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -112,13 +98,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -158,13 +137,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -214,13 +186,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,13 +32,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/periodic-e2e.yml
+++ b/.github/workflows/periodic-e2e.yml
@@ -39,13 +39,6 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,13 +29,6 @@ jobs:
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
-        run: |
-          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
-          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
-
-      - name: Check for known security issues with npm packages
-        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,4 @@
-# This is an npm only setting. We do not use npm, but if it is run by accident, this setting prevents pre- and
-# post-install scripts from executing. This is aligns with pnpm's behaviour, where these scripts must be explicitly
-# approved with `pnpm approve-builds`.
+# We do not use npm, but if it was ever run by accident, this should make sure that pre- and post-install scripts will
+# NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
+# pnpm approve-builds
 ignore-scripts=true
-
-provenance=true

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "url": "git@github.com:nl-design-system/theme-wizard.git",
     "directory": "."
   },
-  "packageManager": "pnpm@10.30.1+sha512.3590e550d5384caa39bd5c7c739f72270234b2f6059e13018f975c313b1eb9fefcc09714048765d4d9efe961382c312e624572c0420762bdc5d5940cdf9be73a",
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916",
   "engines": {
     "//": "Update @types/node to match the highest node version here",
     "node": ">=24 <=25",
-    "pnpm": "^10.17.0"
+    "pnpm": "^11.4.0"
   },
   "workspaces": [
     "./packages/*",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,10 @@ packages:
   - 'packages/*'
   - 'proprietary/*'
 
+allowBuilds:
+  esbuild: true
+  sharp: true
+
 # Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
 autoInstallPeers: false
 
@@ -41,3 +45,4 @@ savePrefix: ''
 # Configure pnpm to not fail when there are missing or invalid peer dependencies in the tree.
 strictPeerDependencies: false
 
+provenance: true


### PR DESCRIPTION
This PR upgrades pnpm to the latest version.  pnpm 11 has been out for a while now, and is now the recommended version to use.  Set the minimum version to 11.4 since that is the latest version with security fixes.  To use pnpm 11, ensure you're on a recent version of Node and run `corepack enable` in the root of the repository.

```sh
# to use the version of pnpm as specified in package.json
corepack enable
```

[pnpm 11](https://pnpm.io/blog/releases/11.0#highlights) comes with breaking changes and the [migration guide](https://pnpm.io/migration) was used.  It comes with better defaults for [strictDepBuilds](https://pnpm.io/settings#strictdepbuilds): you must now explicitly review which build scripts are allowed.  As well as `blockExoticSubdeps`.

The automigration moved all properties from `.npmrc` to `pnpm-workspace.yaml`, but we want to keep `ignore-scripts` as a safety measure and `provenance` because changeset publish bypasses pnpm.

`minimumReleaseAge` by default is now 24h, same as our existing setting.  I still kept it in `pnpm-workspace.yaml`, as it doesn't hurt to be explicit about it.

Also cleaned up the workaround in pipelines that allowed an RC version of pnpm to be used when the npm audit endpoint was down.  With pnpm 11, this is no longer needed.
