### PR TITLE
Voeg Card as Radio button component toe

### DIFF
--- a/packages/clippy-components/src/clippy-card-radio-group/README.md
+++ b/packages/clippy-components/src/clippy-card-radio-group/README.md
@@ -1,0 +1,63 @@
+# `<clippy-card-radio-group>`
+
+Form-associated radiogroup wrapping `<clippy-card-radio-option>` children. Handles roving tabindex, arrow-key navigation, name propagation, and native form participation via `ElementInternals`.
+
+Importing the group also registers `<clippy-card-radio-option>`.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-card-radio-group';
+```
+
+```html
+<clippy-card-radio-group name="plan">
+  <clippy-card-radio-option value="starter">
+    Starter
+    <span slot="description">Up to 3 projects</span>
+  </clippy-card-radio-option>
+
+  <clippy-card-radio-option value="pro">
+    Pro
+    <span slot="description">Unlimited projects</span>
+    <div slot="body">Everything in Starter, plus…</div>
+  </clippy-card-radio-option>
+</clippy-card-radio-group>
+```
+
+Reading the selected value:
+
+```js
+const group = document.querySelector('clippy-card-radio-group');
+group.addEventListener('change', () => console.log(group.value));
+```
+
+Pre-selecting a card programmatically:
+
+```js
+group.value = 'pro';
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type    | Default |
+| -------------------- | ------- | ------- |
+| `name`               | string  | `''`    |
+| `value`              | string  | `null`  |
+| `disabled`           | boolean | `false` |
+| `readonly`           | boolean | `false` |
+| `hidden-label`       | string  | `''`    |
+
+## Events
+
+| Event    | Description                           |
+| -------- | ------------------------------------- |
+| `change` | Fired when a child option is selected |
+
+## Keyboard interaction
+
+| Key                        | Action                       |
+| -------------------------- | ---------------------------- |
+| `Tab` / `Shift+Tab`        | Enter or leave the group     |
+| `ArrowDown` / `ArrowRight` | Select next card (wraps)     |
+| `ArrowUp` / `ArrowLeft`    | Select previous card (wraps) |

--- a/packages/clippy-components/src/clippy-card-radio-group/README.md
+++ b/packages/clippy-components/src/clippy-card-radio-group/README.md
@@ -40,13 +40,10 @@ group.value = 'pro';
 
 ## Attributes & properties
 
-| Attribute / Property | Type    | Default |
-| -------------------- | ------- | ------- |
-| `name`               | string  | `''`    |
-| `value`              | string  | `null`  |
-| `disabled`           | boolean | `false` |
-| `readonly`           | boolean | `false` |
-| `hidden-label`       | string  | `''`    |
+| Attribute / Property | Type   | Default |
+| -------------------- | ------ | ------- |
+| `name`               | string | `''`    |
+| `value`              | string | `null`  |
 
 ## Events
 

