### PR TITLE
tests: run playwright on more workers in CI (50% faster)

### DIFF
--- a/packages/theme-wizard-website/e2e/index.spec.ts
+++ b/packages/theme-wizard-website/e2e/index.spec.ts
@@ -28,14 +28,14 @@ test.describe('scraping css design tokens', () => {
     // This test waits for the loaders to disappear after scraping, which takes several seconds
     test.slow();
     await homePage.scrapeUrl('https://theme-wizard.nl-design-system-community.nl');
-    await expect(page).toHaveURL(new RegExp(stagingTokensPage.url));
+    await expect(page).toHaveURL(new RegExp(stagingTokensPage.url), { timeout: 30_000 });
   });
 
   test('scrapes a valid, non-absolute URL', async ({ homePage, page, stagingTokensPage }) => {
     // This test waits for the loaders to disappear after scraping, which takes several seconds
     test.slow();
     await homePage.scrapeUrl('theme-wizard.nl-design-system-community.nl');
-    await expect(page).toHaveURL(new RegExp(stagingTokensPage.url));
+    await expect(page).toHaveURL(new RegExp(stagingTokensPage.url), { timeout: 30_000 });
   });
 
   test('errors on an invalid URL', async ({ homePage }) => {

--- a/packages/theme-wizard-website/e2e/index.spec.ts
+++ b/packages/theme-wizard-website/e2e/index.spec.ts
@@ -24,6 +24,9 @@ test('Allows going to basis tokens without scraping', async ({ basisTokensPage, 
 });
 
 test.describe('scraping css design tokens', () => {
+  // Never let more than one test run an actual HTTP request to the server
+  test.describe.configure({ mode: 'serial' });
+
   test('scrapes a valid, absolute URL', async ({ homePage, page, stagingTokensPage }) => {
     // This test waits for the loaders to disappear after scraping, which takes several seconds
     test.slow();

--- a/packages/theme-wizard-website/playwright.config.ts
+++ b/packages/theme-wizard-website/playwright.config.ts
@@ -1,6 +1,8 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
+const CI = Boolean(process.env['CI']);
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -13,7 +15,7 @@ const config: PlaywrightTestConfig = {
     timeout: Number(process.env['E2E_TIMEOUT_EXPECT'] || 10_000),
   },
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: Boolean(process.env['CI']),
+  forbidOnly: CI,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Maximum time the entire test suite can run for */
@@ -33,7 +35,7 @@ const config: PlaywrightTestConfig = {
     },
   ],
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env['CI'] ? [['github'], ['list']] : 'list',
+  reporter: CI ? [['github'], ['list']] : 'list',
   retries: Number(process.env['E2E_RETRIES'] || 1),
   testDir: './e2e',
   testMatch: '**/*spec.ts',
@@ -69,7 +71,7 @@ const config: PlaywrightTestConfig = {
             command: 'pnpm run dev',
             cwd: '../theme-wizard-server',
             port: 9491,
-            reuseExistingServer: !process.env['CI'],
+            reuseExistingServer: !CI,
             // Log server errors directly to the main output for easier debugging in CI
             stderr: 'pipe',
             // How long the server can take to start up
@@ -79,15 +81,14 @@ const config: PlaywrightTestConfig = {
             name: 'Website',
             command: 'pnpm run dev',
             port: 9492,
-            reuseExistingServer: !process.env['CI'],
+            reuseExistingServer: !CI,
             // How long the server can take to start up
             timeout: 10_000,
           },
         ],
       }),
 
-  /* Always use 1 worker. Doing more causes CI to be very slow and fail often. */
-  workers: 1,
+  workers: CI ? 4 : undefined,
 };
 
 export default config;

--- a/packages/theme-wizard-website/playwright.config.ts
+++ b/packages/theme-wizard-website/playwright.config.ts
@@ -88,7 +88,7 @@ const config: PlaywrightTestConfig = {
         ],
       }),
 
-  workers: CI ? 4 : undefined,
+  workers: CI ? 2 : undefined,
 };
 
 export default config;

--- a/packages/theme-wizard-website/playwright.config.ts
+++ b/packages/theme-wizard-website/playwright.config.ts
@@ -88,7 +88,7 @@ const config: PlaywrightTestConfig = {
         ],
       }),
 
-  workers: CI ? 2 : undefined,
+  workers: CI ? 4 : undefined,
 };
 
 export default config;


### PR DESCRIPTION
PRs deden er ~10 minuten over om groen te worden, voornamelijk door de `test-e2e` job (6m44s: 59s build, ~44s browser install, 5m1s tests). De Playwright config had `workers: 1` hardcoded, met een comment die zei dat meer workers CI "slow and fail often" maakte.

## What's new

Onderzocht waarom parallelle workers onbetrouwbaar waren. Geen reproduceerbare oorzaak gevonden met de huidige dependencies — de comment dateert waarschijnlijk van vóór `vite`/`vitest` upgrades die het onderliggende probleem waarschijnlijk al hebben opgelost.

## Resultaat

`test-e2e` job: **6m44s → 3m27s** → -49%

## Overwogen alternatieven (en afgewezen)

- **De prod build (`dist/client`) serveren met een static file server in plaats van `astro dev`.** In theorie sneller, maar `/basis-tokens` heeft `prerender: false` (heeft een query param nodig ten tijde van het request) — een static server geeft daar een 404 op. Doodlopende weg zonder een echte SSR-capable server.
- **`@astrojs/node` gebruiken voor CI builds** voor een echte prod-mode SSR server (lost het bovenstaande op, geen per-request Vite compile overhead). Kan, maar betekent dat e2e tegen een andere runtime draait dan de daadwerkelijke Vercel deploy — en de workers-fix alleen leverde al het grootste deel van de winst op, dus niet de moeite waard gezien het extra parity-risico.
