### PR TITLE
feat: clippy token sample spacing (#912)

### DIFF
--- a/packages/clippy-components/src/clippy-token-sample-spacing/README.md
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/README.md
@@ -1,0 +1,20 @@
+# `<clippy-token-sample-spacing>`
+
+Renders a sample of a spacing token. Used to illustrate spacing tokens and their concepts in the NL Design System.
+
+## Installation
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
+```
+
+## Usage
+
+TBD
+
+## Attributes & properties
+
+| Attribute / Property | Type     | Description                                                                                                  | Default     |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
+| `concept`            | `string` | Spacing token concept, see [concepts](https://nldesignsystem.nl/richtlijnen/stijl/ruimte/spacing-concepten/) | `'inine'`   |
+| `size`               | `string` | Spacing token size                                                                                           | `undefined` |

--- a/packages/clippy-components/src/clippy-token-sample-spacing/README.md
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/README.md
@@ -2,15 +2,33 @@
 
 Renders a sample of a spacing token. Used to illustrate spacing tokens and their concepts in the NL Design System.
 
-## Installation
+## Usage
 
 ```js
 import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
 ```
 
-## Usage
+```html
+<!-- standard, defaults to `inline` `conept` -->
+<clippy-token-sample-spacing size="3rem"></clippy-token-sample-spacing>
 
-TBD
+<!-- Concepts -->
+<clippy-token-sample-spacing size="3rem" concept="block"></clippy-token-sample-spacing>
+
+<!-- Custom labels -->
+<clippy-token-sample-spacing size="3rem" concept="block">
+  <span slot="label">item</span>
+  <!-- Only available to `row`, `column` and `text` concepts -->
+  <span slot="label-start">item</span>
+</clippy-token-sample-spacing>
+```
+
+## Slots
+
+| Slot          | Description                                                                          | default                  |
+| ------------- | ------------------------------------------------------------------------------------ | ------------------------ |
+| `label`       | Slot for the default label                                                           | `label`                  |
+| `label-start` | Slot for the secondary label, only available to `row`, `column` and `text` concepts. | `label` or `clippy-icon` |
 
 ## Attributes & properties
 
@@ -18,3 +36,15 @@ TBD
 | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------ | ----------- |
 | `concept`            | `string` | Spacing token concept, see [concepts](https://nldesignsystem.nl/richtlijnen/stijl/ruimte/spacing-concepten/) | `'inine'`   |
 | `size`               | `string` | Spacing token size                                                                                           | `undefined` |
+
+## CSS Custom Properties
+
+| Property                                        | Description                                               | Default                                              |
+| ----------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------- |
+| `--clippy-token-sample-spacing-size`            | Size of the spacing illustration                          | `undefined`                                          |
+| `--clippy-token-sample-spacing-bg-color-inline` | bg-color of the `inline` spacing illustration             | `#F2C9DC`                                            |
+| `--clippy-token-sample-spacing-bg-color-block`  | bg-color of the `block` spacing illustration              | `#E289B1`                                            |
+| `--clippy-token-sample-spacing-bg-color-text`   | bg-color of the `text` spacing illustration               | `#4AD571`                                            |
+| `--clippy-token-sample-spacing-bg-color-row`    | bg-color of the `row` spacing illustration                | `#40ADEF`                                            |
+| `--clippy-token-sample-spacing-bg-color-column` | bg-color of the `column` spacing illustration             | `#ABDBF8`                                            |
+| `--clippy-token-sample-spacing-bg-color`        | bg color of the illustration (overrides all other colors) | `var(--clippy-token-sample-spacing-bg-color-inline)` |

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.test.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.test.ts
@@ -1,28 +1,72 @@
-import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+import Color from 'colorjs.io';
 import './index';
-import { page } from 'vitest/browser';
+import { describe, expect, it, afterEach } from 'vitest';
+import { ClippyTokenSampleSpacing } from './index';
 
 const tag = 'clippy-token-sample-spacing';
 
-type ComponentElement = { shadowRoot: ShadowRoot; updateComplete: Promise<boolean> };
-
 function getComponent() {
-  return document.querySelector(tag) as unknown as ComponentElement;
+  return document.querySelector(tag) as unknown as ClippyTokenSampleSpacing;
 }
 
-describe(`<${tag}>`, () => {
-  beforeEach(() => {
-    document.body.innerHTML = `<${tag}></${tag}>`;
-  });
+const concepts = [
+  {
+    color: '#f2c9dc',
+    concept: 'inline',
+  },
+  {
+    color: '#e289b1',
+    concept: 'block',
+  },
+  {
+    color: '#4ad571',
+    concept: 'text',
+  },
+  {
+    color: '#40adef',
+    concept: 'row',
+  },
+  {
+    color: '#abdbf8',
+    concept: 'column',
+  },
+];
 
+describe(`<${tag}>`, () => {
   afterEach(() => {
     document.body.innerHTML = '';
   });
 
   it('renders', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
     const component = getComponent();
     await component.updateComplete;
 
-    expect(page.getByText('clippy-token-sample-spacing')).toBeVisible();
+    const element = document.querySelector(tag);
+    expect(element).toBeDefined();
+  });
+
+  it.each(concepts)('accepts concept $concept', async ({ color, concept }) => {
+    document.body.innerHTML = `<${tag} concept="${concept}"></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    const backgroundColor = getComputedStyle(component, ':before').backgroundColor;
+    const normalizedColor = new Color(backgroundColor);
+    const expectedColor = new Color(color);
+
+    expect(component.concept).toBe(concept);
+    expect(normalizedColor.toString({ format: 'rgb' })).toBe(expectedColor.toString({ format: 'rgb' }));
+  });
+
+  // test size property
+  it('accepts size property', async () => {
+    document.body.innerHTML = `<${tag} size="2rem"></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component).toHaveStyle('--_clippy-internal-token-sample-spacing-size: 2rem');
+    const inlineSize = getComputedStyle(component, ':before').inlineSize;
+    expect(inlineSize).toBe('32px');
   });
 });

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.test.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, afterEach, beforeEach } from 'vitest';
+import './index';
+import { page } from 'vitest/browser';
+
+const tag = 'clippy-token-sample-spacing';
+
+type ComponentElement = { shadowRoot: ShadowRoot; updateComplete: Promise<boolean> };
+
+function getComponent() {
+  return document.querySelector(tag) as unknown as ComponentElement;
+}
+
+describe(`<${tag}>`, () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders', async () => {
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(page.getByText('clippy-token-sample-spacing')).toBeVisible();
+  });
+});

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
@@ -19,7 +19,15 @@ declare global {
  *
  * @property {Concepts} concept - Spacing token concept
  * @property {string} size - Spacing token size
- * @cssprop [--clippy-token-sample-spacing-value] - Size of the spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-size] - Size of the spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-bg-color-inline] - bg-color of the inline spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-bg-color-block] - bg-color of the block spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-bg-color-text] - bg-color of the text spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-bg-color-row] - bg-color of the row spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-bg-color-column] - bg-color of the column spacing illustration
+ * @cssprop [--clippy-token-sample-spacing-bg-color] - bg-color of the illustration (overrides all other colors)
+ * @slot [label] - Slot for the default label
+ * @slot [label-start] - Slot for the secondary label, only available to 'row', 'column' and 'text' concepts.
  */
 @safeCustomElement(tag)
 export class ClippyTokenSampleSpacing extends LitElement {
@@ -42,7 +50,7 @@ export class ClippyTokenSampleSpacing extends LitElement {
       this.concept = 'inline';
     }
     if (changed.has('size') && this.size) {
-      this.style.setProperty('--clippy-token-sample-spacing-size', this.size);
+      this.style.setProperty('--_clippy-internal-token-sample-spacing-size', this.size);
     }
   }
 

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
@@ -1,6 +1,8 @@
 import { safeCustomElement } from '@src/lib/decorators';