--- a/packages/clippy-components/src/clippy-card-radio-group/index.test.ts
+++ b/packages/clippy-components/src/clippy-card-radio-group/index.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from 'vitest';
+import '../clippy-card-radio-option/index';
+import './index';
+import type { ClippyCardRadioOption } from '../clippy-card-radio-option/index';
+import type { ClippyCardRadioGroup } from './index';
+
+const groupTag = 'clippy-card-radio-group';
+const optionTag = 'clippy-card-radio-option';
+
+function getGroup() {
+  return document.querySelector(groupTag) as ClippyCardRadioGroup;
+}
+
+function getOptions() {
+  return Array.from(document.querySelectorAll(optionTag)) as ClippyCardRadioOption[];
+}
+
+async function setup(html: string) {
+  document.body.innerHTML = html;
+  const group = getGroup();
+  await group.updateComplete;
+  const options = getOptions();
+  for (const option of options) {
+    await option.updateComplete;
+  }
+  return { group, options };
+}
+
+const defaultHtml = `
+  <${groupTag} name="theme">
+    <${optionTag} value="light">Light</${optionTag}>
+    <${optionTag} value="dark">Dark</${optionTag}>
+    <${optionTag} value="system">System</${optionTag}>
+  </${groupTag}>
+`;
+
+describe(`<${groupTag}>`, () => {
+  describe('accessibility', () => {
+    it('has role="radiogroup"', async () => {
+      const { group } = await setup(defaultHtml);
+      expect(group.internals_.role).toBe('radiogroup');
+    });
+  });
+
+  describe('name propagation', () => {
+    it('propagates name attribute to all child options', async () => {
+      const { options } = await setup(defaultHtml);
+      for (const option of options) {
+        expect(option.name).toBe('theme');
+      }
+    });
+
+    it('propagates updated name to all children', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.name = 'color';
+      await group.updateComplete;
+      for (const option of options) {
+        expect(option.name).toBe('color');
+      }
+    });
+
+    it('propagates name to children added via slot', async () => {
+      const { group } = await setup(defaultHtml);
+      const newOption = document.createElement(optionTag) as ClippyCardRadioOption;
+      newOption.value = 'custom';
+      group.appendChild(newOption);
+      await newOption.updateComplete;
+      await group.updateComplete;
+      expect(newOption.name).toBe('theme');
+    });
+  });
+
+  describe('selection via user interaction', () => {
+    it('clicking an option sets group value', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[1].shadowRoot!.querySelector('input')!.click();
+      await group.updateComplete;
+      expect(group.value).toBe('dark');
+    });
+
+    it('clicking an option checks that option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[2].shadowRoot!.querySelector('input')!.click();
+      await group.updateComplete;
+      expect(options[2].checked).toBe(true);
+    });
+
+    it('clicking an option unchecks all others', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[1].shadowRoot!.querySelector('input')!.click();
+      await group.updateComplete;
+      expect(options[0].checked).toBe(false);
+      expect(options[1].checked).toBe(true);
+      expect(options[2].checked).toBe(false);
+    });
+
+    it('switching selection moves checked to new option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].shadowRoot!.querySelector('input')!.click();
+      await group.updateComplete;
+      options[2].shadowRoot!.querySelector('input')!.click();
+      await group.updateComplete;
+      expect(options[0].checked).toBe(false);
+      expect(options[2].checked).toBe(true);
+    });
+  });
+
+  describe('programmatic value', () => {
+    it('setting value checks the matching option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.value = 'system';
+      await group.updateComplete;
+      expect(options[2].checked).toBe(true);
+    });
+
+    it('setting value unchecks non-matching options', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.value = 'dark';
+      await group.updateComplete;
+      expect(options[0].checked).toBe(false);
+      expect(options[2].checked).toBe(false);
+    });
+
+    it('setting value to unrecognised string leaves selection unchanged', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.value = 'neon';
+      await group.updateComplete;
+      for (const option of options) {
+        expect(option.checked).toBe(false);
+      }
+    });
+  });
+
+  describe('roving tabindex', () => {
+    it('first option has tabindex=0 when nothing is checked', async () => {
+      const { options } = await setup(defaultHtml);
+      expect(options[0].inputTabIndex).toBe(0);
+      expect(options[1].inputTabIndex).toBe(-1);
+      expect(options[2].inputTabIndex).toBe(-1);
+    });
+
+    it('checked option gets tabindex=0, others get -1', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.value = 'dark';
+      await group.updateComplete;
+      expect(options[0].inputTabIndex).toBe(-1);
+      expect(options[1].inputTabIndex).toBe(0);
+      expect(options[2].inputTabIndex).toBe(-1);
+    });
+
+    it('tabindex follows selection change', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.value = 'light';
+      await group.updateComplete;
+      expect(options[0].inputTabIndex).toBe(0);
+
+      group.value = 'system';
+      await group.updateComplete;
+      expect(options[0].inputTabIndex).toBe(-1);
+      expect(options[2].inputTabIndex).toBe(0);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('ArrowDown selects next option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }));
+      expect(options[1].checked).toBe(true);
+      expect(group.value).toBe('dark');
+    });
+
+    it('ArrowRight selects next option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowRight' }));
+      expect(options[1].checked).toBe(true);
+      expect(group.value).toBe('dark');
+    });
+
+    it('ArrowUp selects previous option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[1].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowUp' }));
+      expect(options[0].checked).toBe(true);
+      expect(group.value).toBe('light');
+    });
+
+    it('ArrowLeft selects previous option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[2].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowLeft' }));
+      expect(options[1].checked).toBe(true);
+      expect(group.value).toBe('dark');
+    });
+
+    it('ArrowDown wraps from last to first', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[2].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }));
+      expect(options[0].checked).toBe(true);
+    });
+
+    it('ArrowUp wraps from first to last', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowUp' }));
+      expect(options[2].checked).toBe(true);
+    });
+
+    it('arrow keys prevent default to stop page scroll', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].focusInput();
+      const event = new KeyboardEvent('keydown', {
+        bubbles: true,
+        cancelable: true,
+        key: 'ArrowDown',
+      });
+      group.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('non-arrow keys do not change selection', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+      for (const option of options) {
+        expect(option.checked).toBe(false);
+      }
+    });
+
+    it('arrow keys do nothing when no option is focused', async () => {
+      const { group, options } = await setup(defaultHtml);
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }));
+      for (const option of options) {
+        expect(option.checked).toBe(false);
+      }
+    });
+
+    it('ArrowDown moves focus to next option', async () => {
+      const { group, options } = await setup(defaultHtml);
+      options[0].focusInput();
+      group.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'ArrowDown' }));
+      expect(options[1].matches(':focus-within')).toBe(true);
+    });
+  });
+
+  describe('form integration', () => {
+    it('submits selected value under the group name', async () => {
+      document.body.innerHTML = `
+        <form>
+          <${groupTag} name="theme">
+            <${optionTag} value="light">Light</${optionTag}>
+            <${optionTag} value="dark">Dark</${optionTag}>
+          </${groupTag}>
+        </form>
+      `;
+      const group = document.querySelector(groupTag) as ClippyCardRadioGroup;
+      await group.updateComplete;
+      for (const option of getOptions()) {
+        await option.updateComplete;
+      }
+
+      group.value = 'dark';
+      await group.updateComplete;
+
+      const form = document.querySelector('form')!;
+      const data = new FormData(form);
+      expect(data.get('theme')).toBe('dark');
+    });
+
+    it('form value updates when selection changes', async () => {
+      document.body.innerHTML = `
+        <form>
+          <${groupTag} name="color">
+            <${optionTag} value="red">Red</${optionTag}>
+            <${optionTag} value="blue">Blue</${optionTag}>
+          </${groupTag}>
+        </form>
+      `;
+      const group = document.querySelector(groupTag) as ClippyCardRadioGroup;
+      await group.updateComplete;
+      for (const option of getOptions()) {
+        await option.updateComplete;
+      }
+
+      group.value = 'red';
+      await group.updateComplete;
+      expect(new FormData(document.querySelector('form')!).get('color')).toBe('red');
+
+      group.value = 'blue';
+      await group.updateComplete;
+      expect(new FormData(document.querySelector('form')!).get('color')).toBe('blue');
+    });
+
+    it('submits no value when nothing is selected', async () => {
+      document.body.innerHTML = `
+        <form>
+          <${groupTag} name="theme">
+            <${optionTag} value="light">Light</${optionTag}>
+          </${groupTag}>
+        </form>
+      `;
+      const group = document.querySelector(groupTag) as ClippyCardRadioGroup;
+      await group.updateComplete;
+      const form = document.querySelector('form')!;
+      const data = new FormData(form);
+      expect(data.get('theme')).toBeNull();
+    });
+
+    it('is associated with the parent form', async () => {
+      document.body.innerHTML = `
+        <form>
+          <${groupTag} name="theme">
+            <${optionTag} value="light">Light</${optionTag}>
+          </${groupTag}>
+        </form>
+      `;
+      const group = document.querySelector(groupTag) as ClippyCardRadioGroup;
+      await group.updateComplete;
+      expect(group.form).toBe(document.querySelector('form'));
+    });
+  });
+});

