### PR TITLE
feat: create vite-plugin-terse-log package

### DIFF
--- a/packages/clippy-components/package.json
+++ b/packages/clippy-components/package.json
@@ -80,6 +80,7 @@
   },
   "devDependencies": {
     "@nl-design-system-community/design-tokens-schema": "workspace:*",
+    "@nl-design-system-community/vite-plugin-terse-log": "workspace:*",
     "@types/dlv": "1.1.5",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",

--- a/packages/clippy-components/vite.config.ts
+++ b/packages/clippy-components/vite.config.ts
@@ -1,3 +1,4 @@
+import { terseLog } from '@nl-design-system-community/vite-plugin-terse-log';
 import { globSync } from 'node:fs';
 import { extname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -53,6 +54,7 @@ export default defineConfig(() => ({
     },
   },
   plugins: [
+    terseLog(),
     dts({
       entryRoot: 'src',
       exclude: ['**/*.test.*', '**/styles.ts'],

--- a/packages/clippy-storybook/package.json
+++ b/packages/clippy-storybook/package.json
@@ -29,7 +29,7 @@
     "lint:css": "stylelint \"**/*.css\" --ignore-path ../../.stylelintignore",
     "lint:js": "eslint",
     "lint-fix:js": "eslint --fix",
-    "storybook": "storybook dev --config-dir ./config/ --port 6006"
+    "storybook": "storybook dev --config-dir ./config/ --port 6006 --no-version-updates"
   },
   "devDependencies": {
     "@amsterdam/design-system-css": "4.3.0",

--- a/packages/css-scraper/package.json
+++ b/packages/css-scraper/package.json
@@ -40,6 +40,7 @@
     "clean": "premove dist/"
   },
   "devDependencies": {
+    "@nl-design-system-community/vite-plugin-terse-log": "workspace:*",
     "@vitest/coverage-v8": "4.1.10",
     "premove": "4.0.0",
     "publint": "0.3.22",

--- a/packages/css-scraper/vite.config.js
+++ b/packages/css-scraper/vite.config.js
@@ -1,3 +1,4 @@
+import { terseLog } from '@nl-design-system-community/vite-plugin-terse-log';
 import { resolve } from 'node:path';
 import dts from 'unplugin-dts/vite';
 import { defineConfig } from 'vite';
@@ -21,5 +22,5 @@ export default defineConfig({
       ],
     },
   },
-  plugins: [dts()],
+  plugins: [terseLog(), dts()],
 });

--- a/packages/design-tokens-schema/package.json
+++ b/packages/design-tokens-schema/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@nl-design-system-community/ma-design-tokens": "6.0.0",
     "@nl-design-system-community/purmerend-design-tokens": "1.2.3",
+    "@nl-design-system-community/vite-plugin-terse-log": "workspace:*",
     "@nl-design-system-unstable/leiden-design-tokens": "3.0.0",
     "@nl-design-system-unstable/start-design-tokens": "7.0.0",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "12.0.0",

--- a/packages/design-tokens-schema/vite.config.js
+++ b/packages/design-tokens-schema/vite.config.js
@@ -1,3 +1,4 @@
+import { terseLog } from '@nl-design-system-community/vite-plugin-terse-log';
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
@@ -18,5 +19,5 @@ export default defineConfig({
       },
     },
   },
-  plugins: [dts()],
+  plugins: [terseLog(), dts()],
 });

--- a/packages/theme-wizard-app/package.json
+++ b/packages/theme-wizard-app/package.json
@@ -110,6 +110,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@nl-design-system-community/vite-plugin-terse-log": "workspace:*",
     "@projectwallace/css-parser": "0.18.1",
     "@storybook/react-vite": "10.5.4",
     "@types/dlv": "1.1.5",

