### PR TITLE
Verdeel de eerste Theme Wizard keuzes in een stappenplan met Task Navigation

### DIFF
--- a/.changeset/hip-weeks-own.md
+++ b/.changeset/hip-weeks-own.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/clippy-components': minor
+---
+
+add `clippy-task-navigation`

--- a/packages/clippy-components/package.json
+++ b/packages/clippy-components/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@amsterdam/design-system-css": "4.1.0",
+    "@gemeente-denhaag/action": "4.2.2",
     "@nl-design-system-candidate/button-css": "1.1.0",
     "@nl-design-system-candidate/button-tokens": "1.0.0",
     "@nl-design-system-candidate/code-block-tokens": "2.0.3",
@@ -55,6 +56,7 @@
     "@nl-design-system-candidate/data-badge-tokens": "2.0.3",
     "@nl-design-system-candidate/heading-css": "1.1.3",
     "@nl-design-system-candidate/heading-tokens": "1.1.2",
+    "@nl-design-system-candidate/link-css": "2.0.3",
     "@nl-design-system-candidate/link-tokens": "3.0.3",
     "@nl-design-system-candidate/mark-tokens": "2.0.3",
     "@nl-design-system-candidate/number-badge-tokens": "2.0.3",

--- a/packages/clippy-components/src/clippy-task-navigation/README.md
+++ b/packages/clippy-components/src/clippy-task-navigation/README.md
@@ -1,0 +1,46 @@
+# `<clippy-task-navigation>`
+
+Navigation item linking to a single task. Renders a styled anchor with optional icon, details, and action slots. Focus styles work without needing Den Haag design tokens loaded.
+
+Based on [`@gemeente-denhaag/action`](https://npmx.dev/package/@gemeente-denhaag/action). See the [Den Haag action documentation](https://nl-design-system.github.io/denhaag/?path=/docs/css-action--docs) for available design tokens and guidelines.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-task-navigation';
+```
+
+```html
+<clippy-task-navigation href="/wizard/typography">Task description</clippy-task-navigation>
+```
+
+With icon and action indicator:
+
+```html
+<clippy-task-navigation href="/wizard/typography">
+  <clippy-icon slot="iconStart"><svg>…</svg></clippy-icon>
+  Task description
+  <clippy-icon slot="actions"><svg>…</svg></clippy-icon>
+</clippy-task-navigation>
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type   | Description | Default |
+| -------------------- | ------ | ----------- | ------- |
+| `href`               | string | Link URL    | `''`    |
+
+## Slots
+
+| Slot        | Description                                                                                          |
+| ----------- | ---------------------------------------------------------------------------------------------------- |
+| _(default)_ | Task label                                                                                           |
+| `iconStart` | Icon placed before the label                                                                         |
+| `details`   | Supplementary info (e.g. due date) shown below or next to the label, depending on screen real estate |
+| `actions`   | Action indicator (e.g. chevron) shown at the end                                                     |
+
+## CSS custom properties
+
+| Property                                    | Description                           |
+| ------------------------------------------- | ------------------------------------- |
+| `--clippy-task-navigation-icon-start-align` | `align-self` for the `iconStart` slot |

--- a/packages/clippy-components/src/clippy-task-navigation/index.test.ts
+++ b/packages/clippy-components/src/clippy-task-navigation/index.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import './index';
+
+const tag = 'clippy-task-navigation';
+
+describe(`<${tag}>`, () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders an anchor with Den Haag action classes', async () => {
+    document.body.innerHTML = `<${tag}>Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const anchor = component.shadowRoot?.querySelector('a');
+    expect(anchor).toBeTruthy();
+    expect(anchor?.classList.contains('denhaag-action')).toBe(true);
+    expect(anchor?.classList.contains('denhaag-action--single')).toBe(true);
+    expect(anchor?.classList.contains('nl-link')).toBe(true);
+  });
+
+  it('sets the href attribute on the anchor', async () => {
+    document.body.innerHTML = `<${tag} href="/tasks/1">Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const anchor = component.shadowRoot?.querySelector('a');
+    expect(anchor?.getAttribute('href')).toBe('/tasks/1');
+  });
+
+  it('renders the default slot inside denhaag-action__content > strong', async () => {
+    document.body.innerHTML = `<${tag}>My Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const strong = component.shadowRoot?.querySelector('.denhaag-action__content strong');
+    expect(strong).toBeTruthy();
+
+    const slot = strong?.querySelector('slot:not([name])');
+    const slottedText =
+      slot instanceof HTMLSlotElement
+        ? slot
+            .assignedNodes({ flatten: true })
+            .map((n) => n.textContent ?? '')
+            .join('')
+        : '';
+    expect(slottedText).toContain('My Task');
+  });
+
+  it('renders the details slot inside denhaag-action__details', async () => {
+    document.body.innerHTML = `<${tag}><time slot="details">1 jan 2025</time>Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const detailsSlot = component.shadowRoot?.querySelector('.denhaag-action__details slot[name="details"]');
+    expect(detailsSlot).toBeTruthy();
+  });
+
+  it('renders the actions slot inside denhaag-action__actions', async () => {
+    document.body.innerHTML = `<${tag}><span slot="actions">→</span>Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const actionsSlot = component.shadowRoot?.querySelector('.denhaag-action__actions slot[name="actions"]');
+    expect(actionsSlot).toBeTruthy();
+  });
+
+  it('the inner anchor is focusable', async () => {
+    document.body.innerHTML = `<${tag} href="/tasks/1">Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const anchor = component.shadowRoot?.querySelector('a');
+    anchor?.focus();
+    expect(component.shadowRoot?.activeElement).toBe(anchor);
+  });
+
+  it('renders the iconStart slot before denhaag-action__content', async () => {
+    document.body.innerHTML = `<${tag}><span slot="iconStart">★</span>Task</${tag}>`;
+    const component = document.querySelector(tag) as unknown as {
+      updateComplete: Promise<void>;
+      shadowRoot?: ShadowRoot;
+    };
+    await component.updateComplete;
+
+    const anchor = component.shadowRoot?.querySelector('a');
+    const children = Array.from(anchor?.children ?? []);
+    const slotIndex = children.findIndex((el) => el.matches('slot[name="iconStart"]'));
+    const contentIndex = children.findIndex((el) => el.matches('.denhaag-action__content'));
+
+    expect(slotIndex).toBeGreaterThanOrEqual(0);
+    expect(slotIndex).toBeLessThan(contentIndex);
+  });
+});

