### PR TITLE
feat: move stringifyToken to design-tokens-schema, export TokenCandidate

### DIFF
--- a/packages/design-tokens-schema/src/index.ts
+++ b/packages/design-tokens-schema/src/index.ts
@@ -11,6 +11,7 @@ export * from './extensions';
 export * from './remove-non-token-properties';
 export * from './resolve-refs';
 export * from './reuse-tokens';
+export * from './stringify-token';
 export * from './theme';
 export * from './upgrade-legacy-tokens';
 export * from './walker';

--- a/packages/design-tokens-schema/src/reuse-tokens.ts
+++ b/packages/design-tokens-schema/src/reuse-tokens.ts
@@ -26,7 +26,7 @@ import { walkTokens } from './walker';
  * A component token paired with the basis token it could reference instead.
  * `path` / `suggestion.path` are absolute paths in the tree.
  */
-type TokenCandidate = {
+export type TokenCandidate = {
   path: TokenPath;
   token: BaseDesignToken;
   suggestion: {

--- a/packages/design-tokens-schema/src/stringify-token.test.ts
+++ b/packages/design-tokens-schema/src/stringify-token.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { stringifyToken } from './stringify-token';
+
+describe('color token', () => {
+  it('returns hex string for sRGB color', () => {
+    const token = {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [1, 0, 0] as [number, number, number] },
+    };
+    expect(stringifyToken(token)).toBe('#ff0000');
+  });
+
+  it('returns hex string for color with alpha', () => {
+    const token = {
+      $type: 'color',
+      $value: { alpha: 0.5, colorSpace: 'srgb', components: [0, 0, 1] as [number, number, number] },
+    };
+    const result = stringifyToken(token);
+    expect(result).toMatch(/^#[0-9a-f]{6,8}$/i);
+  });
+});
+
+describe('dimension token', () => {
+  it('returns value with px unit', () => {
+    const token = {
+      $type: 'dimension',
+      $value: { unit: 'px', value: 16 },
+    };
+    expect(stringifyToken(token)).toBe('16px');
+  });
+
+  it('returns value with rem unit', () => {
+    const token = {
+      $type: 'dimension',
+      $value: { unit: 'rem', value: 1.5 },
+    };
+    expect(stringifyToken(token)).toBe('1.5rem');
+  });
+
+  it('falls back to JSON.stringify for invalid dimension value', () => {
+    const token = {
+      $type: 'dimension',
+      $value: 'invalid-dimension',
+    };
+    expect(stringifyToken(token)).toBe('"invalid-dimension"');
+  });
+});
+
+describe('fontFamily token', () => {
+  it('returns single font name as-is', () => {
+    const token = {
+      $type: 'fontFamily',
+      $value: ['Roboto'],
+    };
+    expect(stringifyToken(token)).toBe('"Roboto"');
+  });
+
+  it('returns generic font name without quotes', () => {
+    const token = {
+      $type: 'fontFamily',
+      $value: ['sans-serif'],
+    };
+    expect(stringifyToken(token)).toBe('sans-serif');
+  });
+
+  it('returns named font quoted and generic unquoted in multi-font array', () => {
+    const token = {
+      $type: 'fontFamily',
+      $value: ['Roboto', 'sans-serif'],
+    };
+    expect(stringifyToken(token)).toBe('"Roboto",sans-serif');
+  });
+
+  it('falls back to JSON.stringify for invalid fontFamily value', () => {
+    const token = {
+      $type: 'fontFamily',
+      $value: 'bad,value',
+    };
+    expect(stringifyToken(token)).toBe('"bad,value"');
+  });
+});
+
+describe('number token', () => {
+  it('stringifies integer', () => {
+    const token = { $type: 'number', $value: 42 };
+    expect(stringifyToken(token)).toBe('42');
+  });
+
+  it('stringifies float', () => {
+    const token = { $type: 'number', $value: 1.5 };
+    expect(stringifyToken(token)).toBe('1.5');
+  });
+
+  it('falls back to JSON.stringify for non-finite number', () => {
+    const token = { $type: 'number', $value: Infinity };
+    expect(stringifyToken(token)).toBe('null');
+  });
+});
+
+describe('unknown / fallback', () => {
+  it('JSON.stringifies string value', () => {
+    const token = { $type: 'unknown', $value: 'some-value' };
+    expect(stringifyToken(token)).toBe('"some-value"');
+  });
+
+  it('JSON.stringifies object value', () => {
+    const token = { $type: 'unknown', $value: { foo: 'bar' } };
+    expect(stringifyToken(token)).toBe('{"foo":"bar"}');
+  });
+});

--- a/packages/design-tokens-schema/src/stringify-token.ts
+++ b/packages/design-tokens-schema/src/stringify-token.ts
@@ -1,0 +1,32 @@
+import { BaseDesignToken } from './tokens/base-token';
+import { stringifyColor } from './tokens/color-token';
+import { ModernDimensionValueSchema, stringifyDimension } from './tokens/dimension-token';
+import { ModernFontFamilyValueSchema, stringifyFontFamily } from './tokens/fontfamily-token';
+import { stringifyNumber } from './tokens/number-token';
+import { isColorToken } from './walker';
+
+export const stringifyToken = (token: BaseDesignToken): string => {
+  if (isColorToken(token)) {
+    return stringifyColor(token.$value);
+  }
+
+  if (token.$type === 'dimension') {
+    const parsed = ModernDimensionValueSchema.safeParse(token.$value);
+    if (parsed.success) {
+      return stringifyDimension(parsed.data);
+    }
+  }
+
+  if (token.$type === 'fontFamily') {
+    const parsed = ModernFontFamilyValueSchema.safeParse(token.$value);
+    if (parsed.success) {
+      return stringifyFontFamily(parsed.data);
+    }
+  }
+
+  if (token.$type === 'number' && Number.isFinite(token.$value)) {
+    return stringifyNumber(Number(token.$value));
+  }
+
+  return JSON.stringify(token.$value);
+};

--- a/packages/design-tokens-schema/src/tokens/number-token.ts
+++ b/packages/design-tokens-schema/src/tokens/number-token.ts
@@ -13,3 +13,7 @@ export const NumberTokenSchema = z.looseObject({
   $value: z.union([z.number(), TokenReferenceSchema]),
 });
 export type NumberToken = z.infer<typeof NumberTokenSchema>;
+
+export const stringifyNumber = (value: number): string => {
+  return value.toString();
+};


### PR DESCRIPTION
Uitgesplitst van #809 

- Add stringify-token.ts with stringifyToken for color/dimension/fontFamily/number
- Add stringifyNumber to number-token.ts
- Export TokenCandidate type from reuse-tokens.ts
- Export stringify-token from package index