--- a/packages/theme-wizard-app/vite.config.ts
+++ b/packages/theme-wizard-app/vite.config.ts
@@ -1,3 +1,4 @@
+import { terseLog } from '@nl-design-system-community/vite-plugin-terse-log';
 import { globSync, readFileSync } from 'node:fs';
 import { extname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -43,6 +44,7 @@ export default defineConfig(() => ({
     sourcemap: false,
   },
   plugins: [
+    terseLog(),
     dts({
       compilerOptions: { declarationMap: false },
       entryRoot: 'src',

--- a/packages/theme-wizard-server/package.json
+++ b/packages/theme-wizard-server/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@hono/vite-dev-server": "0.26.1",
+    "@nl-design-system-community/vite-plugin-terse-log": "workspace:*",
     "@types/node": "24.13.3",
     "@vitest/coverage-v8": "4.1.10",
     "premove": "4.0.0",

--- a/packages/theme-wizard-server/vite.config.js
+++ b/packages/theme-wizard-server/vite.config.js
@@ -1,4 +1,5 @@
 import devServer from '@hono/vite-dev-server';
+import { terseLog } from '@nl-design-system-community/vite-plugin-terse-log';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
@@ -11,6 +12,7 @@ export default defineConfig({
     ssr: true,
   },
   plugins: [
+    terseLog(),
     devServer({
       entry: 'src/index.ts',
     }),

--- a/packages/theme-wizard-website/package.json
+++ b/packages/theme-wizard-website/package.json
@@ -9,9 +9,9 @@
   },
   "private": true,
   "scripts": {
-    "dev": "API_HOST=http://localhost:9491 astro dev",
+    "dev": "API_HOST=http://localhost:9491 astro dev --host",
     "build": "pnpm run clean && astro build",
-    "clean": "rm -rf dist .astro build",
+    "clean": "premove dist .astro build",
     "lint": "pnpm run --sequential '/^lint:.+$/'",
     "lint:css": "stylelint .",
     "lint:js": "eslint",
@@ -91,6 +91,7 @@
     "@types/dlv": "1.1.5",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
-    "postcss-html": "1.8.1"
+    "postcss-html": "1.8.1",
+    "premove": "4.0.0"
   }
 }

--- a/packages/vite-plugin-terse-log/README.md
+++ b/packages/vite-plugin-terse-log/README.md
@@ -1,0 +1,77 @@
+# @nl-design-system-community/vite-plugin-terse-log
+
+A Vite plugin that quiets `vite`'s dev-server and `vite build --watch` output down to a
+single line per package: the package name plus either its dev server URL or a
+"done building" message.
+
+## Why
+
+This monorepo starts every package's dev server at once with
+`pnpm --recursive --parallel run dev`. With N packages all printing Vite's default
+"VITE vX ready in Xms" banners, "watching for file changes..." lines, and rebuild
+notices, the combined output is hard to scan for the one thing you actually want:
+is this package ready, and where do I find it?
+
+`terseLog()` drops the noise and prints exactly one line per package instead:
+
+```text
+css-scraper → http://localhost:5173
+clippy-components done building
+```
+
+## When not to use this
+
+- **Plain `vite build`** (a one-off production build, not `--watch`) is left
+  completely untouched on purpose — you still want the full rollup/dts output
+  there to debug bundle size, warnings, etc.
+- If you want to see the normal Vite startup banner, rebuild timings, or other
+  `info`-level logging while developing a single package in isolation, skip this
+  plugin — it sets `logLevel: 'error'` for `serve` and watch builds, so only
+  actual errors get through in those modes.
+- It doesn't help with non-Vite dev servers (Astro, Storybook, etc.) — those
+  don't expose an equivalent hook to swap in a custom logger without patching
+  their internals, so this plugin only covers packages that run Vite directly.
+
+## Install
+
+```sh
+pnpm add -D @nl-design-system-community/vite-plugin-terse-log
+```
+
+## Usage
+
+Add it to a package's `vite.config.ts`/`.js` `plugins` array — order doesn't
+matter relative to other plugins:
+
+```ts
+import { terseLog } from '@nl-design-system-community/vite-plugin-terse-log';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [terseLog()],
+});
+```
+
+The label is read from the consuming package's own `package.json` `name` field
+(with the npm scope stripped), so there's nothing to configure.
+
+Behavior by command:
+
+| Command                 | Output                                                             |
+| ----------------------- | ------------------------------------------------------------------ |
+| `vite` (dev server)     | `<package> → http://localhost:<port>` once the server is listening |
+| `vite build --watch`    | `<package> done building` after every (re)build                    |
+| `vite build` (no watch) | Untouched — full default build output                              |
+
+## Testing
+
+The plugin's hooks (`config`, `configureServer`, `closeBundle`) are plain
+functions, so they're tested directly with `vitest` — no real Vite server or
+build needed. See [`src/index.test.ts`](./src/index.test.ts) for examples, e.g.
+calling `config()` with a fake `ConfigEnv` and asserting the returned
+`logLevel`, or invoking `configureServer()` with a stub `httpServer` to check
+the printed URL.
+
+```sh
+pnpm run test-build
+```

--- a/packages/vite-plugin-terse-log/package.json
+++ b/packages/vite-plugin-terse-log/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@nl-design-system-community/vite-plugin-terse-log",
+  "version": "1.0.0",
+  "author": "Community for NL Design System",
+  "description": "Shared Vite plugin that quiets dev/watch output down to a single line",
+  "license": "EUPL-1.2",
+  "keywords": [
+    "expertteam-digitale-toegankelijkheid",
+    "nl-design-system"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git+ssh",
+    "url": "git@github.com:nl-design-system/theme-wizard.git",
+    "directory": "packages/vite-plugin-terse-log"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit --project tsconfig.json",
+    "build": "pnpm run type-check && vite build",
+    "lint-build": "tsc --noEmit --project tsconfig.json",
+    "clean": "premove dist/",
+    "lint:js": "eslint",
+    "lint-fix:js": "eslint --fix",
+    "test-build": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "4.1.10",
+    "premove": "4.0.0",
+    "typescript": "6.0.3",
+    "vite": "8.1.5",
+    "vite-plugin-dts": "5.0.3",
+    "vitest": "4.1.10"
+  },
+  "peerDependencies": {
+    "vite": "^8.0.0"
+  }
+}

--- a/packages/vite-plugin-terse-log/src/index.test.ts
+++ b/packages/vite-plugin-terse-log/src/index.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { terseLog } from './index';
+
+type ConfigHook = (
+  config: { build?: { watch?: unknown } },
+  env: { command: 'build' | 'serve' },
+) => { logLevel?: string } | undefined;
+
+type ConfigureServerHook = (server: {
+  config: { server: { https?: boolean; port?: number } };
+  httpServer: { address: () => { port: number } | null; once: (event: 'listening', cb: () => void) => void } | null;
+}) => void;
+
+type CloseBundleHook = () => void;
+
+describe('terseLog', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('sets logLevel to error for the dev server', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+
+    expect(config({}, { command: 'serve' })).toEqual({ logLevel: 'error' });
+  });
+
+  it('sets logLevel to error for a watch build', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+
+    expect(config({ build: { watch: {} } }, { command: 'build' })).toEqual({ logLevel: 'error' });
+  });
+
+  it('leaves a plain build untouched', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+
+    expect(config({}, { command: 'build' })).toBeUndefined();
+  });
+
+  it('logs "<name> done building" after each rebuild in watch mode', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const closeBundle = plugin.closeBundle as CloseBundleHook;
+
+    config({ build: { watch: {} } }, { command: 'build' });
+    closeBundle();
+
+    expect(logSpy).toHaveBeenCalledWith('vite-plugin-terse-log done building');
+  });
+
+  it('does not log on closeBundle for a plain build', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const closeBundle = plugin.closeBundle as CloseBundleHook;
+
+    config({}, { command: 'build' });
+    closeBundle();
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs the dev server URL once it starts listening', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const configureServer = plugin.configureServer as ConfigureServerHook;
+    let listeningCallback: (() => void) | undefined;
+
+    config({}, { command: 'serve' });
+    configureServer({
+      config: { server: { https: false, port: 5173 } },
+      httpServer: {
+        address: () => ({ port: 5174 }),
+        once: (event, cb) => {
+          if (event === 'listening') {
+            listeningCallback = cb;
+          }
+        },
+      },
+    });
+    listeningCallback?.();
+
+    expect(logSpy).toHaveBeenCalledWith('vite-plugin-terse-log → http://localhost:5174');
+  });
+
+  it('uses https when the server is configured for it', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const configureServer = plugin.configureServer as ConfigureServerHook;
+    let listeningCallback: (() => void) | undefined;
+
+    config({}, { command: 'serve' });
+    configureServer({
+      config: { server: { https: true, port: 5173 } },
+      httpServer: {
+        address: () => ({ port: 5174 }),
+        once: (event, cb) => {
+          if (event === 'listening') {
+            listeningCallback = cb;
+          }
+        },
+      },
+    });
+    listeningCallback?.();
+
+    expect(logSpy).toHaveBeenCalledWith('vite-plugin-terse-log → https://localhost:5174');
+  });
+
+  it('falls back to the configured port when the address is unavailable', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const configureServer = plugin.configureServer as ConfigureServerHook;
+    let listeningCallback: (() => void) | undefined;
+
+    config({}, { command: 'serve' });
+    configureServer({
+      config: { server: { https: false, port: 5173 } },
+      httpServer: {
+        address: () => null,
+        once: (event, cb) => {
+          if (event === 'listening') {
+            listeningCallback = cb;
+          }
+        },
+      },
+    });
+    listeningCallback?.();
+
+    expect(logSpy).toHaveBeenCalledWith('vite-plugin-terse-log → http://localhost:5173');
+  });
+
+  it('does not attach a server listener outside serve mode', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const configureServer = plugin.configureServer as ConfigureServerHook;
+    const once = vi.fn();
+
+    config({ build: { watch: {} } }, { command: 'build' });
+    configureServer({ config: { server: {} }, httpServer: { address: () => null, once } });
+
+    expect(once).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no http server', () => {
+    const plugin = terseLog();
+    const config = plugin.config as ConfigHook;
+    const configureServer = plugin.configureServer as ConfigureServerHook;
+
+    config({}, { command: 'serve' });
+
+    expect(() => configureServer({ config: { server: {} }, httpServer: null })).not.toThrow();
+  });
+});