--- a/packages/clippy-components/src/clippy-card-radio-group/index.ts
+++ b/packages/clippy-components/src/clippy-card-radio-group/index.ts
@@ -1,0 +1,135 @@
+import { safeCustomElement } from '@lib/decorators';
+import { html } from 'lit';
+import { ClippyCardRadioOption, radioTag } from '../clippy-card-radio-option/index';
+import { FormElement } from '../lib/FormElement';
+import { groupStyles } from './styles';
+
+const groupTag = 'clippy-card-radio-group';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [groupTag]: ClippyCardRadioGroup;
+  }
+}
+
+/**
+ * Form-associated radiogroup wrapping `<clippy-card-radio-option>` children. Extends
+ * `FormElement<string>` for native form participation. Sets `internals_.role =
+ * 'radiogroup'` in `connectedCallback` so the role exists before first render.
+ *
+ * **Tab roving:** `#syncTabIndex()` gives `tabindex="0"` to the checked card (or first
+ * card if none checked) and `-1` to all others — Tab enters/exits the group in one step.
+ *
+ * **Keyboard navigation:** Arrow keys move selection and focus, wrapping at both ends.
+ * `:focus-within` locates the active card; wrapping modulo picks the next; `#selectCard()`
+ * + `focusInput()` commit the move. `preventDefault()` suppresses page scroll.
+ *
+ * **Name propagation:** `name` changes are pushed to all child radios via `#syncName()`
+ * so inputs share a group name for form submission and native mutual-exclusion.
+ *
+ * **Value sync:** Programmatic `value` changes in `updated()` find and select the
+ * matching card to keep checked state and tabindex consistent.
+ */
+@safeCustomElement(groupTag)
+export class ClippyCardRadioGroup extends FormElement<string> {
+  static override readonly styles = [groupStyles];
+
+  readonly #handleChange = (event: Event) => {
+    const target = event.target;
+    if (!(target instanceof ClippyCardRadioOption)) {
+      return;
+    }
+    this.#selectCard(target);
+  };
+
+  readonly #handleKeyDown = (event: KeyboardEvent) => {
+    const { key } = event;
+
+    if (key !== 'ArrowDown' && key !== 'ArrowUp' && key !== 'ArrowLeft' && key !== 'ArrowRight') {
+      return;
+    }
+
+    const cards = this.#cards;
+    const currentIndex = cards.findIndex((card) => card.matches(':focus-within'));
+
+    if (currentIndex === -1) {
+      return;
+    }
+
+    const delta = key === 'ArrowDown' || key === 'ArrowRight' ? 1 : -1;
+    const nextCard = cards.at((currentIndex + delta + cards.length) % cards.length);
+
+    if (!nextCard) {
+      return;
+    }
+
+    // Prevent page scroll by pressing an arrow key
+    event.preventDefault();
+
+    this.#selectCard(nextCard);
+    nextCard.focusInput();
+  };
+
+  /** When the name of this element changes, we need to update the options */
+  #syncName() {
+    for (const card of this.#cards) {
+      card.name = this.name;
+    }
+  }
+
+  /** Roving tabindex: one card in the tab sequence (checked, or first as fallback) — all others at -1. */
+  #syncTabIndex() {
+    const cards = this.#cards;
+    const active = cards.find((card) => card.checked) ?? cards[0];
+    for (const card of cards) {
+      card.inputTabIndex = card === active ? 0 : -1;
+    }
+  }
+
+  #selectCard(selected: ClippyCardRadioOption) {
+    for (const card of this.#cards) {
+      card.checked = card === selected;
+    }
+    this.value = selected.value;
+    this.#syncTabIndex();
+  }
+
+  get #cards(): ClippyCardRadioOption[] {
+    return Array.from(this.querySelectorAll<ClippyCardRadioOption>(radioTag));
+  }
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.internals_.role = 'radiogroup';
+    this.addEventListener('change', this.#handleChange);
+    this.addEventListener('keydown', this.#handleKeyDown);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.removeEventListener('change', this.#handleChange);
+    this.removeEventListener('keydown', this.#handleKeyDown);
+  }
+
+  protected override updated(changed: Map<string, unknown>): void {
+    if (changed.has('name')) {
+      this.#syncName();
+    }
+    if (changed.has('value')) {
+      const match = this.#cards.find((card) => card.value === this.value);
+      if (match) {
+        this.#selectCard(match);
+      }
+    }
+    this.#syncTabIndex();
+  }
+
+  readonly #onSlotChange = () => {
+    this.#syncName();
+    this.#syncTabIndex();
+  };
+
+  override render() {
+    return html`<slot @slotchange=${this.#onSlotChange}></slot>`;
+  }
+}

--- a/packages/clippy-components/src/clippy-card-radio-group/styles.ts
+++ b/packages/clippy-components/src/clippy-card-radio-group/styles.ts
@@ -1,0 +1,12 @@
+import { css } from 'lit';
+
+export const groupStyles = css`
+  :host(:not([hidden])) {
+    display: flex;
+  }
+
+  :host {
+    flex-direction: column;
+    row-gap: var(--basis-space-row-lg);
+  }
+`;

