### PR TITLE
ci: rewrite codecov to use workflow_call and upgrade codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
 name: Continuous Integration
-# Triggers the following workflows:
-# - .github/workflows/codecov.yml
 
 on: pull_request
 
@@ -159,6 +157,12 @@ jobs:
           name: coverage-report
           path: "**/coverage/"
           retention-days: 1
+
+  codecov:
+    needs: test
+    uses: ./.github/workflows/codecov.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,11 +1,10 @@
-name: Codecov for pull requests
+name: Codecov
 
 on:
-  workflow_run:
-    workflows:
-      - Continuous Integration
-    types:
-      - completed
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 
 permissions:
   contents: read
@@ -13,16 +12,14 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
           # Make sure that history is available to Codecov
-          fetch-depth: 0
-
+          fetch-depth: 2
           persist-credentials: false
+
       - name: Install pnpm package manager
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
@@ -43,15 +40,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-report
-          # Needed to download an artifact created in a different workflow
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Upload coverage to codecov.io
         id: codecov-action
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
-          override_commit: ${{ github.event.workflow_run.head_sha }}
-          override_pr: ${{ github.event.workflow_run.pull_requests[0].number }}
+          override_commit: ${{ github.event.pull_request.head.sha }}
+          override_pr: ${{ github.event.pull_request.number }}
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The `workflow_call` change is necessary because it is safer than `workflow_run`.

The v7 upgrade is necessary because older versions seem to have a public key problem (disallowing this job from running).