--- a/packages/vite-plugin-terse-log/src/index.ts
+++ b/packages/vite-plugin-terse-log/src/index.ts
@@ -1,0 +1,47 @@
+import type { Plugin } from 'vite';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Silences Vite's default dev/watch banners and replaces them with a single line:
+ * the package name plus either the dev server URL or a "done building" message.
+ * `vite build` (without --watch) is left untouched so full build output still shows.
+ */
+export function terseLog(): Plugin {
+  const { name } = JSON.parse(readFileSync('./package.json', 'utf8'));
+  // Strip the npm scope (e.g. "@nl-design-system-community/") so the log line stays short.
+  const label = name.replace(/^@[^/]+\//, '');
+
+  let isServe = false;
+  let isWatchBuild = false;
+
+  return {
+    name: 'terse-log',
+    closeBundle() {
+      if (isWatchBuild) {
+        console.log(`${label} done building`);
+      }
+    },
+    config(userConfig, { command }) {
+      isServe = command === 'serve';
+      isWatchBuild = command === 'build' && Boolean(userConfig.build?.watch);
+
+      if (isServe || isWatchBuild) {
+        // Keep errors visible, drop the "VITE ready in Xms" / "watching for file changes" info logs.
+        return { logLevel: 'error' };
+      }
+
+      return undefined;
+    },
+    configureServer(server) {
+      if (!isServe) {
+        return;
+      }
+      server.httpServer?.once('listening', () => {
+        const address = server.httpServer?.address();
+        const port = address && typeof address === 'object' ? address.port : server.config.server.port;
+        const protocol = server.config.server.https ? 'https' : 'http';
+        console.log(`${label} → ${protocol}://localhost:${port}`);
+      });
+    },
+  };
+}

--- a/packages/vite-plugin-terse-log/tsconfig.json
+++ b/packages/vite-plugin-terse-log/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2024", "DOM"],
+    "strict": true,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["vite/client"],
+    "importHelpers": false,
+    "useDefineForClassFields": false,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/vite-plugin-terse-log/tsconfig.node.json
+++ b/packages/vite-plugin-terse-log/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/vite-plugin-terse-log/vite.config.js
+++ b/packages/vite-plugin-terse-log/vite.config.js
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve('./src/index.ts'),
+      fileName: 'index',
+      formats: ['es'],
+    },
+    minify: false,
+    rollupOptions: {
+      external: [/^node:/, 'vite'],
+    },
+    sourcemap: false,
+  },
+  plugins: [dts()],
+});

