### PR TITLE
fix: make color table reactive to updates

### DIFF
--- a/packages/theme-wizard-app/src/components/wizard-color-system-preview/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-color-system-preview/index.ts
@@ -5,7 +5,7 @@ import '../wizard-table-scroller';
 
 import { arrayFromCommaList } from '@nl-design-system-community/clippy-components/lib/converters';
 import { safeCustomElement } from '@nl-design-system-community/clippy-components/lib/decorators';
-import { LitElement, html } from 'lit';
+import { LitElement, html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
@@ -30,8 +30,8 @@ export class WizardColorSystemPreview extends LitElement {
   @property({ converter: arrayFromCommaList })
   groups: string[] = [];
 
-  override connectedCallback() {
-    super.connectedCallback();
+  protected override willUpdate(changedProperties: PropertyValues) {
+    if (!changedProperties.has('theme') && !changedProperties.has('groups')) return;
 
     const basis = this.theme.tokens['basis'] as Record<string, unknown>;
     const colors = basis['color'] as Record<string, unknown>;
@@ -49,7 +49,6 @@ export class WizardColorSystemPreview extends LitElement {
   }
 
   override render() {
-    console.log(this.#visibleTokenGroups);
     return html`<clippy-token-table-color .groups=${this.#visibleTokenGroups}></clippy-token-table-color>`;
   }
 }


### PR DESCRIPTION
Was aan het prototypen op de style guide pagina. Deze change zorgt ervoor dat een change in het thema op bv de basis tokens page ook direct doorvloeit in deze tabel zodat ie live update.