### PR TITLE
feat: add typography system style guide page

### DIFF
--- a/.changeset/better-chairs-stay.md
+++ b/.changeset/better-chairs-stay.md
@@ -1,0 +1,6 @@
+---
+'@nl-design-system-community/clippy-components': minor
+'@nl-design-system-community/theme-wizard-app': minor
+---
+
+Add `clippy-graph-paper` component

--- a/packages/clippy-components/src/clippy-graph-paper/README.md
+++ b/packages/clippy-components/src/clippy-graph-paper/README.md
@@ -1,0 +1,36 @@
+# `<clippy-graph-paper>`
+
+Renders slotted content on top of a graph paper style background grid. Useful as a neutral backdrop for previewing typography or spacing tokens.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-graph-paper';
+```
+
+```html
+<clippy-graph-paper>
+  <p>Placeholder content</p>
+</clippy-graph-paper>
+
+<!-- Custom grid -->
+<clippy-graph-paper style="--clippy-graph-paper-cell-size: 16px;">
+  <p>Placeholder content</p>
+</clippy-graph-paper>
+```
+
+## Slots
+
+| Slot        | Description |
+| ----------- | ----------- |
+| _(default)_ | Content     |
+
+## CSS custom properties
+
+| Property                                   | Description                              |
+| ------------------------------------------ | ---------------------------------------- |
+| `--clippy-graph-paper-cell-size`           | Size of one grid cell                    |
+| `--clippy-graph-paper-line-size`           | Thickness of the grid lines              |
+| `--clippy-graph-paper-minor-line-color`    | Color of the minor (per-cell) grid lines |
+| `--clippy-graph-paper-major-line-color`    | Color of the major grid lines            |
+| `--clippy-graph-paper-major-line-interval` | Number of cells between major grid lines |

--- a/packages/clippy-components/src/clippy-graph-paper/index.test.ts
+++ b/packages/clippy-components/src/clippy-graph-paper/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { page } from 'vitest/browser';
+import './index';
+import type { ClippyGraphPaper } from './index';
+
+const tag = 'clippy-graph-paper';
+
+describe(`<${tag}>`, () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders element', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const element = document.querySelector(tag);
+    expect(element).toBeDefined();
+  });
+
+  it('has a slot for content', () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const element = document.querySelector(tag);
+    const slot = element?.shadowRoot?.querySelector('slot');
+    expect(slot).toBeDefined();
+  });
+
+  it('renders slotted content', async () => {
+    document.body.innerHTML = `<${tag}><p>Hello world</p></${tag}>`;
+    const component = document.querySelector(tag) as ClippyGraphPaper;
+    await component?.updateComplete;
+
+    const paragraph = page.getByText('Hello world');
+    expect(paragraph).toBeDefined();
+  });
+
+  it('renders a background grid by default', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = document.querySelector(tag) as ClippyGraphPaper;
+    await component?.updateComplete;
+
+    const backgroundImage = getComputedStyle(component).backgroundImage;
+    expect(backgroundImage).not.toBe('none');
+  });
+
+  it('honors a custom --clippy-graph-paper-cell-size', async () => {
+    document.body.innerHTML = `<${tag} style="--clippy-graph-paper-cell-size: 16px;"></${tag}>`;
+    const component = document.querySelector(tag) as ClippyGraphPaper;
+    await component?.updateComplete;
+
+    const backgroundSize = getComputedStyle(component).backgroundSize;
+    expect(backgroundSize).toContain('16px');
+  });
+});

--- a/packages/clippy-components/src/clippy-graph-paper/index.ts
+++ b/packages/clippy-components/src/clippy-graph-paper/index.ts
@@ -9,11 +9,11 @@ const tag = 'clippy-graph-paper';
  *
  * @slot - Default slot for content
  *
- * @cssprop [--clippy-graph-paper-cell-size=8px] - Size of one grid cell
- * @cssprop [--clippy-graph-paper-line-size=1px] - Thickness of the grid lines
- * @cssprop [--clippy-graph-paper-minor-line-color=rgba(0, 0, 0, 0.06)] - Color of the minor (per-cell) grid lines
- * @cssprop [--clippy-graph-paper-major-line-color=rgba(0, 0, 0, 0.06)] - Color of the major grid lines
- * @cssprop [--clippy-graph-paper-major-line-interval=4] - Number of cells between major grid lines
+ * @cssprop [--clippy-graph-paper-cell-size] - Size of one grid cell
+ * @cssprop [--clippy-graph-paper-line-size] - Thickness of the grid lines
+ * @cssprop [--clippy-graph-paper-minor-line-color] - Color of the minor (per-cell) grid lines
+ * @cssprop [--clippy-graph-paper-major-line-color] - Color of the major grid lines
+ * @cssprop [--clippy-graph-paper-major-line-interval] - Number of cells between major grid lines
  */
 @safeCustomElement(tag)
 export class ClippyGraphPaper extends LitElement {

--- a/packages/clippy-components/src/clippy-graph-paper/index.ts
+++ b/packages/clippy-components/src/clippy-graph-paper/index.ts
@@ -1,0 +1,31 @@
+import { safeCustomElement } from '@lib/decorators';
+import { LitElement, html } from 'lit';
+import styles from './styles';
+
+const tag = 'clippy-graph-paper';
+
+/**
+ * Clippy Graph Paper Component
+ *
+ * @slot - Default slot for content
+ *
+ * @cssprop [--clippy-graph-paper-cell-size=8px] - Size of one grid cell
+ * @cssprop [--clippy-graph-paper-line-size=1px] - Thickness of the grid lines
+ * @cssprop [--clippy-graph-paper-minor-line-color=rgba(0, 0, 0, 0.06)] - Color of the minor (per-cell) grid lines
+ * @cssprop [--clippy-graph-paper-major-line-color=rgba(0, 0, 0, 0.06)] - Color of the major grid lines
+ * @cssprop [--clippy-graph-paper-major-line-interval=4] - Number of cells between major grid lines
+ */
+@safeCustomElement(tag)
+export class ClippyGraphPaper extends LitElement {
+  static override readonly styles = [styles];
+
+  override render() {
+    return html` <slot></slot> `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: ClippyGraphPaper;
+  }
+}

--- a/packages/clippy-components/src/clippy-graph-paper/styles.ts
+++ b/packages/clippy-components/src/clippy-graph-paper/styles.ts
@@ -2,10 +2,17 @@ import { css } from 'lit';
 
 export default css`
   :host {
-    --_clippy-graph-paper-cell-size: var(--clippy-graph-paper-cell-size, 8px);
+    --_clippy-graph-paper-cell-size: var(--clippy-graph-paper-cell-size, 1lh);
     --_clippy-graph-paper-line-size: var(--clippy-graph-paper-line-size, 1px);
-    --_clippy-graph-paper-minor-line-color: var(--clippy-graph-paper-minor-line-color, rgb(0 0 0 / 6%));
-    --_clippy-graph-paper-major-line-color: var(--clippy-graph-paper-major-line-color, rgb(0 0 0 / 6%));
+    --_clippy-graph-paper-line-color: var(--clippy-graph-paper-line-color, rgb(0 0 0 / 6%));
+    --_clippy-graph-paper-minor-line-color: var(
+      --clippy-graph-paper-minor-line-color,
+      var(--_clippy-graph-paper-line-color)
+    );
+    --_clippy-graph-paper-major-line-color: var(
+      --clippy-graph-paper-major-line-color,
+      var(--_clippy-graph-paper-line-color)
+    );
     --_clippy-graph-paper-major-line-interval: var(--clippy-graph-paper-major-line-interval, 4);
 
     background-image:
@@ -29,7 +36,7 @@ export default css`
         var(--_clippy-graph-paper-major-line-color) var(--_clippy-graph-paper-line-size),
         transparent var(--_clippy-graph-paper-line-size)
       );
-    background-position: -1px -1px;
+    background-position: calc(var(--_clippy-graph-paper-line-size) * -1) calc(var(--_clippy-graph-paper-line-size) * -1);
     background-size:
       var(--_clippy-graph-paper-cell-size) var(--_clippy-graph-paper-cell-size),
       var(--_clippy-graph-paper-cell-size) var(--_clippy-graph-paper-cell-size),

--- a/packages/clippy-components/src/clippy-graph-paper/styles.ts
+++ b/packages/clippy-components/src/clippy-graph-paper/styles.ts
@@ -1,0 +1,41 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    --_clippy-graph-paper-cell-size: var(--clippy-graph-paper-cell-size, 8px);
+    --_clippy-graph-paper-line-size: var(--clippy-graph-paper-line-size, 1px);
+    --_clippy-graph-paper-minor-line-color: var(--clippy-graph-paper-minor-line-color, rgb(0 0 0 / 6%));
+    --_clippy-graph-paper-major-line-color: var(--clippy-graph-paper-major-line-color, rgb(0 0 0 / 6%));
+    --_clippy-graph-paper-major-line-interval: var(--clippy-graph-paper-major-line-interval, 4);
+
+    background-image:
+      linear-gradient(
+        to right,
+        var(--_clippy-graph-paper-minor-line-color) var(--_clippy-graph-paper-line-size),
+        transparent var(--_clippy-graph-paper-line-size)
+      ),
+      linear-gradient(
+        to bottom,
+        var(--_clippy-graph-paper-minor-line-color) var(--_clippy-graph-paper-line-size),
+        transparent var(--_clippy-graph-paper-line-size)
+      ),
+      linear-gradient(
+        to right,
+        var(--_clippy-graph-paper-major-line-color) var(--_clippy-graph-paper-line-size),
+        transparent var(--_clippy-graph-paper-line-size)
+      ),
+      linear-gradient(
+        to bottom,
+        var(--_clippy-graph-paper-major-line-color) var(--_clippy-graph-paper-line-size),
+        transparent var(--_clippy-graph-paper-line-size)
+      );
+    background-position: -1px -1px;
+    background-size:
+      var(--_clippy-graph-paper-cell-size) var(--_clippy-graph-paper-cell-size),
+      var(--_clippy-graph-paper-cell-size) var(--_clippy-graph-paper-cell-size),
+      calc(var(--_clippy-graph-paper-cell-size) * var(--_clippy-graph-paper-major-line-interval))
+        calc(var(--_clippy-graph-paper-cell-size) * var(--_clippy-graph-paper-major-line-interval)),
+      calc(var(--_clippy-graph-paper-cell-size) * var(--_clippy-graph-paper-major-line-interval))
+        calc(var(--_clippy-graph-paper-cell-size) * var(--_clippy-graph-paper-major-line-interval));
+  }
+`;

--- a/packages/clippy-storybook/src/web-components/clippy-graph-paper.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-graph-paper.stories.tsx
@@ -4,8 +4,6 @@ import { html } from 'lit';
 import React from 'react';
 import { templateToHtml } from '../utils/templateToHtml';
 
-const createTemplate = () => html`<clippy-graph-paper>Example content</clippy-graph-paper>`;
-
 const meta = {
   id: 'clippy-graph-paper',
   argTypes: {
@@ -66,17 +64,120 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+const createTemplate = () =>
+  html`<clippy-graph-paper style="display: block; padding-block: 2lh; padding-inline: 3ch;"
+    >Example content</clippy-graph-paper
+  >`;
+
 export const Default: Story = {
   name: 'Default',
   parameters: {
     docs: {
       source: {
-        transform: () => {
-          const template = createTemplate();
-          return templateToHtml(template);
-        },
+        transform: () => templateToHtml(createTemplate()),
         type: 'code',
       },
     },
   },
+  render: () => React.createElement('div', { dangerouslySetInnerHTML: { __html: templateToHtml(createTemplate()) } }),
+};
+
+const createoldSchoolMathTemplate = () => html`
+  <clippy-graph-paper
+    style="
+      --clippy-graph-paper-cell-size: .5lh;
+      --clippy-graph-paper-major-line-interval: 4;
+      --clippy-graph-paper-line-color: rgb(0 0 0/ 6%);
+      --clippy-graph-paper-major-line-color: oklch(from deepskyblue l calc(c * .5) h / 25%);
+
+      display: block;
+      padding-block: 2.5lh;
+      padding-inline: 6ch;
+    "
+    >1 + 1 = 2</clippy-graph-paper
+  >
+`;
+
+export const OldSchoolMathPaper: Story = {
+  name: 'Old-school Math Paper',
+  parameters: {
+    docs: {
+      source: {
+        transform: () => templateToHtml(createoldSchoolMathTemplate()),
+        type: 'code',
+      },
+    },
+  },
+  render: () =>
+    React.createElement('div', { dangerouslySetInnerHTML: { __html: templateToHtml(createoldSchoolMathTemplate()) } }),
+};
+
+// Example SVG taken from https://nldesignsystem.nl/componenten/ with the SVG's background graph paper removed.
+const createNlDesignSystemComponentCardTemplate = () => html`
+  <div style="container-type: inline-size; max-inline-size: 500px;">
+    <clippy-graph-paper
+      style="
+        --clippy-graph-paper-cell-size: calc((100 / 12 * 1cqi) + 1px);
+        --clippy-graph-paper-major-line-interval: calc(infinity);
+
+        display: block;
+        padding-block: 2lh;
+        padding-inline: 3ch;
+      "
+    >
+      <svg
+        style="width: 100%; height: auto;"
+        width="960"
+        height="540"
+        viewBox="0 0 960 540"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+      >
+        <g>
+          <rect
+            x="127"
+            y="229"
+            width="330"
+            height="84"
+            rx="16"
+            fill="var(--ma-component-illustration-color, #666)"
+          ></rect>
+          <rect
+            x="172"
+            y="263"
+            width="240"
+            height="16"
+            rx="8"
+            fill="var(--ma-component-illustration-background-color, white)"
+          ></rect>
+          <rect
+            x="505"
+            y="230"
+            width="326"
+            height="80"
+            rx="14"
+            fill="var(--ma-component-illustration-background-color, white)"
+            stroke="var(--ma-component-illustration-color, #666)"
+            stroke-width="4"
+          ></rect>
+        </g>
+      </svg>
+    </clippy-graph-paper>
+  </div>
+`;
+
+export const NlDesignSystemComponentCard: Story = {
+  name: 'NL Design System Component Card',
+  parameters: {
+    docs: {
+      source: {
+        transform: () => templateToHtml(createNlDesignSystemComponentCardTemplate()),
+        type: 'code',
+      },
+    },
+  },
+  render: () =>
+    React.createElement('div', {
+      dangerouslySetInnerHTML: { __html: templateToHtml(createNlDesignSystemComponentCardTemplate()) },
+    }),
 };

--- a/packages/clippy-storybook/src/web-components/clippy-graph-paper.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-graph-paper.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '@nl-design-system-community/clippy-components/clippy-graph-paper';
+import { html } from 'lit';
+import React from 'react';
+import { templateToHtml } from '../utils/templateToHtml';
+
+const createTemplate = () => html`<clippy-graph-paper>Example content</clippy-graph-paper>`;
+
+const meta = {
+  id: 'clippy-graph-paper',
+  argTypes: {
+    '--clippy-graph-paper-cell-size': {
+      control: false,
+      description: 'Size of one grid cell',
+      table: {
+        category: 'CSS Custom Properties',
+        type: { summary: '<length>' },
+      },
+    },
+    '--clippy-graph-paper-line-size': {
+      control: false,
+      description: 'Thickness of the grid lines',
+      table: {
+        category: 'CSS Custom Properties',
+        type: { summary: '<length>' },
+      },
+    },
+    '--clippy-graph-paper-major-line-color': {
+      control: false,
+      description: 'Color of the major grid lines',
+      table: {
+        category: 'CSS Custom Properties',
+        type: { summary: '<color>' },
+      },
+    },
+    '--clippy-graph-paper-major-line-interval': {
+      control: false,
+      description: 'Number of cells between major grid lines',
+      table: {
+        category: 'CSS Custom Properties',
+        type: { summary: '<number>' },
+      },
+    },
+    '--clippy-graph-paper-minor-line-color': {
+      control: false,
+      description: 'Color of the minor (per-cell) grid lines',
+      table: {
+        category: 'CSS Custom Properties',
+        type: { summary: '<color>' },
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: '`<clippy-graph-paper>` renders content on top of a graph paper style background grid.',
+      },
+    },
+  },
+  render: () => React.createElement('clippy-graph-paper', {}, 'Example content'),
+  tags: ['autodocs'],
+  title: 'Clippy/Graph Paper',
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Default',
+  parameters: {
+    docs: {
+      source: {
+        transform: () => {
+          const template = createTemplate();
+          return templateToHtml(template);
+        },
+        type: 'code',
+      },
+    },
+  },
+};

--- a/packages/theme-wizard-app/src/components/wizard-story-matches/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-story-matches/index.ts
@@ -1,9 +1,12 @@
 import { consume } from '@lit/context';
+import paragraphStyles from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
 import { arrayFromCommaList } from '@nl-design-system-community/clippy-components/lib/converters';
-import { LitElement, html, type PropertyValues } from 'lit';
+import { LitElement, html, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
+import '../wizard-story-section';
+import { t } from '../../i18n';
 import {
   findMatchingStories,
   prepareStoryCandidates,
@@ -11,7 +14,6 @@ import {
   type StoryCandidate,
   type StoryMatch,
 } from '../../utils/story-token-matches';
-import '../wizard-story-section';
 import styles from './styles';
 
 const tag = 'wizard-story-matches';
@@ -28,7 +30,7 @@ declare global {
  */
 @customElement(tag)
 export class WizardStoryMatches extends LitElement {
-  static override readonly styles = [styles];
+  static override readonly styles = [unsafeCSS(paragraphStyles), styles];
 
   @consume({ context: themeContext, subscribe: true })
   @state()
@@ -85,6 +87,10 @@ export class WizardStoryMatches extends LitElement {
   }
 
   override render() {
+    if (this.storyMatches.length === 0) {
+      return html`<p class="nl-paragraph | wizard-story-matches__empty">${t('styleGuide.nothingToShow')}.</p>`;
+    }
+
     return html`
       ${this.storyMatches.map(({ id, meta, story }) => {
         // `DataBadgeColor` → `Data Badge Color`

--- a/packages/theme-wizard-app/src/components/wizard-story-matches/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-story-matches/styles.ts
@@ -13,4 +13,8 @@ export default css`
     padding-inline: var(--basis-space-inline-3xl);
     row-gap: var(--basis-space-row-2xl);
   }
+
+  .wizard-story-matches__empty {
+    color: var(--basis-color-default-color-subtle);
+  }
 `;

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -158,6 +158,7 @@ export const en = {
         title: 'Where is this token used?',
       },
     },
+    nothingToShow: 'Nothing to show',
     reference: 'Reference',
     sample: 'Sample',
     sections: {
@@ -632,6 +633,7 @@ export const nl = {
         title: 'Waar wordt deze token gebruikt?',
       },
     },
+    nothingToShow: 'Niets te tonen',
     reference: 'Referentie',
     sample: 'Voorbeeld',
     sections: {

--- a/packages/theme-wizard-website/package.json
+++ b/packages/theme-wizard-website/package.json
@@ -81,6 +81,7 @@
     "astro": "7.1.6",
     "dequal": "2.0.3",
     "dlv": "1.1.3",
+    "es-toolkit": "1.50.0",
     "neotraverse": "1.0.1",
     "react": "19.2.8",
     "react-dom": "19.2.8"

--- a/packages/theme-wizard-website/src/components/StyleGuideNav.astro
+++ b/packages/theme-wizard-website/src/components/StyleGuideNav.astro
@@ -2,6 +2,7 @@
 const slug = Astro.url.pathname;
 const pages: { title: string; slug: string }[] = [
   { title: 'Kleur systeem', slug: '/style-guide/color-system' },
+  { title: 'Typografie systeem', slug: '/style-guide/typography-system' },
   { title: 'Design tokens', slug: '/style-guide/design-tokens' },
 ];
 ---

--- a/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
@@ -7,7 +7,7 @@ import '@nl-design-system-community/clippy-components/clippy-reset-theme';
 
 ---
 
-<BaseLayout title="Stijlgids kleur systeem - Theme Wizard">
+<BaseLayout title="Stijlgids kleur systeem - Style guide - Theme Wizard">
   <theme-wizard-app>
     <wizard-layout>
       <wizard-page-nav slot="page-nav"></wizard-page-nav>

--- a/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
@@ -7,7 +7,7 @@ import '@nl-design-system-community/clippy-components/clippy-reset-theme';
 
 ---
 
-<BaseLayout title="Stijlgids kleur systeem - Style guide - Theme Wizard">
+<BaseLayout title="Kleur systeem - Stijlgids - Theme Wizard">
   <theme-wizard-app>
     <wizard-layout>
       <wizard-page-nav slot="page-nav"></wizard-page-nav>

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -1,0 +1,95 @@
+---
+import StyleGuideNav from "@/components/StyleGuideNav.astro";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import TokenStoryMatches from '@/components/TokenStoryMatches.astro';
+import { capitalize } from 'es-toolkit/string';
+
+const fontFamilies = ['default', 'monospace']
+const fontWeights = ['default', 'bold']
+const fontSizes = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
+const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
+---
+
+<BaseLayout title="Typografie systeem - Style-guide - Theme Wizard">
+  <theme-wizard-app>
+    <wizard-layout>
+      <wizard-page-nav slot="page-nav"></wizard-page-nav>
+      <StyleGuideNav />
+
+      <wizard-container slot="main">
+        <wizard-stack size="5xl">
+          <clippy-heading level="1">Typografie systeem</clippy-heading>
+
+          <wizard-stack size="4xl">
+            <clippy-heading level="2">Lettertype</clippy-heading>
+            <wizard-stack size="3xl">
+              {fontFamilies.map((family) => (
+                <clippy-story-preview>
+                  <wizard-stack size="2xl">
+                    <clippy-heading level="3">{capitalize(family)}</clippy-heading>
+                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                      Placeholder {family}
+                    </div>
+                    <TokenStoryMatches groups={`basis.text.font-family.${family}`} />
+                  </wizard-stack>
+                </clippy-story-preview>
+              ))}
+            </wizard-stack>
+          </wizard-stack>
+
+          <wizard-stack size="4xl">
+            <clippy-heading level="2">Lettergewicht</clippy-heading>
+            <wizard-stack size="3xl">
+              {fontWeights.map((weight) => (
+                <clippy-story-preview>
+                  <wizard-stack size="2xl">
+                    <clippy-heading level="3">{capitalize(weight)}</clippy-heading>
+                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                      Placeholder {weight}
+                    </div>
+                    <TokenStoryMatches groups={`basis.text.font-weight.${weight}`} />
+                  </wizard-stack>
+                </clippy-story-preview>
+              ))}
+            </wizard-stack>
+          </wizard-stack>
+
+          <wizard-stack size="4xl">
+            <clippy-heading level="2">Lettergrootte</clippy-heading>
+            <wizard-stack size="3xl">
+              {fontSizes.map((size) => (
+                <clippy-story-preview>
+                  <wizard-stack size="2xl">
+                    <clippy-heading level="3">{capitalize(size)}</clippy-heading>
+                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                      Placeholder {size}
+                    </div>
+                    <TokenStoryMatches groups={`basis.text.font-size.${size}`} />
+                  </wizard-stack>
+                </clippy-story-preview>
+              ))}
+            </wizard-stack>
+          </wizard-stack>
+
+          <wizard-stack size="4xl">
+            <clippy-heading level="2">Regelhoogte</clippy-heading>
+            <wizard-stack size="3xl">
+              {lineHeights.map((lineHeight) => (
+                <clippy-story-preview>
+                  <wizard-stack size="2xl">
+                    <clippy-heading level="3">{capitalize(lineHeight)}</clippy-heading>
+                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                      Placeholder {lineHeight}
+                    </div>
+                    <TokenStoryMatches groups={`basis.text.line-height.${lineHeight}`} />
+                  </wizard-stack>
+                </clippy-story-preview>
+              ))}
+            </wizard-stack>
+          </wizard-stack>
+
+        </wizard-stack>
+      </wizard-container>
+    </wizard-layout>
+  </theme-wizard-app>
+</BaseLayout>

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -10,7 +10,7 @@ const fontSizes = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
 const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
 ---
 
-<BaseLayout title="Typografie systeem - Style-guide - Theme Wizard">
+<BaseLayout title="Typografie systeem - Stijlgids - Theme Wizard">
   <theme-wizard-app>
     <wizard-layout>
       <wizard-page-nav slot="page-nav"></wizard-page-nav>

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -100,9 +100,7 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
 
 <style>
   clippy-graph-paper {
-    --clippy-graph-paper-cell-size: var(--basis-size-xs);
-
-    padding-block: var(--basis-space-block-4xl);
+    padding-block: 2lh;
     padding-inline: var(--basis-space-inline-3xl);
   }
 </style>

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -4,11 +4,15 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import TokenStoryMatches from '@/components/TokenStoryMatches.astro';
 import { capitalize } from 'es-toolkit/string';
 
-const fontFamilies = ['default', 'monospace']
-const fontWeights = ['default', 'bold']
-const fontSizes = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
-const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
+const fontFamilies = ['default', 'monospace'] as const
+const fontWeights = ['default', 'bold'] as const
+const fontSizes = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
+const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
 ---
+
+<script>
+  import '@nl-design-system-community/clippy-components/clippy-graph-paper';
+</script>
 
 <BaseLayout title="Typografie systeem - Stijlgids - Theme Wizard">
   <theme-wizard-app>
@@ -27,9 +31,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(family)}</clippy-heading>
-                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                    <clippy-graph-paper>
                       Placeholder {family}
-                    </div>
+                    </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-family.${family}`} />
                   </wizard-stack>
                 </clippy-story-preview>
@@ -44,9 +48,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(weight)}</clippy-heading>
-                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                    <clippy-graph-paper>
                       Placeholder {weight}
-                    </div>
+                    </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-weight.${weight}`} />
                   </wizard-stack>
                 </clippy-story-preview>
@@ -61,9 +65,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(size)}</clippy-heading>
-                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                    <clippy-graph-paper>
                       Placeholder {size}
-                    </div>
+                    </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-size.${size}`} />
                   </wizard-stack>
                 </clippy-story-preview>
@@ -78,9 +82,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(lineHeight)}</clippy-heading>
-                    <div style="background:linear-gradient(-90deg,rgba(0,0,0,.04) 1px,transparent 1px),linear-gradient(rgba(0,0,0,.04) 1px,transparent 1px),var(--basis-color-default-bg-document);background-size:4px 4px,4px 4px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px,80px 80px;background-color:var(--basis-color-default-bg-document);padding:2rem">
+                    <clippy-graph-paper>
                       Placeholder {lineHeight}
-                    </div>
+                    </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.line-height.${lineHeight}`} />
                   </wizard-stack>
                 </clippy-story-preview>
@@ -93,3 +97,12 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
     </wizard-layout>
   </theme-wizard-app>
 </BaseLayout>
+
+<style>
+  clippy-graph-paper {
+    --clippy-graph-paper-cell-size: var(--basis-size-xs);
+
+    padding-block: var(--basis-space-block-4xl);
+    padding-inline: var(--basis-space-inline-3xl);
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1112,6 +1112,9 @@ importers:
       dlv:
         specifier: 1.1.3
         version: 1.1.3
+      es-toolkit:
+        specifier: 1.50.0
+        version: 1.50.0
       neotraverse:
         specifier: 1.0.1
         version: 1.0.1


### PR DESCRIPTION
test-url: https://theme-wizard-git-feat-typo-system-nl-design-system.vercel.app/style-guide/typography-system

- `<clippy-graph-paper>` - een web component om een element met een raster-achtergrond te renderen. Afmetingen en kleuren zijn instelbaar met CSS custom properties.
- stijlgidspagina voor typografiesysteem - grotendeels hetzelfde qua opzet als die voor kleursysteem, maar bestaat uit wat meer sections, dus heb een laag tussenkopjes extra in moeten bouwen. Iets vergelijkbaars gaan we moeten doen voor het 'lijnen en kaders'-systeem.
- melding wanneer er geen stories zijn om te tonen, anders kijk je zo raar tegen een leeg grijs vlak aan.
- Voorbeeldwaardes van de typografische waardes zijn nu placeholders, die vervangen we deze week met de nieuwe clippy sample componenten die @bramsmulders nu aan het maken is.

<img width="1720" height="969" alt="Screenshot 2026-08-04 at 16 53 06" src="https://github.com/user-attachments/assets/6b5f4d3f-a305-4e27-b820-799ef05ed580" />
