### PR TITLE
fix: make sure to force updated sub-packages in local-dev

### DIFF
--- a/packages/clippy-components/src/lib/decorators/index.ts
+++ b/packages/clippy-components/src/lib/decorators/index.ts
@@ -14,5 +14,10 @@ export const safeCustomElement = (tagName: string) => {
     if (registry && !registry.get(tagName)) {
       registry.define(tagName, target);
     }
+    // Make sure that updates propagate in Dev mode.
+    // Will be bundled away in Prod mode.
+    else if (import.meta.hot) {
+      import.meta.hot.invalidate();
+    }
   };
 };


### PR DESCRIPTION
When making a change in `packages/clippy-components/src/clippy-token-sample-spacing/styles.ts`, I expect storybook (at `packages/clippy-storybook`) to update immediately with that change. But the only thing that happens is that the page briefly flickers, indicating that _something_ happened, but no visual update. When I refresh the page (e.g. http://localhost:6006/?path=/docs/clippy-token-sample-spacing--documentatie), then the update becomes visible. 

Problem: our `safeCustomElement` prevents HMR to replace the existing (old) component with the new one, because it's already registered.

This PR fixes our `safeCustomElement` decorator to force invalidation in Dev mode.