+import CalendarIcon from '@tabler/icons/outline/calendar.svg?raw';
 import { LitElement, PropertyValues, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
+import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import type { Concepts } from './types';
 import styles from './styles';
 
@@ -31,7 +33,7 @@ export class ClippyTokenSampleSpacing extends LitElement {
 
   #renderDummy({ icon, slotName }: { icon?: boolean; slotName: string }) {
     return html`<span class="clippy-token-sample-spacing__dummy">
-      <slot name="${slotName}">${icon ? 'icon' : 'label'}</slot>
+      <slot name="${slotName}">${icon ? html`<clippy-icon>${unsafeSVG(CalendarIcon)}</clippy-icon>` : 'label'}</slot>
     </span>`;
   }
 

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
@@ -1,0 +1,25 @@
+import { safeCustomElement } from '@src/lib/decorators';
+import { LitElement, html } from 'lit';
+import { property } from 'lit/decorators.js';
+import type { Concepts } from './types';
+import styles from './styles';
+
+const tag = 'clippy-token-sample-spacing';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: ClippyTokenSampleSpacing;
+  }
+}
+
+@safeCustomElement(tag)
+export class ClippyTokenSampleSpacing extends LitElement {
+  static override readonly styles = [styles];
+
+  @property({ reflect: true })
+  concept: Concepts = 'inline';
+
+  override render() {
+    return html`<span>clippy-token-sample-spacing</span>`;
+  }
+}

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
@@ -12,6 +12,13 @@ declare global {
   }
 }
 
