### PR TITLE
chore: upgrade node-tar (resolves GHSA-23hp-3jrh-7fpw)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+overrides:
+  tar@<=7.5.18: ^7.5.19
+
 importers:
 
   .:
@@ -8471,11 +8474,6 @@ packages:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   templite@1.2.0:
     resolution: {integrity: sha512-O9BpPXF44a9Pg84Be6mjzlrqOtbP2I/B5PNLWu5hb1n9UQ1GTLsjdMg1z5ROCkF6NFXsO5LQfRXEpgTGrZ7Q0Q==}
 
@@ -12794,7 +12792,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 7.5.7
+      tar: 7.5.19
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -17477,14 +17475,6 @@ snapshots:
       - react-native-b4a
 
   tar@7.5.19:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
-  tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,9 @@ allowBuilds:
   esbuild: true
   sharp: true
 
+overrides:
+  tar@<=7.5.18: ^7.5.19 # GHSA-23hp-3jrh-7fpw
+
 # Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
 autoInstallPeers: false
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,8 +37,6 @@ minimumReleaseAgeExclude:
   - '@rijkshuisstijl-community/*'
   - '@utrecht/*'
   - '@projectwallace/*'
-  - 'color-sorter'
-  - 'style-dictionary@5.4.4' # GHSA-vj5c-m527-mpff
 
 # Configure pnpm to save exact version numbers (not including ^ or ~) in package.json. Lock dependencies to specific
 # versions to ensure reproducible installs and prevent automatic upgrades to newer minor or patch releases.


### PR DESCRIPTION
- **chore: override tar (resolves GHSA-23hp-3jrh-7fpw)**
- **chore: clean up minimumReleaseAgeExclude entries**
