### PR TITLE
fix: color-sample label attribute and rectangular rendering

### DIFF
--- a/.changeset/ready-otters-pull.md
+++ b/.changeset/ready-otters-pull.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/clippy-components': minor
+---
+
+color-sample renders different aspect ratios correctly and supports a label attribute

--- a/packages/clippy-components/src/clippy-color-sample/index.test.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.test.ts
@@ -38,6 +38,14 @@ describe(`<${tag}>`, () => {
     expect(getSvgComputedColor(component)).toBe('rgb(255, 0, 0)');
   });
 
+  it('renders a color-sample by default without a label', async () => {
+    document.body.innerHTML = `<${tag} color="red"></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component.shadowRoot.querySelector('title')).toBeFalsy();
+  });
+
   it('updates the SVG computed color when the color property changes', async () => {
     document.body.innerHTML = `<${tag} color="rgb(0, 0, 255)"></${tag}>`;
     const component = getComponent() as ComponentElement & { color: string };
@@ -61,5 +69,14 @@ describe(`<${tag}>`, () => {
 
     expect(getSvgComputedColor(first)).toBe('rgb(255, 0, 0)');
     expect(getSvgComputedColor(second)).toBe('rgb(0, 0, 255)');
+  });
+
+  it('renders a color-sample with a label', async () => {
+    document.body.innerHTML = `<${tag} color="red" label="Label"></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component.shadowRoot.querySelector('title')).toBeTruthy();
+    expect(component.shadowRoot.querySelector('title')!.textContent).toBe('Label');
   });
 });

--- a/packages/clippy-components/src/clippy-color-sample/index.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.ts
@@ -2,6 +2,7 @@ import colorSampleStyles from '@nl-design-system-candidate/color-sample-css/colo
 import { safeCustomElement } from '@src/lib/decorators';
 import { LitElement, html, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
+import styles from './styles';
 
 const tag = 'clippy-color-sample';
 
@@ -13,7 +14,7 @@ declare global {
 
 @safeCustomElement(tag)
 export class ClippyColorSample extends LitElement {
-  static override readonly styles = [unsafeCSS(colorSampleStyles)];
+  static override readonly styles = [unsafeCSS(colorSampleStyles), styles];
 
   @property() color: string = '';
 

--- a/packages/clippy-components/src/clippy-color-sample/index.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.ts
@@ -18,18 +18,13 @@ export class ClippyColorSample extends LitElement {
 
   @property() color: string = '';
 
+  @property() label?: string = '';
+
   override render() {
     return html`
-      <svg
-        role="img"
-        xmlns="http://www.w3.org/2000/svg"
-        class="nl-color-sample"
-        style="color: ${this.color};"
-        width="32"
-        height="32"
-        viewBox="0 0 32 32"
-      >
-        <path d="M0 0H32V32H0Z" fill="currentcolor" />
+      <svg role="img" xmlns="http://www.w3.org/2000/svg" class="nl-color-sample" style="color: ${this.color};">
+        ${this.label ? html`<title>${this.label}</title>` : null}
+        <rect width="100%" height="100%" fill="currentcolor" />
       </svg>
     `;
   }

--- a/packages/clippy-components/src/clippy-color-sample/index.ts
+++ b/packages/clippy-components/src/clippy-color-sample/index.ts
@@ -22,7 +22,14 @@ export class ClippyColorSample extends LitElement {
 
   override render() {
     return html`
-      <svg role="img" xmlns="http://www.w3.org/2000/svg" class="nl-color-sample" style="color: ${this.color};">
+      <svg
+        role="img"
+        xmlns="http://www.w3.org/2000/svg"
+        class="nl-color-sample"
+        style="color: ${this.color};"
+        width="16"
+        height="16"
+      >
         ${this.label ? html`<title>${this.label}</title>` : null}
         <rect width="100%" height="100%" fill="currentcolor" />
       </svg>

--- a/packages/clippy-components/src/clippy-color-sample/styles.ts
+++ b/packages/clippy-components/src/clippy-color-sample/styles.ts
@@ -1,0 +1,12 @@
+import { css } from 'lit';
+
+export default css`
+  :host(:not([hidden])) {
+    display: inline-block;
+  }
+
+  /* Remove the whitespace below the color sample */
+  .nl-color-sample {
+    vertical-align: middle;
+  }
+`;

--- a/packages/clippy-storybook/src/web-components/clippy-color-sample.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-color-sample.stories.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 type ColorSampleStoryArgs = {
   color?: string;
+  label?: string;
 };
 
 const meta = {
@@ -12,6 +13,10 @@ const meta = {
     color: {
       control: { type: 'color' },
       description: 'De kleur van de color-sample. Ondersteunt alle geldige CSS-kleurwaarden.',
+    },
+    label: {
+      control: { type: 'text' },
+      description: 'De label van de color-sample.',
     },
   },
   parameters: {
@@ -22,7 +27,7 @@ const meta = {
       },
     },
   },
-  render: ({ color }) => React.createElement('clippy-color-sample', { color }),
+  render: ({ color, label }) => React.createElement('clippy-color-sample', { color, label }),
   tags: ['autodocs'],
   title: 'Clippy/Color Sample',
 } satisfies Meta<ColorSampleStoryArgs>;
@@ -36,6 +41,23 @@ export const Default: Story = {
   args: {
     color: '#8a3a9f',
   },
+};
+
+export const Label: Story = {
+  name: 'Label in color-sample',
+  args: {
+    color: '#8a3a9f',
+    label: 'Label',
+  },
+};
+
+export const Rectangle: Story = {
+  name: 'Rechthoekige color-sample',
+  args: {
+    color: '#8a3a9f',
+  },
+  render: ({ color, label }) =>
+    React.createElement('clippy-color-sample', { color, label, style: { '--nl-color-sample-inline-size': '3rem' } }),
 };
 
 export const Multiple: Story = {


### PR DESCRIPTION
Deze PR fixed de volgende zaken: 

- Voegt een `label` property toe om een `title` in de SVG te renderen
- Fixt het in een andere aspect ratio renderen van de color-sample kleur. Zie: https://github.com/nl-design-system/candidate/issues/1286