+/**
+ * Clippy Token Sample Spacing Component
+ *
+ * @property {Concepts} concept - Spacing token concept
+ * @property {string} size - Spacing token size
+ * @cssprop [--clippy-token-sample-spacing-value] - Size of the spacing illustration
+ */
 @safeCustomElement(tag)
 export class ClippyTokenSampleSpacing extends LitElement {
   static override readonly styles = [styles];
@@ -19,7 +26,28 @@ export class ClippyTokenSampleSpacing extends LitElement {
   @property({ reflect: true })
   concept: Concepts = 'inline';
 
+  @property({ type: String })
+  size?: string = undefined;
+
+  #renderLabel() {
+    return html`<mark class="clippy-token-sample-spacing__label">Label</mark>`;
+  }
+
+  #renderIcon() {
+    return html`<mark class="clippy-token-sample-spacing__icon">Icon</mark>`;
+  }
+
+  override willUpdate() {
+    if (this.size) {
+      this.style.setProperty('--clippy-token-sample-spacing-value', this.size);
+      this.requestUpdate();
+    }
+  }
+
   override render() {
-    return html`<span>clippy-token-sample-spacing</span>`;
+    return html`
+      ${['text'].includes(this.concept) ? this.#renderIcon() : null} ${this.#renderLabel()}
+      ${['row', 'column'].includes(this.concept) ? this.#renderLabel() : null}
+    `;
   }
 }

--- a/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/index.ts
@@ -1,5 +1,5 @@
 import { safeCustomElement } from '@src/lib/decorators';
