### PR TITLE
feat: styleguide split into 2 pages

### DIFF
--- a/packages/theme-wizard-website/e2e/styleguide-tokens.spec.ts
+++ b/packages/theme-wizard-website/e2e/styleguide-tokens.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from './fixtures/fixtures';
 
 test('page has accessibility basics', async ({ page }) => {
-  await page.goto('/style-guide');
+  await page.goto('/style-guide/design-tokens');
 
   // Has <title>
   const title = await page.title();
@@ -11,6 +11,11 @@ test('page has accessibility basics', async ({ page }) => {
   await expect.soft(page.locator('html')).toHaveAttribute('lang', 'nl-NL');
 });
 
+test('shows sidebar with all styleguide pages', async ({ page }) => {
+  await page.goto('/style-guide/design-tokens');
+  await expect(page.locator('wizard-sidebar-link')).not.toHaveCount(0);
+});
+
 test('page uses values as stored by the configuration page', async ({ basisTokensPage, page }) => {
   // Set Accent 1 to red
   await basisTokensPage.goto();
@@ -18,7 +23,7 @@ test('page uses values as stored by the configuration page', async ({ basisToken
   await basisTokensPage.changeColor('Accent 1', '#ff0000');
 
   // Style guide page uses the same storage and theme, thus showing a red-ish initial for accent-1.border-default
-  await page.goto('/style-guide');
+  await page.goto('/style-guide/design-tokens');
   const table = page.getByRole('table', { name: 'Accent 1' });
   await expect(table).toBeVisible();
   await expect(table.getByRole('button', { name: 'Kopieer "#ff0000" naar klembord' })).toBeVisible();
@@ -28,9 +33,9 @@ test.describe('interaction tests', () => {
   test.beforeEach(async ({ context, page }) => {
     // Enable clipboard access to we can test working of copy-to-clipboard buttons
     await context.grantPermissions(['clipboard-write', 'clipboard-read']);
-    await page.goto('/style-guide');
+    await page.goto('/style-guide/design-tokens');
     // Make sure to wait for page to be fully rendered
-    await expect(page.getByRole('heading', { name: 'Stijlgids' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Design Tokens' })).toBeVisible();
   });
 
   test.describe('colors', () => {

--- a/packages/theme-wizard-website/src/components/StyleGuideNav.astro
+++ b/packages/theme-wizard-website/src/components/StyleGuideNav.astro
@@ -1,0 +1,13 @@
+---
+const slug = Astro.url.pathname;
+const pages: { title: string; slug: string }[] = [
+  { title: 'Kleur systeem', slug: '/style-guide/color-system' },
+  { title: 'Design tokens', slug: '/style-guide/design-tokens' },
+];
+---
+
+<nav slot="sidebar">
+  {pages.map((page) => (
+    <wizard-sidebar-link href={page.slug} current={page.slug === slug ? 'page' : undefined}>{page.title}</wizard-sidebar-link>
+  ))}
+</nav>

--- a/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
@@ -1,0 +1,19 @@
+---
+import StyleGuideNav from '@/components/StyleGuideNav.astro';
+import BaseLayout from '@/layouts/BaseLayout.astro';
+import '@nl-design-system-community/clippy-components/clippy-story-preview';
+
+---
+
+<BaseLayout title="Stijlgids kleur systeem - Theme Wizard">
+  <theme-wizard-app>
+    <wizard-layout>
+      <wizard-page-nav slot="page-nav"></wizard-page-nav>
+      <StyleGuideNav />
+
+      <div slot="main">
+        <h1>Kleur systeem</h1>
+      </div>
+    </wizard-layout>
+  </theme-wizard-app>
+</BaseLayout>

--- a/packages/theme-wizard-website/src/pages/style-guide/design-tokens.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/design-tokens.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '@/layouts/BaseLayout.astro';
 import WithPageNav from '@/components/WithPageNav.astro';
 import '@nl-design-system-community/clippy-components/clippy-story-preview';
+import StyleGuideNav from '@/components/StyleGuideNav.astro';
 
 const SECTION_IDS = {
   typography: 'typography',
@@ -11,16 +12,17 @@ const SECTION_IDS = {
 }
 ---
 
-<BaseLayout title="Stijlgids - Theme Wizard">
+<BaseLayout title="Stijlgids design tokens - Theme Wizard">
   <theme-wizard-app>
     <wizard-layout>
       <wizard-page-nav slot="page-nav"></wizard-page-nav>
+      <StyleGuideNav />
 
       <div slot="main" class="wizard-main">
         <wizard-container>
           <clippy-story-preview size="lg">
             <wizard-stack size="4xl">
-              <clippy-heading level="1">Stijlgids</clippy-heading>
+              <clippy-heading level="1">Design tokens</clippy-heading>
               <WithPageNav>
                 <div slot="page-nav">
                   <wizard-anchor-nav items={JSON.stringify([{title: "Typografie", id: SECTION_IDS.typography}, {title: "Kleuren", id: SECTION_IDS.colors}, {title: "Witruimte", id: SECTION_IDS.spacing}, {title: "Componenten", id: SECTION_IDS.components}])}></wizard-anchor-nav>

--- a/packages/theme-wizard-website/src/pages/style-guide/index.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/index.astro
@@ -1,0 +1,16 @@
+---
+import StyleGuideNav from "@/components/StyleGuideNav.astro"
+import BaseLayout from "@/layouts/BaseLayout.astro"
+---
+
+<BaseLayout title="Style-guide - Theme Wizard">
+  <theme-wizard-app>
+    <wizard-layout>
+      <wizard-page-nav slot="page-nav"></wizard-page-nav>
+      <StyleGuideNav />
+      <main slot="main">
+        <h1>Styleguide</h1>
+      </main>
+     </wizard-layout>
+  </theme-wizard-app>
+</BaseLayout>


### PR DESCRIPTION
Deze PR creeert 2 pagina's onder de style-guide url: 

- /style-guide wijst naar een pagina met sidebar navigatie met de volgende items:
  - /style-guide/color-system
  - /style-guide/design-tokens (huidige stijlgids pagina)
  
fixes: https://github.com/nl-design-system/theme-wizard/issues/849