--- a/packages/clippy-components/src/clippy-task-navigation/index.ts
+++ b/packages/clippy-components/src/clippy-task-navigation/index.ts
@@ -1,0 +1,40 @@
+import actionCss from '@gemeente-denhaag/action/index.css?inline';
+import { safeCustomElement } from '@lib/decorators';
+import linkStyles from '@nl-design-system-candidate/link-css/link.css?inline';
+import { LitElement, html, unsafeCSS } from 'lit';
+import { property } from 'lit/decorators.js';
+import taskNavigationStyles from './styles';
+
+const tag = 'clippy-task-navigation';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: ClippyTaskNavigation;
+  }
+}
+
+@safeCustomElement(tag)
+export class ClippyTaskNavigation extends LitElement {
+  @property({ type: String }) href = '';
+
+  static override readonly styles = [unsafeCSS(linkStyles), unsafeCSS(actionCss), taskNavigationStyles];
+
+  override render() {
+    return html`
+      <a class="nl-link denhaag-action denhaag-action--single" href=${this.href}>
+        <slot name="iconStart"></slot>
+        <div class="denhaag-action__content">
+          <strong><slot></slot></strong>
+        </div>
+        <div class="denhaag-action__context">
+          <div class="denhaag-action__details">
+            <slot name="details"></slot>
+          </div>
+          <div class="denhaag-action__actions">
+            <slot name="actions"></slot>
+          </div>
+        </div>
+      </a>
+    `;
+  }
+}

--- a/packages/clippy-components/src/clippy-task-navigation/index.ts
+++ b/packages/clippy-components/src/clippy-task-navigation/index.ts
@@ -3,7 +3,7 @@ import { safeCustomElement } from '@lib/decorators';
 import linkStyles from '@nl-design-system-candidate/link-css/link.css?inline';
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
-import taskNavigationStyles from './styles';
+import styles from './styles';
 
 const tag = 'clippy-task-navigation';
 