-import { LitElement, html } from 'lit';
+import { LitElement, PropertyValues, html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 import type { Concepts } from './types';
 import styles from './styles';
@@ -29,25 +29,25 @@ export class ClippyTokenSampleSpacing extends LitElement {
   @property({ type: String })
   size?: string = undefined;
 
-  #renderLabel() {
-    return html`<mark class="clippy-token-sample-spacing__label">Label</mark>`;
+  #renderDummy({ icon, slotName }: { icon?: boolean; slotName: string }) {
+    return html`<span class="clippy-token-sample-spacing__dummy">
+      <slot name="${slotName}">${icon ? 'icon' : 'label'}</slot>
+    </span>`;
   }
 
-  #renderIcon() {
-    return html`<mark class="clippy-token-sample-spacing__icon">Icon</mark>`;
-  }
-
-  override willUpdate() {
-    if (this.size) {
-      this.style.setProperty('--clippy-token-sample-spacing-value', this.size);
-      this.requestUpdate();
+  override willUpdate(changed: PropertyValues) {
+    if (changed.has('concept') && this.concept === undefined) {
+      this.concept = 'inline';
+    }
+    if (changed.has('size') && this.size) {
+      this.style.setProperty('--clippy-token-sample-spacing-size', this.size);
     }
   }
 
   override render() {
     return html`
-      ${['text'].includes(this.concept) ? this.#renderIcon() : null} ${this.#renderLabel()}
-      ${['row', 'column'].includes(this.concept) ? this.#renderLabel() : null}
+      ${['row', 'column', 'text'].includes(this.concept) ? this.#renderDummy({ icon: this.concept === 'text', slotName: 'label-start' }) : nothing}
+      ${this.#renderDummy({ slotName: 'label' })}
     `;
   }
 }

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -2,6 +2,30 @@ import { css } from 'lit';
 
 export default css`
   :host(:not([hidden])) {
-    display: block;
+    display: grid;
+    inline-size: fit-content;
+  }
+
+  :host {
+    --_clippy-token-sample-spacing-value: var(--clippy-token-sample-spacing-value, 1rem);
+
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--basis-color-default-border-default);
+
+    &::before,
+    &::after {
+      background-color: red;
+      content: '';
+    }
+  }
+
+  :host([concept='inline']) {
+    grid-template-columns: var(--_clippy-token-sample-spacing-value) auto var(--_clippy-token-sample-spacing-value);
+    grid-template-areas: 'start label end';
+  }
+
+  .clippy-token-sample-spacing__label {
+    grid-area: label;
   }
 `;

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -47,7 +47,18 @@ export default css`
     font-family: var(--basis-text-font-family-default);
     font-size: var(--basis-text-font-size-md);
     line-height: var(--basis-text-line-height-md);
-    padding-inline: var(--basis-space-inline-xs);
+
+    &:not(:has(svg)) {
+      padding-inline: var(--basis-space-inline-xs);
+    }
+
+    :where(clippy-icon) {
+      --clippy-icon-size: var(--basis-text-line-height-md);
+    }
+
+    :where(clippy-icon, svg) {
+      display: block;
+    }
   }
 
   :host([concept='inline']),

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -12,6 +12,7 @@ export default css`
       var(--_clippy-internal-token-sample-spacing-size, 1rem)
     );
     --_clippy-token-sample-spacing-border-color: var(--basis-color-default-border-default);