--- a/packages/clippy-components/src/clippy-card-radio-option/README.md
+++ b/packages/clippy-components/src/clippy-card-radio-option/README.md
@@ -1,0 +1,61 @@
+# `<clippy-card-radio-option>`
+
+Single selectable card for use inside `<clippy-card-radio-group>`. The hidden `<input type="radio">` participates in form submission; the card is the visual surface. `delegatesFocus: true` forwards host focus to the hidden input.
+
+`inputTabIndex` and `checked` are managed by the parent `<clippy-card-radio-group>` — do not set them manually.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-card-radio-option';
+```
+
+Usually used inside `<clippy-card-radio-group>`:
+
+```html
+<clippy-card-radio-group name="plan">
+  <clippy-card-radio-option value="starter">
+    Starter
+    <span slot="description">Up to 3 projects</span>
+  </clippy-card-radio-option>
+
+  <clippy-card-radio-option value="pro">
+    Pro
+    <span slot="description">Unlimited projects</span>
+    <div slot="body">Everything in Starter, plus…</div>
+  </clippy-card-radio-option>
+</clippy-card-radio-group>
+```
+
+With a leading icon:
+
+```html
+<clippy-card-radio-option value="light">
+  <img slot="start" src="sun.svg" alt="" />
+  Light mode
+</clippy-card-radio-option>
+```
+
+## Attributes & properties
+
+| Attribute / Property | Type    | Default | Notes                          |
+| -------------------- | ------- | ------- | ------------------------------ |
+| `value`              | string  | `''`    | Submitted with the form        |
+| `name`               | string  | `''`    | Set automatically by the group |
+| `checked`            | boolean | `false` | Reflected; set by the group    |
+
+## Slots
+
+| Slot          | Description                                                     |
+| ------------- | --------------------------------------------------------------- |
+| _(default)_   | Card label (also the `<label>` text for the hidden radio input) |
+| `start`       | Leading slot — icon, image, or avatar                           |
+| `description` | Hint text below the label; linked via `aria-describedby`        |
+| `body`        | Card body content rendered below the header                     |
+| `footer`      | Card footer content rendered below the body                     |
+
+## Events
+
+| Event    | Description                                                    |
+| -------- | -------------------------------------------------------------- |
+| `change` | Fired when the option becomes checked; bubbles and is composed |

--- a/packages/clippy-components/src/clippy-card-radio-option/index.test.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/index.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import './index';
+import type { ClippyCardRadioOption } from './index';
+
+const tag = 'clippy-card-radio-option';
+
+async function setup(html: string) {
+  document.body.innerHTML = html;
+  const option = document.querySelector(tag) as ClippyCardRadioOption;
+  await option.updateComplete;
+  return option;
+}
+
+describe(`<${tag}>`, () => {
+  describe('rendering', () => {
+    it('renders a hidden radio input', async () => {
+      const option = await setup(`<${tag} value="light" name="theme">Light</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input[type="radio"]');
+      expect(input).toBeTruthy();
+    });
+
+    it('input has correct name attribute', async () => {
+      const option = await setup(`<${tag} value="dark" name="color">Dark</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      expect(input.name).toBe('color');
+    });
+
+    it('input has correct value attribute', async () => {
+      const option = await setup(`<${tag} value="dark" name="color">Dark</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      expect(input.value).toBe('dark');
+    });
+
+    it('renders a label element', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const label = option.shadowRoot!.querySelector('label');
+      expect(label).toBeTruthy();
+    });
+
+    it('label is associated with the input via for/id', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      const label = option.shadowRoot!.querySelector('label') as HTMLLabelElement;
+      expect(label.htmlFor).toBe(input.id);
+    });
+  });
+
+  describe('slots', () => {
+    it('default slot renders inside label', async () => {
+      const option = await setup(`<${tag}>My Label</${tag}>`);
+      const labelSlot = option.shadowRoot!.querySelector('label slot:not([name])');
+      expect(labelSlot).toBeTruthy();
+    });
+
+    it('description slot is present', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const descSlot = option.shadowRoot!.querySelector('slot[name="description"]');
+      expect(descSlot).toBeTruthy();
+    });
+
+    it('description slot is linked via aria-describedby', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      const describedBy = input.getAttribute('aria-describedby') ?? '';
+      expect(describedBy).toBeTruthy();
+      const descContainer = option.shadowRoot!.getElementById(describedBy);
+      expect(descContainer).toBeTruthy();
+      expect(descContainer!.querySelector('slot[name="description"]')).toBeTruthy();
+    });
+
+    it('body slot is present', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const bodySlot = option.shadowRoot!.querySelector('slot[name="body"]');
+      expect(bodySlot).toBeTruthy();
+    });
+
+    it('footer slot is present', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const footerSlot = option.shadowRoot!.querySelector('slot[name="footer"]');
+      expect(footerSlot).toBeTruthy();
+    });
+
+    it('start slot absent: no --with-start class on header', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      await option.updateComplete;
+      const header = option.shadowRoot!.querySelector('.clippy-card-radio-option__header');
+      expect(header!.classList.contains('clippy-card-radio-option__header--with-start')).toBe(false);
+    });
+
+    it('start slot filled: adds --with-start class on header', async () => {
+      const option = await setup(`
+        <${tag}>
+          <img slot="start" src="icon.png" alt="" />
+          Label
+        </${tag}>
+      `);
+      await option.updateComplete;
+      const header = option.shadowRoot!.querySelector('.clippy-card-radio-option__header');
+      expect(header!.classList.contains('clippy-card-radio-option__header--with-start')).toBe(true);
+    });
+
+    it('start slot filled: start content wrapped in span', async () => {
+      const option = await setup(`
+        <${tag}>
+          <img slot="start" src="icon.png" alt="" />
+          Label
+        </${tag}>
+      `);
+      await option.updateComplete;
+      const startSpan = option.shadowRoot!.querySelector('.clippy-card-radio-option__start');
+      expect(startSpan).toBeTruthy();
+    });
+
+    it('start slot empty: no start span rendered', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const startSpan = option.shadowRoot!.querySelector('.clippy-card-radio-option__start');
+      expect(startSpan).toBeNull();
+    });
+  });
+
+  describe('checked state', () => {
+    it('unchecked by default', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      expect(option.checked).toBe(false);
+    });
+
+    it('checked attribute sets initial state', async () => {
+      const option = await setup(`<${tag} checked>Label</${tag}>`);
+      expect(option.checked).toBe(true);
+    });
+
+    it('checked reflects as attribute', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      option.checked = true;
+      await option.updateComplete;
+      expect(option.hasAttribute('checked')).toBe(true);
+    });
+
+    it('unchecked removes attribute', async () => {
+      const option = await setup(`<${tag} checked>Label</${tag}>`);
+      option.checked = false;
+      await option.updateComplete;
+      expect(option.hasAttribute('checked')).toBe(false);
+    });
+
+    it('input checked state matches property', async () => {
+      const option = await setup(`<${tag} checked>Label</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      expect(input.checked).toBe(true);
+    });
+  });
+
+  describe('change event', () => {
+    it('clicking input fires change event on the option element', async () => {
+      const option = await setup(`<${tag} value="light" name="theme">Light</${tag}>`);
+      let fired = false;
+      option.addEventListener('change', () => {
+        fired = true;
+      });
+      option.shadowRoot!.querySelector('input')!.click();
+      expect(fired).toBe(true);
+    });
+
+    it('change event bubbles', async () => {
+      const option = await setup(`<${tag} value="light" name="theme">Light</${tag}>`);
+      const events: Event[] = [];
+      document.addEventListener('change', (e) => events.push(e), { once: true });
+      option.shadowRoot!.querySelector('input')!.click();
+      expect(events[0]?.bubbles).toBe(true);
+    });
+
+    it('change event is composed', async () => {
+      const option = await setup(`<${tag} value="light" name="theme">Light</${tag}>`);
+      const events: Event[] = [];
+      option.addEventListener('change', (e) => events.push(e), { once: true });
+      option.shadowRoot!.querySelector('input')!.click();
+      expect(events[0]?.composed).toBe(true);
+    });
+
+    it('clicking input sets checked=true', async () => {
+      const option = await setup(`<${tag} value="light" name="theme">Light</${tag}>`);
+      option.shadowRoot!.querySelector('input')!.click();
+      expect(option.checked).toBe(true);
+    });
+  });
+
+  describe('tabindex', () => {
+    it('input tabindex defaults to -1', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      expect(input.tabIndex).toBe(-1);
+    });
+
+    it('inputTabIndex=0 sets input tabindex to 0', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      option.inputTabIndex = 0;
+      await option.updateComplete;
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      expect(input.tabIndex).toBe(0);
+    });
+
+    it('inputTabIndex=-1 keeps input out of tab order', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      option.inputTabIndex = -1;
+      await option.updateComplete;
+      const input = option.shadowRoot!.querySelector('input') as HTMLInputElement;
+      expect(input.tabIndex).toBe(-1);
+    });
+  });
+
+  describe('focusInput()', () => {
+    it('focusInput() makes option match :focus-within', async () => {
+      const option = await setup(`<${tag}>Label</${tag}>`);
+      option.inputTabIndex = 0;
+      await option.updateComplete;
+      option.focusInput();
+      expect(option.matches(':focus-within')).toBe(true);
+    });
+  });
+});

--- a/packages/clippy-components/src/clippy-card-radio-option/index.test.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/index.test.ts
@@ -80,25 +80,6 @@ describe(`<${tag}>`, () => {
       expect(footerSlot).toBeTruthy();
     });
 
-    it('start slot absent: no --with-start class on header', async () => {
-      const option = await setup(`<${tag}>Label</${tag}>`);
-      await option.updateComplete;
-      const header = option.shadowRoot!.querySelector('.clippy-card-radio-option__header');
-      expect(header!.classList.contains('clippy-card-radio-option__header--with-start')).toBe(false);
-    });
-
-    it('start slot filled: adds --with-start class on header', async () => {
-      const option = await setup(`
-        <${tag}>
-          <img slot="start" src="icon.png" alt="" />
-          Label
-        </${tag}>
-      `);
-      await option.updateComplete;
-      const header = option.shadowRoot!.querySelector('.clippy-card-radio-option__header');
-      expect(header!.classList.contains('clippy-card-radio-option__header--with-start')).toBe(true);
-    });
-
     it('start slot filled: start content wrapped in span', async () => {
       const option = await setup(`
         <${tag}>
@@ -111,10 +92,10 @@ describe(`<${tag}>`, () => {
       expect(startSpan).toBeTruthy();
     });
 
-    it('start slot empty: no start span rendered', async () => {
+    it('start slot empty: empty start span rendered', async () => {
       const option = await setup(`<${tag}>Label</${tag}>`);
       const startSpan = option.shadowRoot!.querySelector('.clippy-card-radio-option__start');
-      expect(startSpan).toBeNull();
+      expect(startSpan).toBeTruthy();
     });
   });
 

--- a/packages/clippy-components/src/clippy-card-radio-option/index.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/index.ts
@@ -1,0 +1,109 @@
+import { safeCustomElement } from '@lib/decorators';
+import { LitElement, html } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import srOnly from '../lib/sr-only';
+import { radioStyles } from './styles';
+
+export const radioTag = 'clippy-card-radio-option';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [radioTag]: ClippyCardRadioOption;
+  }
+}
+
+/**
+ * Radio option styled as a card. The `<input type="radio">` is sr-only; the card is the
+ * visual surface. `delegatesFocus: true` forwards host focus to the hidden input.
+ *
+ * `inputTabIndex` is controlled by the parent `ClippyCardRadioGroup` for roving tabindex.
+ * `focusInput()` lets the parent move focus programmatically during arrow-key navigation.
+ *
+ * Slots: default (label), `start` (leading icon), `description` (aria-describedby), `body`, `footer`.
+ */
+@safeCustomElement(radioTag)
+export class ClippyCardRadioOption extends LitElement {
+  static override readonly styles = [srOnly, radioStyles];
+  static override readonly shadowRootOptions = { ...LitElement.shadowRootOptions, delegatesFocus: true };
+
+  @property({ type: String }) value = '';
+  @property({ type: String }) name = '';
+  @property({ reflect: true, type: Boolean }) checked = false;
+  @property({ attribute: false, type: Number }) inputTabIndex = -1;
+  @state() private hasStart = false;
+  @state() private hasBody = false;
+  @state() private hasFooter = false;
+
+  readonly #inputId = crypto.randomUUID();
+
+  #handleChange() {
+    this.checked = true;
+    this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+  }
+
+  readonly #onStartSlotChange = (event: Event) => {
+    const slot = event.target as HTMLSlotElement;
+    this.hasStart = slot.assignedNodes({ flatten: true }).length > 0;
+  };
+
+  readonly #onBodySlotChange = (event: Event) => {
+    const slot = event.target as HTMLSlotElement;
+    this.hasBody = slot.assignedNodes({ flatten: true }).length > 0;
+  };
+
+  readonly #onFooterSlotChange = (event: Event) => {
+    const slot = event.target as HTMLSlotElement;
+    this.hasFooter = slot.assignedNodes({ flatten: true }).length > 0;
+  };
+
+  focusInput() {
+    const input = this.shadowRoot?.querySelector('input');
+    if (!input) {
+      return;
+    }
+    input.focus();
+  }
+
+  override render() {
+    const startSlot = html`<slot name="start" @slotchange=${this.#onStartSlotChange}></slot>`;
+    const descriptionId = `${this.#inputId}-description`;
+
+    return html`
+      <input
+        class="sr-only"
+        id=${this.#inputId}
+        type="radio"
+        name=${this.name}
+        value=${this.value}
+        tabindex=${this.inputTabIndex}
+        .checked=${this.checked}
+        @change=${this.#handleChange}
+        aria-describedby=${descriptionId}
+      />
+      <div
+        class="clippy-card-radio-option__header ${classMap({
+          'clippy-card-radio-option__header--with-start': this.hasStart,
+        })}"
+      >
+        ${this.hasStart ? html`<span class="clippy-card-radio-option__start">${startSlot}</span>` : startSlot}
+        <label class="clippy-card-radio-option__label" for=${this.#inputId}>
+          <slot></slot>
+        </label>
+        <div class="clippy-card-radio-option__description" id=${descriptionId}>
+          <slot name="description"></slot>
+        </div>
+      </div>
+      ${this.hasBody
+        ? html`<div class="clippy-radio-card__body">
+            <slot name="body" @slotchange=${this.#onBodySlotChange}></slot>
+          </div>`
+        : html`<slot name="body" @slotchange=${this.#onBodySlotChange}></slot>`}
+      ${this.hasFooter
+        ? html`<div class="clippy-radio-card__footer">
+            <slot name="footer" @slotchange=${this.#onFooterSlotChange}></slot>
+          </div>`
+        : html`<slot name="footer" @slotchange=${this.#onFooterSlotChange}></slot>`}
+    `;
+  }
+}

--- a/packages/clippy-components/src/clippy-card-radio-option/index.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/index.ts
@@ -1,7 +1,6 @@
 import { safeCustomElement } from '@lib/decorators';
 import { LitElement, html } from 'lit';
-import { property, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
+import { property, query, state } from 'lit/decorators.js';
 import srOnly from '../lib/sr-only';
 import { radioStyles } from './styles';
 
@@ -31,9 +30,9 @@ export class ClippyCardRadioOption extends LitElement {
   @property({ type: String }) name = '';
   @property({ reflect: true, type: Boolean }) checked = false;
   @property({ attribute: false, type: Number }) inputTabIndex = -1;
-  @state() private hasStart = false;
   @state() private hasBody = false;
   @state() private hasFooter = false;
+  @query('input') input!: HTMLInputElement;
 
   readonly #inputId = crypto.randomUUID();
 
@@ -41,11 +40,6 @@ export class ClippyCardRadioOption extends LitElement {
     this.checked = true;
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
   }
-
-  readonly #onStartSlotChange = (event: Event) => {
-    const slot = event.target as HTMLSlotElement;
-    this.hasStart = slot.assignedNodes({ flatten: true }).length > 0;
-  };
 
   readonly #onBodySlotChange = (event: Event) => {
     const slot = event.target as HTMLSlotElement;
@@ -58,15 +52,10 @@ export class ClippyCardRadioOption extends LitElement {
   };
 
   focusInput() {
-    const input = this.shadowRoot?.querySelector('input');
-    if (!input) {
-      return;
-    }
-    input.focus();
+    this.input.focus();
   }
 
   override render() {
-    const startSlot = html`<slot name="start" @slotchange=${this.#onStartSlotChange}></slot>`;
     const descriptionId = `${this.#inputId}-description`;
 
     return html`
@@ -81,17 +70,15 @@ export class ClippyCardRadioOption extends LitElement {
         @change=${this.#handleChange}
         aria-describedby=${descriptionId}
       />
-      <div
-        class="clippy-card-radio-option__header ${classMap({
-          'clippy-card-radio-option__header--with-start': this.hasStart,
-        })}"
-      >
-        ${this.hasStart ? html`<span class="clippy-card-radio-option__start">${startSlot}</span>` : startSlot}
-        <label class="clippy-card-radio-option__label" for=${this.#inputId}>
-          <slot></slot>
-        </label>
-        <div class="clippy-card-radio-option__description" id=${descriptionId}>
-          <slot name="description"></slot>
+      <div class="clippy-card-radio-option__header">
+        <slot name="start" class="clippy-card-radio-option__start"></slot>
+        <div class="clippy-card-radio-option__header-body">
+          <label class="clippy-card-radio-option__label" for=${this.#inputId}>
+            <slot></slot>
+          </label>
+          <div class="clippy-card-radio-option__description" id=${descriptionId}>
+            <slot name="description"></slot>
+          </div>
         </div>
       </div>
       ${this.hasBody

--- a/packages/clippy-components/src/clippy-card-radio-option/styles.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/styles.ts
@@ -19,10 +19,6 @@ export const radioStyles = css`
     position: relative;
   }
 
-  .clippy-card-radio-option__start {
-    align-self: center;
-  }
-
   /**
    * 1. Pseudo element that overlays the entire radio card to make it entirely mouse-interactive;
    *    This element also takes care of the additional border-width on interaction and [checked] state.
@@ -57,9 +53,9 @@ export const radioStyles = css`
   }
 
   .clippy-card-radio-option__header {
-    align-items: start;
-    display: grid;
-    grid-template-rows: auto auto;
+    align-items: center;
+    column-gap: var(--basis-space-inline-lg);
+    display: flex;
     justify-content: start;
     min-block-size: var(--basis-pointer-target-min-block-size);
     padding-block-end: var(--basis-space-inline-lg);
@@ -68,25 +64,17 @@ export const radioStyles = css`
     padding-inline-start: var(--basis-space-inline-xl);
   }
 
-  .clippy-card-radio-option__header--with-start {
-    align-items: center;
-    column-gap: var(--basis-space-inline-lg);
-    grid-template-columns: min-content minmax(0, 1fr);
+  .clippy-card-radio-option__start {
+    align-self: center;
+    flex-basis: auto;
+    flex-grow: 0;
+    flex-shrink: 0;
+  }
 
-    & .clippy-card-radio-option__start {
-      grid-column: 1;
-      grid-row: 1 / -1;
-    }
-
-    & .clippy-card-radio-option__label {
-      grid-column: 2;
-      grid-row: 1;
-    }
-
-    & .clippy-card-radio-option__description {
-      grid-column: 2;
-      grid-row: 2;
-    }
+  .clippy-card-radio-option__header-body {
+    align-self: start;
+    flex: 1;
+    min-inline-size: 0;
   }
 
   .clippy-radio-card__body {

--- a/packages/clippy-components/src/clippy-card-radio-option/styles.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/styles.ts
@@ -1,0 +1,169 @@
+import { css } from 'lit';
+
+export const radioStyles = css`
+  :host(:not([hidden])) {
+    display: block;
+  }
+
+  /* ELEMENTS */
+
+  :host {
+    --_clippy-card-radio-option-border-radius: var(--basis-border-radius-md);
+
+    background-color: var(--basis-color-default-bg-document);
+    border-color: var(--basis-color-default-border-subtle);
+    border-radius: var(--_clippy-card-radio-option-border-radius);
+    border-style: solid;
+    border-width: var(--basis-border-width-sm);
+    min-inline-size: var(--basis-pointer-target-min-inline-size);
+    position: relative;
+  }
+
+  .clippy-card-radio-option__start {
+    align-self: center;
+  }
+
+  /**
+   * 1. Pseudo element that overlays the entire radio card to make it entirely mouse-interactive;
+   *    This element also takes care of the additional border-width on interaction and [checked] state.
+   */
+  .clippy-card-radio-option__label {
+    /* [1] */
+    color: var(--basis-color-default-color-document);
+    font-family: var(--basis-text-font-family-default);
+    font-size: var(--basis-text-font-size-md);
+    font-weight: var(--basis-text-font-weight-bold);
+    line-height: var(--basis-text-line-height-md);
+
+    /* [1] */
+    &::after {
+      border-color: var(--basis-form-control-border-color);
+      border-radius: var(--_clippy-card-radio-option-border-radius);
+      border-style: solid;
+      border-width: var(--basis-border-width-none);
+      content: '';
+      cursor: pointer;
+      inset: 0;
+      position: absolute;
+    }
+  }
+
+  .clippy-card-radio-option__description {
+    color: var(--basis-color-default-color-subtle);
+    font-family: var(--basis-text-font-family-default);
+    font-size: var(--basis-text-font-size-md);
+    font-weight: var(--basis-text-font-weight-default);
+    line-height: var(--basis-text-line-height-md);
+  }
+
+  .clippy-card-radio-option__header {
+    align-items: start;
+    display: grid;
+    grid-template-rows: auto auto;
+    justify-content: start;
+    min-block-size: var(--basis-pointer-target-min-block-size);
+    padding-block-end: var(--basis-space-inline-lg);
+    padding-block-start: var(--basis-space-inline-lg);
+    padding-inline-end: var(--basis-space-inline-xl);
+    padding-inline-start: var(--basis-space-inline-xl);
+  }
+
+  .clippy-card-radio-option__header--with-start {
+    align-items: center;
+    column-gap: var(--basis-space-inline-lg);
+    grid-template-columns: min-content minmax(0, 1fr);
+
+    & .clippy-card-radio-option__start {
+      grid-column: 1;
+      grid-row: 1 / -1;
+    }
+
+    & .clippy-card-radio-option__label {
+      grid-column: 2;
+      grid-row: 1;
+    }
+
+    & .clippy-card-radio-option__description {
+      grid-column: 2;
+      grid-row: 2;
+    }
+  }
+
+  .clippy-radio-card__body {
+    padding-block-end: var(--basis-space-inline-xl);
+    padding-block-start: var(--basis-space-none);
+    padding-inline-end: var(--basis-space-inline-xl);
+    padding-inline-start: var(--basis-space-inline-xl);
+  }
+
+  .clippy-radio-card__footer {
+    padding-block-end: var(--basis-space-inline-xl);
+    padding-block-start: var(--basis-space-none);
+    padding-inline-end: var(--basis-space-inline-xl);
+    padding-inline-start: var(--basis-space-inline-xl);
+  }
+
+  /* HOST STATES */
+
+  /* :host(:focus-visible-within) would be ideal but is not yet spec'd (w3c/csswg-drafts#3080).
+     :host(:has(:focus-visible)) also fails — browsers don't re-invalidate shadow styles
+     when dynamic pseudo-classes change on shadow children inside :has() (w3c/csswg-drafts#5893). */
+  :host(:focus-within) {
+    outline-color: var(--basis-focus-outline-color);
+    outline-offset: var(--basis-focus-outline-offset);
+    outline-style: var(--basis-focus-outline-style);
+    outline-width: var(--basis-focus-outline-width);
+    background-color: var(--basis-form-control-focus-background-color);
+    color: var(--basis-form-control-focus-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-focus-border-color);
+      border-width: var(--basis-form-control-focus-border-width);
+    }
+  }
+
+  :host([checked]) {
+    background-color: var(--basis-color-default-bg-document);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-active-border-color);
+      border-width: var(--basis-border-width-md);
+    }
+  }
+
+  :host([checked]:hover) {
+    background-color: var(--basis-form-control-hover-background-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-hover-border-color);
+      border-width: var(--basis-border-width-md);
+    }
+  }
+
+  :host([checked]:active) {
+    background-color: var(--basis-form-control-active-background-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-active-border-color);
+      border-width: var(--basis-border-width-md);
+    }
+  }
+
+  :host(:hover) {
+    background-color: var(--basis-form-control-hover-background-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-hover-border-color);
+      border-width: var(--basis-border-width-md);
+    }
+  }
+
+  :host(:active) {
+    background-color: var(--basis-form-control-active-background-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-active-border-color);
+      border-width: var(--basis-border-width-md);
+    }
+  }
+`;

--- a/packages/clippy-components/src/clippy-card-radio-option/styles.ts
+++ b/packages/clippy-components/src/clippy-card-radio-option/styles.ts
@@ -109,16 +109,34 @@ export const radioStyles = css`
      :host(:has(:focus-visible)) also fails — browsers don't re-invalidate shadow styles
      when dynamic pseudo-classes change on shadow children inside :has() (w3c/csswg-drafts#5893). */
   :host(:focus-within) {
+    background-color: var(--basis-form-control-focus-background-color);
+    color: var(--basis-form-control-focus-color);
     outline-color: var(--basis-focus-outline-color);
     outline-offset: var(--basis-focus-outline-offset);
     outline-style: var(--basis-focus-outline-style);
     outline-width: var(--basis-focus-outline-width);
-    background-color: var(--basis-form-control-focus-background-color);
-    color: var(--basis-form-control-focus-color);
 
     & .clippy-card-radio-option__label::after {
       border-color: var(--basis-form-control-focus-border-color);
       border-width: var(--basis-form-control-focus-border-width);
+    }
+  }
+
+  :host(:hover) {
+    background-color: var(--basis-form-control-hover-background-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-hover-border-color);
+      border-width: var(--basis-border-width-md);
+    }
+  }
+
+  :host(:active) {
+    background-color: var(--basis-form-control-active-background-color);
+
+    & .clippy-card-radio-option__label::after {
+      border-color: var(--basis-form-control-active-border-color);
+      border-width: var(--basis-border-width-md);
     }
   }
 