--- a/packages/vite-plugin-terse-log/vitest.config.ts
+++ b/packages/vite-plugin-terse-log/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+    typecheck: {
+      tsconfig: './tsconfig.node.json',
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@nl-design-system-community/design-tokens-schema':
         specifier: workspace:*
         version: link:../design-tokens-schema
+      '@nl-design-system-community/vite-plugin-terse-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-terse-log
       '@types/dlv':
         specifier: 1.1.5
         version: 1.1.5
@@ -384,6 +387,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@nl-design-system-community/vite-plugin-terse-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-terse-log
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -506,6 +512,9 @@ importers:
       '@nl-design-system-community/purmerend-design-tokens':
         specifier: 1.2.3
         version: 1.2.3
+      '@nl-design-system-community/vite-plugin-terse-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-terse-log
       '@nl-design-system-unstable/leiden-design-tokens':
         specifier: 3.0.0
         version: 3.0.0
@@ -702,6 +711,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@nl-design-system-community/vite-plugin-terse-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-terse-log
       '@projectwallace/css-parser':
         specifier: 0.18.1
         version: 0.18.1
@@ -772,6 +784,9 @@ importers:
       '@hono/vite-dev-server':
         specifier: 0.26.1
         version: 0.26.1(hono@4.12.32)
+      '@nl-design-system-community/vite-plugin-terse-log':
+        specifier: workspace:*
+        version: link:../vite-plugin-terse-log
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -1125,6 +1140,30 @@ importers:
       postcss-html:
         specifier: 1.8.1
         version: 1.8.1
+      premove:
+        specifier: 4.0.0
+        version: 4.0.0
+
+  packages/vite-plugin-terse-log:
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 4.1.10
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      premove:
+        specifier: 4.0.0
+        version: 4.0.0
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+      vite:
+        specifier: 8.1.5
+        version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-dts:
+        specifier: 5.0.3
+        version: 5.0.3(esbuild@0.28.1)(rolldown@1.1.5)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(tsx@4.21.0)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
 
   proprietary/assets: {}
 


### PR DESCRIPTION
- Nieuw: `vite-plugin-terse-log` package om vite logs op dieet te sturen in dev/watch mode
- Al onze eigen Vite packages gebruiken deze nieuwe plugin om lokaal de dev logs te verkorten
- disable Storybook's "Update available" melding tijdens opstarten, hier gebruiken we dependabot voor
- Expose theme-wizard-website standaard op lokaal netwerk omdat we dat vaak gebruiken om met andere devices te testen

## Voor

<img width="898" height="1311" alt="Screenshot 2026-07-31 at 11 25 27" src="https://github.com/user-attachments/assets/f68a0c1c-ae25-425a-8ac9-b2259d129d18" />
<img width="891" height="1310" alt="Screenshot 2026-07-31 at 11 25 42" src="https://github.com/user-attachments/assets/006a2a0d-34d5-434a-af43-54fce84d9357" />


## Na

<img width="923" height="898" alt="Screenshot 2026-07-31 at 11 24 32" src="https://github.com/user-attachments/assets/87f3d322-ec88-41ec-b718-eccb66a19122" />