+
     /* Background colors */
     --_clippy-token-sample-spacing-bg-color-inline: var(--clippy-token-sample-spacing-bg-color-inline, #f2c9dc);
     --_clippy-token-sample-spacing-bg-color-block: var(--clippy-token-sample-spacing-bg-color-block, #e289b1);

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -7,17 +7,21 @@ export default css`
   }
 
   :host {
-    --_clippy-token-sample-spacing-color-inline: var(--basis-color-negative-bg-active);
-    --_clippy-token-sample-spacing-color-block: var(--basis-color-negative-border-subtle);
-    --_clippy-token-sample-spacing-color-text: var(--basis-color-positive-border-subtle);
-    --_clippy-token-sample-spacing-color-row: var(--basis-color-info-border-subtle);
-    --_clippy-token-sample-spacing-color-column: var(--basis-color-info-bg-active);
-    --_clippy-token-sample-spacing-border-color: var(--basis-color-default-border-default);
-    --_clippy-token-sample-spacing-background-color: var(
-      --clippy-token-sample-spacing-background-color,
-      var(--_clippy-token-sample-spacing-color-inline)
+    --_clippy-token-sample-spacing-size: var(
+      --clippy-token-sample-spacing-size,
+      var(--_clippy-internal-token-sample-spacing-size, 1rem)
     );
-    --_clippy-token-sample-spacing-size: var(--clippy-token-sample-spacing-size, 1rem);
+    --_clippy-token-sample-spacing-border-color: var(--basis-color-default-border-default);
+    /* Background colors */
+    --_clippy-token-sample-spacing-bg-color-inline: var(--clippy-token-sample-spacing-bg-color-inline, #f2c9dc);
+    --_clippy-token-sample-spacing-bg-color-block: var(--clippy-token-sample-spacing-bg-color-block, #e289b1);
+    --_clippy-token-sample-spacing-bg-color-text: var(--clippy-token-sample-spacing-bg-color-text, #4ad571);
+    --_clippy-token-sample-spacing-bg-color-row: var(--clippy-token-sample-spacing-bg-color-row, #40adef);
+    --_clippy-token-sample-spacing-bg-color-column: var(--clippy-token-sample-spacing-bg-color-column, #abdbf8);
+    --_clippy-token-sample-spacing-bg-color: var(
+      --clippy-token-sample-spacing-bg-color,
+      var(--_clippy-token-sample-spacing-bg-color-inline)
+    );
 
     border-color: var(--_clippy-token-sample-spacing-border-color);
     border-style: solid;
@@ -25,7 +29,7 @@ export default css`
 
     &::before,
     &::after {
-      background-color: var(--_clippy-token-sample-spacing-background-color);
+      background-color: var(--_clippy-token-sample-spacing-bg-color);
       content: '';
       inline-size: var(--_clippy-token-sample-spacing-size);
     }
@@ -111,18 +115,32 @@ export default css`
   }
 
   :host([concept='block']) {
-    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-block);
+    --clippy-token-sample-spacing-bg-color: var(--_clippy-token-sample-spacing-bg-color-block);
   }
 
   :host([concept='text']) {
-    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-text);
+    --clippy-token-sample-spacing-bg-color: var(--_clippy-token-sample-spacing-bg-color-text);
   }
 
   :host([concept='column']) {
-    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-column);
+    --clippy-token-sample-spacing-bg-color: var(--_clippy-token-sample-spacing-bg-color-column);
   }
 
   :host([concept='row']) {
-    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-row);
+    --clippy-token-sample-spacing-bg-color: var(--_clippy-token-sample-spacing-bg-color-row);
+  }
+
+  /**
+   * Use the system's accent color for the background when the user has enabled forced colors
+   */
+  @media (forced-colors: active) {
+    :host {
+      --_clippy-token-sample-spacing-bg-color: AccentColor;
+
+      &::before,
+      &::after {
+        forced-color-adjust: none;
+      }
+    }
   }
 `;

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -7,25 +7,111 @@ export default css`
   }
 
   :host {
-    --_clippy-token-sample-spacing-value: var(--clippy-token-sample-spacing-value, 1rem);
+    --_clippy-token-sample-spacing-color-inline: var(--basis-color-negative-bg-active);
+    --_clippy-token-sample-spacing-color-block: var(--basis-color-negative-border-subtle);
+    --_clippy-token-sample-spacing-color-text: var(--basis-color-positive-border-subtle);
+    --_clippy-token-sample-spacing-color-row: var(--basis-color-info-border-subtle);
+    --_clippy-token-sample-spacing-color-column: var(--basis-color-info-bg-active);
+    --_clippy-token-sample-spacing-border-color: var(--basis-color-default-border-default);
+    --_clippy-token-sample-spacing-background-color: var(
+      --clippy-token-sample-spacing-background-color,
+      var(--_clippy-token-sample-spacing-color-inline)
+    );
+    --_clippy-token-sample-spacing-size: var(--clippy-token-sample-spacing-size, 1rem);
 
-    border-width: 1px;
+    border-color: var(--_clippy-token-sample-spacing-border-color);
     border-style: solid;
-    border-color: var(--basis-color-default-border-default);
+    border-width: 1px;
 
     &::before,
     &::after {
-      background-color: red;
+      background-color: var(--_clippy-token-sample-spacing-background-color);
       content: '';
+      inline-size: var(--_clippy-token-sample-spacing-size);
+    }
+
+    &::before {
+      grid-area: start;
+    }
+
+    &::after {
+      grid-area: end;
     }
   }
 
-  :host([concept='inline']) {
-    grid-template-columns: var(--_clippy-token-sample-spacing-value) auto var(--_clippy-token-sample-spacing-value);
-    grid-template-areas: 'start label end';
+  .clippy-token-sample-spacing__dummy {
+    background-color: var(--basis-color-default-bg-document);
+    border-color: var(--_clippy-token-sample-spacing-border-color);
+    border-style: solid;
+    border-width: 0;
+    font-family: var(--basis-text-font-family-default);
+    font-size: var(--basis-text-font-size-md);
+    line-height: var(--basis-text-line-height-md);
+    padding-inline: var(--basis-space-inline-xs);
   }
 
-  .clippy-token-sample-spacing__label {
-    grid-area: label;
+  :host([concept='inline']),
+  :host([concept='text']),
+  :host([concept='column']) {
+    grid-template-areas: 'start center end';
+    grid-template-columns: repeat(3, auto);
+  }
+
+  :host([concept='block']),
+  :host([concept='row']) {
+    grid-template-areas:
+      'start'
+      'center'
+      'end';
+    grid-template-rows: repeat(3, auto);
+
+    &::before,
+    &::after {
+      block-size: var(--_clippy-token-sample-spacing-size);
+      inline-size: auto;
+    }
+  }
+
+  /**
+   * Display the spacing between two components/text nodes
+   */
+  :host([concept='column']),
+  :host([concept='row']),
+  :host([concept='text']) {
+    &::before {
+      grid-area: center;
+    }
+
+    &::after {
+      display: none;
+    }
+  }
+
+  /**
+   * Move border to the label to illustrate spacing between two components
+   */
+  :host([concept='column']),
+  :host([concept='row']) {
+    border-width: 0;
+
+    :where(.clippy-token-sample-spacing__dummy) {
+      border-width: 1px;
+    }
+  }
+
+  :host([concept='block']) {
+    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-block);
+  }
+
+  :host([concept='text']) {
+    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-text);
+  }
+
+  :host([concept='column']) {
+    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-column);
+  }
+
+  :host([concept='row']) {
+    --clippy-token-sample-spacing-background-color: var(--_clippy-token-sample-spacing-color-row);
   }
 `;

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -26,7 +26,7 @@ export default css`
 
     border-color: var(--_clippy-token-sample-spacing-border-color);
     border-style: solid;
-    border-width: 1px;
+    border-width: var(--basis-border-width-sm);
 
     &::before,
     &::after {
@@ -111,7 +111,7 @@ export default css`
     border-width: 0;
 
     :where(.clippy-token-sample-spacing__dummy) {
-      border-width: 1px;
+      border-width: var(--basis-border-width-sm);
     }
   }
 

--- a/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'lit';
+
+export default css`
+  :host(:not([hidden])) {
+    display: block;
+  }
+`;

--- a/packages/clippy-components/src/clippy-token-sample-spacing/types.ts
+++ b/packages/clippy-components/src/clippy-token-sample-spacing/types.ts
@@ -1,0 +1,2 @@
+export const concepts = ['inline', 'block', 'text', 'column', 'row'] as const;
+export type Concepts = (typeof concepts)[number];

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
+import { Concepts } from '@nl-design-system-community/clippy-components/src/clippy-token-sample-spacing/types.js';
+import React from 'react';
+
+type TableColorStoryArgs = {
+  concept?: Concepts;
+};
+
+const meta = {
+  id: 'clippy-token-sample-spacing',
+  parameters: {
+    docs: {
+      description: {
+        component: '`<clippy-token-sample-spacing>` is een component om concepten rond spacing-tokens te illustreren.',
+      },
+    },
+  },
+  render: () => React.createElement('clippy-token-sample-spacing', { concept: 'inline' }),
+  tags: ['autodocs'],
+  title: 'Clippy/Token Sample Spacing',
+} satisfies Meta<TableColorStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Basis token sample spacing',
+};

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
@@ -13,6 +13,10 @@ type TableColorStoryArgs = {
 
 const meta = {
   id: 'clippy-token-sample-spacing',
+  args: {
+    concept: 'inline',
+    size: '1rem',
+  },
   argTypes: {
     concept: {
       control: { type: 'select' },
@@ -22,7 +26,8 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: '`<clippy-token-sample-spacing>` is een component om concepten rond spacing-tokens te illustreren.',
+        component:
+          '`<clippy-token-sample-spacing>` is a component to illustrate spacing tokens and their concepts within the NL Design System.',
       },
     },
   },
@@ -36,9 +41,66 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Basis token sample spacing',
+  name: 'Default inline',
+};
+
+export const Size: Story = {
+  name: 'Size',
   args: {
-    concept: 'inline',
-    size: '2rem',
+    size: '3rem',
   },
+};
+
+export const ConceptBlock: Story = {
+  name: 'Concept: block',
+  args: {
+    concept: 'block',
+  },
+};
+
+export const ConceptText: Story = {
+  name: 'Concept: text',
+  args: {
+    concept: 'text',
+  },
+};
+
+export const ConceptColumn: Story = {
+  name: 'Concept: column',
+  args: {
+    concept: 'column',
+  },
+};
+
+export const ConceptRow: Story = {
+  name: 'Concept: row',
+  args: {
+    concept: 'row',
+  },
+};
+
+export const SlotLabel: Story = {
+  name: 'Slot: `label`',
+  render: (args: TableColorStoryArgs) =>
+    React.createElement('clippy-token-sample-spacing', args, React.createElement('span', { slot: 'label' }, 'item')),
+};
+
+export const SlotLabelStart: Story = {
+  name: 'Slot: `label-start`',
+  args: {
+    concept: 'row',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Slot for a second label placed at the start, only available to `row`, `column` and `text` concepts.',
+      },
+    },
+  },
+  render: (args: TableColorStoryArgs) =>
+    React.createElement(
+      'clippy-token-sample-spacing',
+      args,
+      React.createElement('span', { slot: 'label-start' }, 'item'),
+    ),
 };

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 type TableColorStoryArgs = {
   concept?: Concepts;
+  size?: string;
 };
 
 const meta = {
@@ -16,7 +17,7 @@ const meta = {
       },
     },
   },