@@ -141,24 +159,6 @@ export const radioStyles = css`
   }
 
   :host([checked]:active) {
-    background-color: var(--basis-form-control-active-background-color);
-
-    & .clippy-card-radio-option__label::after {
-      border-color: var(--basis-form-control-active-border-color);
-      border-width: var(--basis-border-width-md);
-    }
-  }
-
-  :host(:hover) {
-    background-color: var(--basis-form-control-hover-background-color);
-
-    & .clippy-card-radio-option__label::after {
-      border-color: var(--basis-form-control-hover-border-color);
-      border-width: var(--basis-border-width-md);
-    }
-  }
-
-  :host(:active) {
     background-color: var(--basis-form-control-active-background-color);
 
     & .clippy-card-radio-option__label::after {

--- a/packages/clippy-storybook/src/web-components/clippy-card-radio.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-card-radio.stories.tsx
@@ -1,0 +1,257 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '@nl-design-system-community/clippy-components/clippy-card-radio-group';
+import React from 'react';
+
+interface ClippyCardRadioStoryArgs {
+  name: string;
+  value: string;
+}
+
+const meta: Meta<ClippyCardRadioStoryArgs> = {
+  id: 'clippy-card-radio-group',
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'Form field name shared across all radio options',
+    },
+    value: {
+      control: 'text',
+      description: 'Currently selected value',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '`<clippy-card-radio-group>` is a form-associated radio group. Each `<clippy-card-radio-option>` child is a selectable card option. Only one card can be selected at a time. The group reports its value to the parent `<form>` via ElementInternals.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  title: 'clippy/Card Radio Group',
+};
+
+export default meta;
+type Story = StoryObj<ClippyCardRadioStoryArgs>;
+
+export const Default: Story = {
+  name: 'Basic group',
+  args: {
+    name: 'font',
+    value: '',
+  },
+  render: ({ name, value }) =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name, value },
+      React.createElement('clippy-card-radio-option', { value: 'sans' }, 'Sans Serif'),
+      React.createElement('clippy-card-radio-option', { value: 'serif' }, 'Serif'),
+      React.createElement('clippy-card-radio-option', { value: 'mono' }, 'Monospace'),
+    ),
+};
+
+export const MultipleGroups: Story = {
+  name: 'Multiple groups',
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story:
+          'Two independent groups with the same option values. Selecting an option in one group never affects the other — each `<clippy-card-radio-option>` belongs to exactly one parent group.',
+      },
+    },
+  },
+  render: () =>
+    React.createElement(
+      'div',
+      { style: { alignItems: 'flex-start', display: 'flex', gap: '1rem' } },
+      React.createElement(
+        'fieldset',
+        null,
+        React.createElement('legend', null, 'Character'),
+        React.createElement(
+          'clippy-card-radio-group',
+          { name: 'character' },
+          React.createElement('clippy-card-radio-option', { value: 'wallace' }, 'Wallace'),
+          React.createElement('clippy-card-radio-option', { value: 'gromit' }, 'Gromit'),
+        ),
+      ),
+      React.createElement(
+        'fieldset',
+        null,
+        React.createElement('legend', null, 'Snack'),
+        React.createElement(
+          'clippy-card-radio-group',
+          { name: 'snack' },
+          React.createElement('clippy-card-radio-option', { value: 'tea' }, 'Tea'),
+          React.createElement('clippy-card-radio-option', { value: 'crackers-and-cheese' }, 'Crackers & Cheese'),
+        ),
+      ),
+    ),
+};
+
+export const PreselectedValue: Story = {
+  name: 'Pre-selected value',
+  parameters: {
+    controls: { disable: true },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name: 'color', value: 'blue' },
+      React.createElement('clippy-card-radio-option', { value: 'red' }, 'Red'),
+      React.createElement('clippy-card-radio-option', { value: 'blue' }, 'Blue'),
+      React.createElement('clippy-card-radio-option', { value: 'green' }, 'Green'),
+    ),
+};
+
+export const SlotStart: Story = {
+  name: 'Slot: start',
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: 'Use the `start` slot for a leading icon, thumbnail, or color swatch.',
+      },
+    },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name: 'shape' },
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'circle' },
+        React.createElement('span', { slot: 'start' }, '⬤'),
+        'Circle',
+      ),
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'square' },
+        React.createElement('span', { slot: 'start' }, '■'),
+        'Square',
+      ),
+    ),
+};
+
+export const SlotDescription: Story = {
+  name: 'Slot: description',
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: 'Use the `description` slot for a short explanatory text below the label.',
+      },
+    },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name: 'style' },
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'minimal' },
+        'Minimal',
+        React.createElement('span', { slot: 'description' }, 'Clean, lots of whitespace'),
+      ),
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'expressive' },
+        'Expressive',
+        React.createElement('span', { slot: 'description' }, 'Bold colors and large type'),
+      ),
+    ),
+};
+
+export const SlotBody: Story = {
+  name: 'Slot: body',
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: 'Use the `body` slot for richer preview content such as a type specimen or color swatch.',
+      },
+    },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name: 'typeface' },
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'sans' },
+        'Sans Serif',
+        React.createElement('div', { slot: 'body', style: { fontFamily: 'sans-serif', fontSize: '2rem' } }, 'Aa'),
+      ),
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'serif' },
+        'Serif',
+        React.createElement('div', { slot: 'body', style: { fontFamily: 'serif', fontSize: '2rem' } }, 'Aa'),
+      ),
+    ),
+};
+
+export const SlotFooter: Story = {
+  name: 'Slot: footer',
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: 'Use the `footer` slot for metadata such as usage counts or secondary actions.',
+      },
+    },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name: 'color-pick' },
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: '#007BC7' },
+        '#007BC7',
+        React.createElement('small', { slot: 'footer' }, 'Used 34× on your site'),
+      ),
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: '#154273' },
+        '#154273',
+        React.createElement('small', { slot: 'footer' }, 'Used 12× on your site'),
+      ),
+    ),
+};
+
+export const AllSlots: Story = {
+  name: 'All slots combined',
+  parameters: {
+    controls: { disable: true },
+    docs: {
+      description: {
+        story: 'All four optional slots used together: `start`, default label, `description`, `body`, `footer`.',
+      },
+    },
+  },
+  render: () =>
+    React.createElement(
+      'clippy-card-radio-group',
+      { name: 'full-example', value: 'option-a' },
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'option-a' },
+        React.createElement('span', { slot: 'start' }, '🎨'),
+        'Option A',
+        React.createElement('span', { slot: 'description' }, 'A short description of this option'),
+        React.createElement('div', { slot: 'body' }, 'Preview content goes here'),
+        React.createElement('small', { slot: 'footer' }, 'Additional metadata'),
+      ),
+      React.createElement(
+        'clippy-card-radio-option',
+        { value: 'option-b' },
+        React.createElement('span', { slot: 'start' }, '✏️'),
+        'Option B',
+        React.createElement('span', { slot: 'description' }, 'A different description'),
+        React.createElement('div', { slot: 'body' }, 'Different preview content'),
+        React.createElement('small', { slot: 'footer' }, 'Other metadata'),
+      ),
+    ),
+};


### PR DESCRIPTION
refs #824 

Voegt een nieuwe clippy component toe die toestaat om met een Card-like UI radio button te selecteren. Tokens in CSS zijn in overleg met @jeffreylauwers geimplementeerd en nagekeken. Vooralsnog geen instelbare tokens ingesteld, maar zou niet moeilijk moeten zijn om hierna te doen.

## In storybook
<img width="1248" height="995" alt="Screenshot 2026-06-29 at 15 45 57" src="https://github.com/user-attachments/assets/c76d9605-e2e9-45ce-a5f3-ad8c33f684bf" />
<img width="1116" height="578" alt="Screenshot 2026-06-29 at 15 46 08" src="https://github.com/user-attachments/assets/ac1adb9f-51d3-4e08-a2ea-bcbc9e93b548" />

## In theme wizard UI

(Niet in deze PR)

<img width="842" height="867" alt="Screenshot 2026-06-29 at 15 50 04" src="https://github.com/user-attachments/assets/1d4e1009-fb71-47f1-95d6-966112600227" />
<img width="810" height="1191" alt="Screenshot 2026-06-29 at 15 50 22" src="https://github.com/user-attachments/assets/8f4746af-8ee4-4a33-b4f5-78077cc4aab8" />