@@ -17,7 +17,7 @@ declare global {
 export class ClippyTaskNavigation extends LitElement {
   @property({ type: String }) href = '';
 
-  static override readonly styles = [unsafeCSS(linkStyles), unsafeCSS(actionCss), taskNavigationStyles];
+  static override readonly styles = [unsafeCSS(linkStyles), unsafeCSS(actionCss), styles];
 
   override render() {
     return html`

--- a/packages/clippy-components/src/clippy-task-navigation/styles.ts
+++ b/packages/clippy-components/src/clippy-task-navigation/styles.ts
@@ -5,7 +5,7 @@ export default css`
     display: block;
   }
 
-  slot[name='iconStart'] {
+  ::slotted([slot="iconStart"]) {
     align-self: var(--clippy-task-navigation-icon-start-align, center);
   }
 `;

--- a/packages/clippy-components/src/clippy-task-navigation/styles.ts
+++ b/packages/clippy-components/src/clippy-task-navigation/styles.ts
@@ -1,0 +1,11 @@
+import { css } from 'lit';
+
+export default css`
+  :host(:not([hidden])) {
+    display: block;
+  }
+
+  slot[name='iconStart'] {
+    align-self: var(--clippy-task-navigation-icon-start-align, center);
+  }
+`;

--- a/packages/clippy-components/src/clippy-task-navigation/styles.ts
+++ b/packages/clippy-components/src/clippy-task-navigation/styles.ts
@@ -5,7 +5,7 @@ export default css`
     display: block;
   }
 
-  ::slotted([slot="iconStart"]) {
+  ::slotted([slot='iconStart']) {
     align-self: var(--clippy-task-navigation-icon-start-align, center);
   }
 `;

--- a/packages/clippy-storybook/src/web-components/clippy-task-navigation.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-task-navigation.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '@nl-design-system-community/clippy-components/clippy-task-navigation';
+import React from 'react';
+
+interface TaskNavigationStoryArgs {
+  content: string;
+  href: string;
+}
+
+const meta = {
+  id: 'clippy-task-navigation',
+  args: {
+    content: 'Task description',
+    href: '#',
+  },
+  argTypes: {
+    content: {
+      name: 'Content',
+      description: 'Label text (default slot)',
+      type: { name: 'string', required: true },
+    },
+    href: {
+      name: 'href',
+      description: 'Link destination',
+      type: { name: 'string', required: true },
+    },
+  },
+  render: ({ content, href }: TaskNavigationStoryArgs) =>
+    React.createElement('clippy-task-navigation', { href }, content),
+  tags: ['autodocs'],
+  title: 'Clippy/Task Navigation',
+} satisfies Meta<TaskNavigationStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Task Navigation',
+};
+
+export const WithDetails: Story = {
+  name: 'Details slot',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-task-navigation',
+      { href: '#' },
+      'Task description',
+      React.createElement('time', { dateTime: '2025-01-01', slot: 'details' }, '1 jan 2025'),
+    ),
+};
+
+export const WithActions: Story = {
+  name: 'Actions slot',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-task-navigation',
+      { href: '#' },
+      'Task description',
+      React.createElement('span', { slot: 'actions' }, '→'),
+    ),
+};
+
+export const WithDetailsAndActions: Story = {
+  name: 'Details and actions',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-task-navigation',
+      { href: '#' },
+      'Task description',
+      React.createElement('time', { dateTime: '2025-01-01', slot: 'details' }, '1 jan 2025'),
+      React.createElement('span', { slot: 'actions' }, '→'),
+    ),
+};
+
+export const WithIconBefore: Story = {
+  name: 'Icon before',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-task-navigation',
+      { href: '#' },
+      React.createElement('span', { slot: 'iconStart' }, '📋'),
+      'Task description',
+      React.createElement('span', { slot: 'actions' }, '→'),
+    ),
+};

--- a/packages/clippy-storybook/src/web-components/clippy-task-navigation.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-task-navigation.stories.tsx
@@ -96,3 +96,18 @@ export const WithIconBefore: Story = {
       React.createElement('span', { slot: 'actions' }, '→'),
     ),
 };
+
+export const WithLongContent: Story = {
+  name: 'Long content',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-task-navigation',
+      { href: '#' },
+      React.createElement('span', { slot: 'iconStart' }, '📋'),
+      'Icon before and a lot of content that should surely make this task navigation item wrap, but some more words appear here, just in case.',
+      React.createElement('span', { slot: 'actions' }, '→'),
+    ),
+};

--- a/packages/theme-wizard-website/package.json
+++ b/packages/theme-wizard-website/package.json
@@ -29,6 +29,7 @@
     "@astrojs/vercel": "10.0.8",
     "@fontsource/fira-sans": "5.2.7",
     "@fontsource/source-sans-pro": "5.2.5",
+    "@gemeente-denhaag/design-tokens": "1.2.1",
     "@nl-design-system-candidate/button-css": "1.1.0",
     "@nl-design-system-candidate/button-react": "1.1.0",
     "@nl-design-system-candidate/button-tokens": "1.0.0",

--- a/packages/theme-wizard-website/src/layouts/BaseLayout.astro
+++ b/packages/theme-wizard-website/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import '@utrecht/root-css/dist/index.css';
 import '@utrecht/body-css/dist/index.css';
 import '@nl-design-system-candidate/link-css/link.css';
+import '@gemeente-denhaag/design-tokens/dist/theme/index.css'
 
 export interface Props {
   title?: string;
@@ -12,7 +13,7 @@ const { title = 'Theme Wizard', description = 'Preview and analyze website theme
 ---
 
 <!doctype html>
-<html lang="nl-NL" class="utrecht-root">
+<html lang="nl-NL" class="utrecht-root denhaag-theme">
   <head>
     <meta charset="utf-8" />
     <title>{title}</title>

--- a/packages/theme-wizard-website/src/pages/wizard/basis-text-font-family-default.astro
+++ b/packages/theme-wizard-website/src/pages/wizard/basis-text-font-family-default.astro
@@ -1,0 +1,34 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import '@nl-design-system-candidate/link-css/link.css'
+import '@nl-design-system-candidate/paragraph-css/paragraph.css'
+---
+
+<script>
+  import '@nl-design-system-community/clippy-components/clippy-task-navigation';
+</script>
+
+<BaseLayout title="Wizard - Theme Wizard">
+  <theme-wizard-app>
+    <wizard-layout>
+      <main slot="main" class="wizard-main">
+        <wizard-container size="lg">
+          <clippy-story-preview size="lg">
+            <clippy-heading level="1">Lettertype voor tekst kiezen</clippy-heading>
+            <p class="nl-paragraph nl-paragraph--lead">Dit lettertype wordt bijvoorbeeld toegepast op alinea's, knoppen, en formulier elementen. Je kunt dit later altijd aanpassen.</p>
+          </clippy-story-preview>
+        </wizard-container>
+      </main>
+     </wizard-layout>
+  </theme-wizard-app>
+</BaseLayout>
+
+<style>
+  .wizard-main {
+    padding-block: var(--basis-space-block-5xl);
+  }
+
+  wizard-container {
+    margin-inline: auto;
+  }
+</style>

--- a/packages/theme-wizard-website/src/pages/wizard/index.astro
+++ b/packages/theme-wizard-website/src/pages/wizard/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import '@nl-design-system-candidate/link-css/link.css'
 import '@nl-design-system-candidate/paragraph-css/paragraph.css'
-import { IconChevronRight, IconCircleDashed } from '@tabler/icons-react';
+import { IconChevronRight, IconCircleDashed, IconCircleCheckFilled, IconFileTypography } from '@tabler/icons-react';
 ---
 
 <script>
@@ -15,20 +15,39 @@ import { IconChevronRight, IconCircleDashed } from '@tabler/icons-react';
       <main slot="main" class="wizard-main">
         <wizard-container size="lg">
           <clippy-story-preview size="lg">
-            <clippy-heading level="1">Maak de eerste keuzes voor je thema</clippy-heading>
-            <p class="nl-paragraph nl-paragraph--lead">Voor een optimaal werkend thema maak je eerst keuzes op hoog niveau.</p>
-            <nav>
-              <clippy-heading level="2">Maak stapsgewijs keuzes</clippy-heading>
-              <clippy-task-navigation href="/wizard/basis-text-font-family-default">
-                <span slot="iconStart">
-                  <IconCircleDashed />
-                </span>
-                Lettertype voor tekst
-                <span slot="actions">
-                  <IconChevronRight />
-                </span>
-              </clippy-task-navigation>
-            </nav>
+            <wizard-stack size="3xl">
+              <header>
+                <clippy-heading level="1">Maak de eerste keuzes voor je thema</clippy-heading>
+                <p class="nl-paragraph nl-paragraph--lead">Voor een optimaal werkend thema maak je eerst keuzes op hoog niveau.</p>
+              </header>
+              <nav>
+                <wizard-stack size="lg">
+                  <clippy-heading level="2">Maak stapsgewijs keuzes</clippy-heading>
+                  <div>
+                    <clippy-task-navigation href="/wizard/basis-text-font-family-default">
+                      <span slot="iconStart">
+                        <IconCircleCheckFilled />
+                      </span>
+                      Lettertype voor tekst
+                      <span slot="actions">
+                        <IconChevronRight />
+                      </span>
+                    </clippy-task-navigation>
+                    <clippy-task-navigation href="/wizard/basis-text-font-family-default">
+                      <span slot="iconStart">
+                        <div class="icon-stack">
+                          <IconCircleDashed />
+                        </div>
+                      </span>
+                      Lettertype voor tekst
+                      <span slot="actions">
+                        <IconChevronRight />
+                      </span>
+                    </clippy-task-navigation>
+                  </div>
+                </wizard-stack>
+              </nav>
+            </wizard-stack>
           </clippy-story-preview>
         </wizard-container>
       </main>
@@ -43,9 +62,5 @@ import { IconChevronRight, IconCircleDashed } from '@tabler/icons-react';
 
   wizard-container {
     margin-inline: auto;
-  }
-
-  nav {
-    margin-block-start: var(--basis-space-block-xl);
   }
 </style>

--- a/packages/theme-wizard-website/src/pages/wizard/index.astro
+++ b/packages/theme-wizard-website/src/pages/wizard/index.astro
@@ -1,0 +1,51 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import '@nl-design-system-candidate/link-css/link.css'
+import '@nl-design-system-candidate/paragraph-css/paragraph.css'
+import { IconChevronRight, IconCircleDashed } from '@tabler/icons-react';
+---
+
+<script>
+  import '@nl-design-system-community/clippy-components/clippy-task-navigation';
+</script>
+
+<BaseLayout title="Wizard - Theme Wizard">
+  <theme-wizard-app>
+    <wizard-layout>
+      <main slot="main" class="wizard-main">
+        <wizard-container size="lg">
+          <clippy-story-preview size="lg">
+            <clippy-heading level="1">Maak de eerste keuzes voor je thema</clippy-heading>
+            <p class="nl-paragraph nl-paragraph--lead">Voor een optimaal werkend thema maak je eerst keuzes op hoog niveau.</p>
+            <nav>
+              <clippy-heading level="2">Maak stapsgewijs keuzes</clippy-heading>
+              <clippy-task-navigation href="/wizard/basis-text-font-family-default">
+                <span slot="iconStart">
+                  <IconCircleDashed />
+                </span>
+                Lettertype voor tekst
+                <span slot="actions">
+                  <IconChevronRight />
+                </span>
+              </clippy-task-navigation>
+            </nav>
+          </clippy-story-preview>
+        </wizard-container>
+      </main>
+     </wizard-layout>
+  </theme-wizard-app>
+</BaseLayout>
+
+<style>
+  .wizard-main {
+    padding-block: var(--basis-space-block-5xl);
+  }
+
+  wizard-container {
+    margin-inline: auto;
+  }
+
+  nav {
+    margin-block-start: var(--basis-space-block-xl);
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       '@amsterdam/design-system-css':
         specifier: 4.1.0
         version: 4.1.0(@amsterdam/design-system-assets@2.3.0)(@amsterdam/design-system-tokens@4.0.1)
+      '@gemeente-denhaag/action':
+        specifier: 4.2.2
+        version: 4.2.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@nl-design-system-candidate/button-css':
         specifier: 1.1.0
         version: 1.1.0
@@ -135,6 +138,9 @@ importers:
       '@nl-design-system-candidate/heading-tokens':
         specifier: 1.1.2
         version: 1.1.2
+      '@nl-design-system-candidate/link-css':
+        specifier: 2.0.3
+        version: 2.0.3
       '@nl-design-system-candidate/link-tokens':
         specifier: 3.0.3
         version: 3.0.3
@@ -935,6 +941,9 @@ importers:
       '@fontsource/source-sans-pro':
         specifier: 5.2.5
         version: 5.2.5
+      '@gemeente-denhaag/design-tokens':
+        specifier: 1.2.1
+        version: 1.2.1
       '@nl-design-system-candidate/button-css':
         specifier: 1.1.0
         version: 1.1.0
@@ -1937,8 +1946,20 @@ packages:
       react: 18 || 19
       react-dom: 18 || 19
 
+  '@gemeente-denhaag/action@4.2.2':
+    resolution: {integrity: sha512-NFkRg4UeeuSNVxcg7rdCvq1v5Avz7yhcqw/tPY8Qrf1Zb/ekZE8eWFpNeHP/GDinyRkcSIuQYsc9zweuyhg9cg==}
+    peerDependencies:
+      react: 18 || 19
+      react-dom: 18 || 19
+
   '@gemeente-denhaag/button@3.0.3':
     resolution: {integrity: sha512-VQ8M4CoeKYvsVnm/igoq7DIDpgQu2VpyV+yv01XvrLJXkAaOB2BUGHDJcrujGY4VvNoNXXrt2PpQM0NtxoIBsw==}
+    peerDependencies:
+      react: 18 || 19
+      react-dom: 18 || 19
+
+  '@gemeente-denhaag/button@3.0.4':
+    resolution: {integrity: sha512-+KvYCtoYnujJEeOGrpS5VduE/9YBoiJxNmCSaotRD67+0D92nuKTH5epQGn7X+5x6YCApLT6OJFcHpyvTFf5gA==}
     peerDependencies:
       react: 18 || 19
       react-dom: 18 || 19
@@ -1949,6 +1970,9 @@ packages:
       react: 18 || 19
       react-dom: 18 || 19
 
+  '@gemeente-denhaag/design-tokens@1.2.1':
+    resolution: {integrity: sha512-sbw3mLKZbcAME8fiGodxOrSBxXpHwAMzpDCh48BaqflRxwAUIdQKTykPCMpUQI5ZkNbFPTts+SE1/BcypLbxMg==}
+
   '@gemeente-denhaag/iconbutton@3.1.0':
     resolution: {integrity: sha512-pPH5yW5i3M2e7MWvLopP9i2Qsqt9GIZvCYqJCYXUmJQPw3pRAsVk2WtKuGsam5t0Led6mMxsVN6LxVDTVHLixw==}
     peerDependencies:
@@ -1957,6 +1981,12 @@ packages:
 
   '@gemeente-denhaag/icons@4.0.1':
     resolution: {integrity: sha512-SX+o0S1SvdPDaCXCdha+2dQaOkyiHdYIqLhR80FblBrkxaS45K/zY2vahlI15NdKY8kQ3onEZv26i/6TPh1gyg==}
+    peerDependencies:
+      react: 18 || 19
+      react-dom: 18 || 19
+
+  '@gemeente-denhaag/icons@4.1.0':
+    resolution: {integrity: sha512-Q6fQ1TLQu4USfZyQ+82ONgL60eYgm9AAwMeULvXzOEHOaEHQp74DGBmd5YjNXi0XXkjkBdA+gfUgU+rnYX4R4Q==}
     peerDependencies:
       react: 18 || 19
       react-dom: 18 || 19
@@ -10047,9 +10077,27 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@gemeente-denhaag/action@4.2.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@gemeente-denhaag/button': 3.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@gemeente-denhaag/icons': 4.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@gemeente-denhaag/link': 4.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@gemeente-denhaag/utils': 3.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      date-fns: 4.1.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@gemeente-denhaag/button@3.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@gemeente-denhaag/icons': 4.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@gemeente-denhaag/button@3.0.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@gemeente-denhaag/icons': 4.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -10064,6 +10112,8 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@gemeente-denhaag/design-tokens@1.2.1': {}
+
   '@gemeente-denhaag/iconbutton@3.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@gemeente-denhaag/icons': 4.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -10072,6 +10122,12 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@gemeente-denhaag/icons@4.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@gemeente-denhaag/icons@4.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       clsx: 2.1.1
       react: 19.2.7


### PR DESCRIPTION
Nieuwe `clippy-task-navigation` op basis van https://nldesignsystem.nl/task-navigation/ en de CSS van Den Haag: https://nl-design-system.github.io/denhaag/?path=/docs/css-action--docs

---

## Live in action (theme wizard)

https://theme-wizard-git-clippy-task-navigation-nl-design-system.vercel.app/wizard

- Ja, spacing is hier nog niet ideaal. Ga ik fixen zodra ik meer content op de pagina heb. Focus voor deze PR is de task-navigation zelf en gebruik deze om te zien dat 'ie end-to-end werkt

<img width="783" height="400" alt="Screenshot 2026-06-19 at 14 09 18" src="https://github.com/user-attachments/assets/16e00115-013a-45a9-a2d1-a985258cb7f3" />


## Storybook

<img width="1049" height="1263" alt="Screenshot 2026-06-18 at 16 13 02" src="https://github.com/user-attachments/assets/77ad9781-2389-49d6-b2e0-8002d03bdca4" />