-  render: () => React.createElement('clippy-token-sample-spacing', { concept: 'inline' }),
+  render: (args: TableColorStoryArgs) => React.createElement('clippy-token-sample-spacing', args),
   tags: ['autodocs'],
   title: 'Clippy/Token Sample Spacing',
 } satisfies Meta<TableColorStoryArgs>;
@@ -27,4 +28,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: 'Basis token sample spacing',
+  args: {
+    concept: 'inline',
+    size: '3rem',
+  },
 };

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
-import { Concepts } from '@nl-design-system-community/clippy-components/src/clippy-token-sample-spacing/types.js';
+import {
+  type Concepts,
+  concepts,
+} from '@nl-design-system-community/clippy-components/src/clippy-token-sample-spacing/types.js';
 import React from 'react';
 
 type TableColorStoryArgs = {
@@ -10,6 +13,12 @@ type TableColorStoryArgs = {
 
 const meta = {
   id: 'clippy-token-sample-spacing',
+  argTypes: {
+    concept: {
+      control: { type: 'select' },
+      options: concepts,
+    },
+  },
   parameters: {
     docs: {
       description: {
@@ -30,6 +39,6 @@ export const Default: Story = {
   name: 'Basis token sample spacing',
   args: {
     concept: 'inline',
-    size: '3rem',
+    size: '2rem',
   },
 };


### PR DESCRIPTION
Deze PR voegt het `clippy-token-sample-spacing` component toe aan `clippy-components`.
Zo kunnen we in de toekomst dit component gebruiken om deze pagina op te maken: https://nldesignsystem.nl/richtlijnen/stijl/ruimte/spacing-concepten/


## Screenshots 
<img width="464" height="171" alt="Screenshot 2026-08-04 at 16 07 45" src="https://github.com/user-attachments/assets/49165915-60cb-4cf0-821e-e99c1e16a9dd" />
<img width="182" height="354" alt="Screenshot 2026-08-04 at 16 07 41" src="https://github.com/user-attachments/assets/40759219-65cd-4e68-829f-bda6fd1ae3a3" />
<img width="182" height="331" alt="Screenshot 2026-08-04 at 16 07 38" src="https://github.com/user-attachments/assets/c2f80baa-3839-4ca7-93d3-6ebfba94e67a" />
<img width="473" height="140" alt="Screenshot 2026-08-04 at 16 07 33" src="https://github.com/user-attachments/assets/592696c8-ecef-4082-9725-ad3518452e0a" />
<img width="146" height="351" alt="Screenshot 2026-08-04 at 16 07 27" src="https://github.com/user-attachments/assets/c130c8d0-65c5-42eb-ab83-d7d97e276b25" />

