### PR TITLE
feat: clippy token sample border (#917)

### DIFF
--- a/.changeset/ripe-icons-fix.md
+++ b/.changeset/ripe-icons-fix.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-community/clippy-components': minor
+---
+
+Added `clippy-token-sample-border` component

--- a/packages/clippy-components/src/clippy-token-sample-border/README.md
+++ b/packages/clippy-components/src/clippy-token-sample-border/README.md
@@ -1,0 +1,29 @@
+# `<clippy-token-sample-border>`
+
+Renders a sample of a border token. Used to illustrate border tokens and their concepts in the NL Design System.
+
+## Usage
+
+```js
+import '@nl-design-system-community/clippy-components/clippy-token-sample-border';
+```
+
+```html
+<!-- standard, defaults to `inline` `conept` -->
+<clippy-token-sample-border></clippy-token-sample-border>
+```
+
+## Slots
+
+| Slot | Description | default |
+| ---- | ----------- | ------- |
+
+## Attributes & properties
+
+| Attribute / Property | Type | Description | Default |
+| -------------------- | ---- | ----------- | ------- |
+
+## CSS Custom Properties
+
+| Property | Description | Default |
+| -------- | ----------- | ------- |

--- a/packages/clippy-components/src/clippy-token-sample-border/README.md
+++ b/packages/clippy-components/src/clippy-token-sample-border/README.md
@@ -9,21 +9,30 @@ import '@nl-design-system-community/clippy-components/clippy-token-sample-border
 ```
 
 ```html
-<!-- standard, defaults to `inline` `conept` -->
+<!-- standard, defaults to 1px width, 0 radius -->
 <clippy-token-sample-border></clippy-token-sample-border>
+
+<!-- width -->
+<clippy-token-sample-border border-width="2px"></clippy-token-sample-border>
+
+<!-- radius -->
+<clippy-token-sample-border border-radius="4px"></clippy-token-sample-border>
+
+<!-- width & radius -->
+<clippy-token-sample-border border-width="2px" border-radius="4px"></clippy-token-sample-border>
 ```
-
-## Slots
-
-| Slot | Description | default |
-| ---- | ----------- | ------- |
 
 ## Attributes & properties
 
-| Attribute / Property | Type | Description | Default |
-| -------------------- | ---- | ----------- | ------- |
+| Attribute / Property | Type                                  | Description                 | Default |
+| -------------------- | ------------------------------------- | --------------------------- | ------- |
+| `border-radius`      | `string` (any valid CSS length value) | Border radius of the border | `0`     |
+| `border-width`       | `string` (any valid CSS length value) | Width of the border         | `1px`   |
 
 ## CSS Custom Properties
 
-| Property | Description | Default |
-| -------- | ----------- | ------- |
+| Property                              | Description                 | Default                |
+| ------------------------------------- | --------------------------- | ---------------------- |
+| `--clippy-token-sample-border-size`   | Size of the component       | `var(--basis-size-lg)` |
+| `--clippy-token-sample-border-radius` | Border radius of the border | `0`                    |
+| `--clippy-token-sample-border-width`  | Width of the border         | `1px`                  |

--- a/packages/clippy-components/src/clippy-token-sample-border/index.test.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/index.test.ts
@@ -1,0 +1,24 @@
+import './index';
+import { describe, expect, it, afterEach } from 'vitest';
+import { ClippyTokenSampleBorder } from './index';
+
+const tag = 'clippy-token-sample-border';
+
+function getComponent() {
+  return document.querySelector(tag) as unknown as ClippyTokenSampleBorder;
+}
+
+describe(`<${tag}>`, () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    const element = document.querySelector(tag);
+    expect(element).toBeDefined();
+  });
+});

--- a/packages/clippy-components/src/clippy-token-sample-border/index.test.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/index.test.ts
@@ -21,4 +21,42 @@ describe(`<${tag}>`, () => {
     const element = document.querySelector(tag);
     expect(element).toBeDefined();
   });
+
+  it('border-radius defaults to empty string', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component).toBeDefined();
+    expect(component.borderRadius).toBe('');
+  });
+
+  it('border-width defaults to 1px', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component).toBeDefined();
+    expect(component.borderWidth).toBe('1px');
+  });
+
+  it('adjusts the border width of the dummy element', async () => {
+    document.body.innerHTML = `<${tag} border-width="2px"></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    const dummy = component.shadowRoot?.querySelector('.clippy-token-sample-border__dummy') as HTMLDivElement;
+    expect(dummy).toBeDefined();
+    expect(getComputedStyle(dummy).getPropertyValue('border-width')).toBe('2px');
+  });
+
+  it('adjusts the border radius of the dummy element', async () => {
+    document.body.innerHTML = `<${tag} border-radius="4px"></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    const dummy = component.shadowRoot?.querySelector('.clippy-token-sample-border__dummy') as HTMLDivElement;
+    expect(dummy).toBeDefined();
+    expect(getComputedStyle(dummy).getPropertyValue('border-top-left-radius')).toBe('4px');
+  });
 });

--- a/packages/clippy-components/src/clippy-token-sample-border/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/index.ts
@@ -1,0 +1,23 @@
+import { safeCustomElement } from '@src/lib/decorators';
+import { LitElement, html } from 'lit';
+import styles from './styles';
+
+const tag = 'clippy-token-sample-border';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: ClippyTokenSampleBorder;
+  }
+}
+
+/**
+ * Clippy Token Sample Border Component
+ */
+@safeCustomElement(tag)
+export class ClippyTokenSampleBorder extends LitElement {
+  static override readonly styles = [styles];
+
+  override render() {
+    return html` clippy-token-sample-border `;
+  }
+}

--- a/packages/clippy-components/src/clippy-token-sample-border/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/index.ts
@@ -13,27 +13,31 @@ declare global {
 
 /**
  * Clippy Token Sample Border Component
+ *
+ * @cssprop --clippy-token-sample-border-size - Size of the component
+ * @cssprop --clippy-token-sample-border-radius - Border radius of the border
+ * @cssprop --clippy-token-sample-border-width - Width of the border
  */
 @safeCustomElement(tag)
 export class ClippyTokenSampleBorder extends LitElement {
   static override readonly styles = [styles];
 
   @property({ attribute: 'border-radius', reflect: true, type: String })
-  borderRadius?: string = '0px';
+  borderRadius?: string = '';
 
   @property({ attribute: 'border-width', reflect: true, type: String })
   borderWidth?: string = '1px';
 
   override willUpdate(changed: PropertyValues) {
     if (changed.has('borderWidth')) {
-      if (this.borderWidth === undefined) {
+      if (this.borderWidth === undefined || this.borderWidth === '') {
         this.borderWidth = '1px';
       }
       this.style.setProperty('--_clippy-internal-token-sample-border-width', this.borderWidth);
     }
     if (changed.has('borderRadius')) {
       if (this.borderRadius === undefined) {
-        this.borderRadius = '0px';
+        this.borderRadius = '';
       }
       this.style.setProperty('--_clippy-internal-token-sample-border-radius', this.borderRadius);
     }

--- a/packages/clippy-components/src/clippy-token-sample-border/index.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/index.ts
@@ -1,5 +1,6 @@
 import { safeCustomElement } from '@src/lib/decorators';
-import { LitElement, html } from 'lit';
+import { LitElement, PropertyValues, html } from 'lit';
+import { property } from 'lit/decorators.js';
 import styles from './styles';
 
 const tag = 'clippy-token-sample-border';
@@ -17,7 +18,28 @@ declare global {
 export class ClippyTokenSampleBorder extends LitElement {
   static override readonly styles = [styles];
 
+  @property({ attribute: 'border-radius', reflect: true, type: String })
+  borderRadius?: string = '0px';
+
+  @property({ attribute: 'border-width', reflect: true, type: String })
+  borderWidth?: string = '1px';
+
+  override willUpdate(changed: PropertyValues) {
+    if (changed.has('borderWidth')) {
+      if (this.borderWidth === undefined) {
+        this.borderWidth = '1px';
+      }
+      this.style.setProperty('--_clippy-internal-token-sample-border-width', this.borderWidth);
+    }
+    if (changed.has('borderRadius')) {
+      if (this.borderRadius === undefined) {
+        this.borderRadius = '0px';
+      }
+      this.style.setProperty('--_clippy-internal-token-sample-border-radius', this.borderRadius);
+    }
+  }
+
   override render() {
-    return html` clippy-token-sample-border `;
+    return html`<div class="clippy-token-sample-border__dummy"></div>`;
   }
 }

--- a/packages/clippy-components/src/clippy-token-sample-border/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/styles.ts
@@ -6,47 +6,44 @@ export default css`
   }
 
   :host {
-    --_clippy-token-sample-border-size: var(--basis-size-lg);
-    --_clippy-token-sample-border-dummy-size: var(--_clippy-token-sample-border-size);
+    --_clippy-token-sample-border-size: var(--clippy-token-sample-border-size, var(--basis-size-lg));
     --_clippy-token-sample-border-radius: var(
       --clippy-token-sample-border-radius,
       var(--_clippy-internal-token-sample-border-radius, 0)
     );
     --_clippy-token-sample-border-width: var(
       --clippy-token-sample-border-width,
-      var(--_clippy-internal-token-sample-border-width, 0)
+      var(--_clippy-internal-token-sample-border-width, 1px)
     );
 
-    box-sizing: border-box;
-    inline-size: var(--_clippy-token-sample-border-size);
-    block-size: var(--_clippy-token-sample-border-size);
-    border-width: var(--basis-border-width-sm);
-    border-style: solid;
-    border-color: var(--basis-color-default-border-subtle);
-    position: relative;
-    overflow: hidden;
     background-color: var(--basis-color-default-bg-document);
+    block-size: var(--_clippy-token-sample-border-size);
+    border-color: var(--basis-color-default-border-subtle);
+    border-style: solid;
+    border-width: var(--basis-border-width-sm);
     color: var(--basis-color-default-color-document);
+    inline-size: var(--_clippy-token-sample-border-size);
+    overflow: hidden;
+    position: relative;
   }
 
   .clippy-token-sample-border__dummy {
-    inline-size: var(--_clippy-token-sample-border-dummy-size);
-    block-size: var(--_clippy-token-sample-border-dummy-size);
-    position: absolute;
-    inset-inline-start: 50%;
-    inset-block-start: 50%;
-    translate: calc(var(--_clippy-token-sample-border-width) / 2 * -1) -50%;
-    background-color: transparent;
-    border-width: var(--_clippy-token-sample-border-width);
-    border-style: solid;
+    block-size: var(--_clippy-token-sample-border-size);
     border-color: currentColor;
     border-start-start-radius: var(--_clippy-token-sample-border-radius);
+    border-style: solid;
+    border-width: var(--_clippy-token-sample-border-width);
+    inline-size: var(--_clippy-token-sample-border-size);
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    position: absolute;
+    translate: calc(var(--_clippy-token-sample-border-width) / 2 * -1) -50%;
   }
 
-  :host([border-radius]:not([border-radius^='0'], [border-radius=''])) {
+  :host([border-radius]:not([border-radius=''])) {
     :where(.clippy-token-sample-border__dummy) {
-      inset-inline-start: calc(var(--_clippy-token-sample-border-size) / 4);
       inset-block-start: calc(var(--_clippy-token-sample-border-size) / 4);
+      inset-inline-start: calc(var(--_clippy-token-sample-border-size) / 4);
       translate: 0 0;
     }
   }

--- a/packages/clippy-components/src/clippy-token-sample-border/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/styles.ts
@@ -4,4 +4,50 @@ export default css`
   :host(:not([hidden])) {
     display: block;
   }
+
+  :host {
+    --_clippy-token-sample-border-size: var(--basis-size-lg);
+    --_clippy-token-sample-border-dummy-size: var(--_clippy-token-sample-border-size);
+    --_clippy-token-sample-border-radius: var(
+      --clippy-token-sample-border-radius,
+      var(--_clippy-internal-token-sample-border-radius, 0)
+    );
+    --_clippy-token-sample-border-width: var(
+      --clippy-token-sample-border-width,
+      var(--_clippy-internal-token-sample-border-width, 0)
+    );
+
+    box-sizing: border-box;
+    inline-size: var(--_clippy-token-sample-border-size);
+    block-size: var(--_clippy-token-sample-border-size);
+    border-width: var(--basis-border-width-sm);
+    border-style: solid;
+    border-color: var(--basis-color-default-border-subtle);
+    position: relative;
+    overflow: hidden;
+    background-color: var(--basis-color-default-bg-document);
+    color: var(--basis-color-default-color-document);
+  }
+
+  .clippy-token-sample-border__dummy {
+    inline-size: var(--_clippy-token-sample-border-dummy-size);
+    block-size: var(--_clippy-token-sample-border-dummy-size);
+    position: absolute;
+    inset-inline-start: 50%;
+    inset-block-start: 50%;
+    translate: calc(var(--_clippy-token-sample-border-width) / 2 * -1) -50%;
+    background-color: transparent;
+    border-width: var(--_clippy-token-sample-border-width);
+    border-style: solid;
+    border-color: currentColor;
+    border-start-start-radius: var(--_clippy-token-sample-border-radius);
+  }
+
+  :host([border-radius]:not([border-radius^='0'], [border-radius=''])) {
+    :where(.clippy-token-sample-border__dummy) {
+      inset-inline-start: calc(var(--_clippy-token-sample-border-size) / 4);
+      inset-block-start: calc(var(--_clippy-token-sample-border-size) / 4);
+      translate: 0 0;
+    }
+  }
 `;

--- a/packages/clippy-components/src/clippy-token-sample-border/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-border/styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'lit';
+
+export default css`
+  :host(:not([hidden])) {
+    display: block;
+  }
+`;

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-border.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-border.stories.tsx
@@ -10,7 +10,7 @@ type TokenSampleBorderStoryArgs = {
 const meta = {
   id: 'clippy-token-sample-border',
   args: {
-    borderRadius: '0px',
+    borderRadius: '',
     borderWidth: '1px',
   },
   parameters: {
@@ -32,4 +32,26 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   name: 'Default',
+};
+
+export const Width: Story = {
+  name: 'Width',
+  args: {
+    borderWidth: '5px',
+  },
+};
+
+export const Radius: Story = {
+  name: 'Radius',
+  args: {
+    borderRadius: '10px',
+  },
+};
+
+export const WidthRadius: Story = {
+  name: 'Width & Radius',
+  args: {
+    borderRadius: '10px',
+    borderWidth: '5px',
+  },
 };

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-border.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-border.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '@nl-design-system-community/clippy-components/clippy-token-sample-border';
+import React from 'react';
+
+type TokenSampleBorderStoryArgs = {};
+
+const meta = {
+  id: 'clippy-token-sample-border',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '`<clippy-token-sample-border>` is a component to illustrate border tokens and their concepts within the NL Design System.',
+      },
+    },
+  },
+  render: (args: TokenSampleBorderStoryArgs) => React.createElement('clippy-token-sample-border', args),
+  tags: ['autodocs'],
+  title: 'Clippy/Token Sample: Border',
+} satisfies Meta<TokenSampleBorderStoryArgs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Default',
+};

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-border.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-border.stories.tsx
@@ -2,10 +2,17 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import '@nl-design-system-community/clippy-components/clippy-token-sample-border';
 import React from 'react';
 
-type TokenSampleBorderStoryArgs = {};
+type TokenSampleBorderStoryArgs = {
+  borderRadius?: string;
+  borderWidth?: string;
+};
 
 const meta = {
   id: 'clippy-token-sample-border',
+  args: {
+    borderRadius: '0px',
+    borderWidth: '1px',
+  },
   parameters: {
     docs: {
       description: {

--- a/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
+++ b/packages/clippy-storybook/src/web-components/clippy-token-sample-spacing.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from '@nl-design-system-community/clippy-components/src/clippy-token-sample-spacing/types.js';
 import React from 'react';
 
-type TableColorStoryArgs = {
+type TokenSampleSpacingStoryArgs = {
   concept?: Concepts;
   size?: string;
 };
@@ -31,10 +31,10 @@ const meta = {
       },
     },
   },
-  render: (args: TableColorStoryArgs) => React.createElement('clippy-token-sample-spacing', args),
+  render: (args: TokenSampleSpacingStoryArgs) => React.createElement('clippy-token-sample-spacing', args),
   tags: ['autodocs'],
-  title: 'Clippy/Token Sample Spacing',
-} satisfies Meta<TableColorStoryArgs>;
+  title: 'Clippy/Token Sample: Spacing',
+} satisfies Meta<TokenSampleSpacingStoryArgs>;
 
 export default meta;
 
@@ -81,7 +81,7 @@ export const ConceptRow: Story = {
 
 export const SlotLabel: Story = {
   name: 'Slot: `label`',
-  render: (args: TableColorStoryArgs) =>
+  render: (args: TokenSampleSpacingStoryArgs) =>
     React.createElement('clippy-token-sample-spacing', args, React.createElement('span', { slot: 'label' }, 'item')),
 };
 
@@ -97,7 +97,7 @@ export const SlotLabelStart: Story = {
       },
     },
   },
-  render: (args: TableColorStoryArgs) =>
+  render: (args: TokenSampleSpacingStoryArgs) =>
     React.createElement(
       'clippy-token-sample-spacing',
       args,


### PR DESCRIPTION
Deze PR voegt het `clippy-token-sample-border` component toe. 

## Voorbeelden
<img width="89" height="86" alt="Screenshot 2026-08-07 at 11 43 03" src="https://github.com/user-attachments/assets/a4d7b58f-c8df-49ac-a12f-22d0663d306d" />
<img width="90" height="86" alt="Screenshot 2026-08-07 at 11 43 06" src="https://github.com/user-attachments/assets/7f94ec0a-f3a6-4daa-bf30-f2d0c2e17b54" />
<img width="87" height="87" alt="Screenshot 2026-08-07 at 11 43 09" src="https://github.com/user-attachments/assets/132f6aee-8229-42ae-9bca-07449b5ff910" />
<img width="82" height="82" alt="Screenshot 2026-08-07 at 11 43 13" src="https://github.com/user-attachments/assets/f0d9d1d6-3226-4a2d-8c11-68236eaa28fc" />

