### PR TITLE
design: reduce paper usage in style guide pages 🌱

### DIFF
--- a/packages/theme-wizard-app/src/components/wizard-story-matches/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-story-matches/index.ts
@@ -1,12 +1,11 @@
 import { consume } from '@lit/context';
 import paragraphStyles from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
 import { arrayFromCommaList } from '@nl-design-system-community/clippy-components/lib/converters';
-import { LitElement, html, unsafeCSS, type PropertyValues } from 'lit';
+import { LitElement, html, nothing, unsafeCSS, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
 import '../wizard-story-section';
-import { t } from '../../i18n';
 import {
   findMatchingStories,
   prepareStoryCandidates,
@@ -47,6 +46,10 @@ export class WizardStoryMatches extends LitElement {
 
   @state() private storyMatches: StoryMatch[] = [];
 
+  // Reflects to the `hidden` attribute so callers can hide surrounding chrome (e.g. a
+  // heading) with `.wrapper:has(wizard-story-matches:not([hidden]))`
+  override hidden = true;
+
   // Stories don't change at runtime, so loading & walking them (`prepareStoryCandidates`) only
   // needs to happen once per `components` assignment — every theme/group change afterwards just
   // re-resolves ref chains against this cached list, which is cheap and synchronous.
@@ -80,15 +83,16 @@ export class WizardStoryMatches extends LitElement {
   #recomputeMatches() {
     if (this.groups.length === 0 || !this.theme) {
       this.storyMatches = [];
-      return;
+    } else {
+      this.storyMatches = findMatchingStories(this.groups, this.theme.tokens, this.#candidates);
     }
 
-    this.storyMatches = findMatchingStories(this.groups, this.theme.tokens, this.#candidates);
+    this.hidden = this.storyMatches.length === 0;
   }
 
   override render() {
     if (this.storyMatches.length === 0) {
-      return html`<p class="nl-paragraph | wizard-story-matches__empty">${t('styleGuide.nothingToShow')}.</p>`;
+      return nothing;
     }
 
     return html`

--- a/packages/theme-wizard-app/src/components/wizard-story-matches/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-story-matches/styles.ts
@@ -5,12 +5,9 @@ export default css`
     --nl-heading-level-3-font-size: var(--basis-text-font-size-md);
     --nl-heading-level-3-margin-block-end: var(--basis-space-block-md);
 
-    background: var(--basis-color-default-bg-subtle);
     column-gap: var(--basis-space-column-3xl);
     display: flex;
     flex-wrap: wrap;
-    padding-block: var(--basis-space-block-4xl);
-    padding-inline: var(--basis-space-inline-3xl);
     row-gap: var(--basis-space-row-2xl);
   }
 

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -158,7 +158,6 @@ export const en = {
         title: 'Where is this token used?',
       },
     },
-    nothingToShow: 'No examples to show',
     reference: 'Reference',
     sample: 'Sample',
     sections: {
@@ -633,7 +632,6 @@ export const nl = {
         title: 'Waar wordt deze token gebruikt?',
       },
     },
-    nothingToShow: 'Geen voorbeelden beschikbaar',
     reference: 'Referentie',
     sample: 'Voorbeeld',
     sections: {

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -158,7 +158,7 @@ export const en = {
         title: 'Where is this token used?',
       },
     },
-    nothingToShow: 'Nothing to show',
+    nothingToShow: 'No examples to show',
     reference: 'Reference',
     sample: 'Sample',
     sections: {
@@ -633,7 +633,7 @@ export const nl = {
         title: 'Waar wordt deze token gebruikt?',
       },
     },
-    nothingToShow: 'Niets te tonen',
+    nothingToShow: 'Geen voorbeelden beschikbaar',
     reference: 'Referentie',
     sample: 'Voorbeeld',
     sections: {

--- a/packages/theme-wizard-website/src/components/TokenStoryMatches.astro
+++ b/packages/theme-wizard-website/src/components/TokenStoryMatches.astro
@@ -25,11 +25,11 @@ const { groups } = Astro.props;
 
 <style>
   .wizard-story-samples {
-    padding-inline: var(--basis-space-inline-4xl);
-    padding-block: var(--basis-space-block-3xl);
     background-color: var(--basis-color-default-bg-subtle);
     display: flex;
     flex-direction: column;
+    padding-block: var(--basis-space-block-3xl);
+    padding-inline: var(--basis-space-inline-4xl);
     row-gap: var(--basis-space-row-3xl);
   }
 </style>

--- a/packages/theme-wizard-website/src/components/TokenStoryMatches.astro
+++ b/packages/theme-wizard-website/src/components/TokenStoryMatches.astro
@@ -32,4 +32,8 @@ const { groups } = Astro.props;
     padding-inline: var(--basis-space-inline-4xl);
     row-gap: var(--basis-space-row-3xl);
   }
+
+  .wizard-story-samples:has(wizard-story-matches[hidden]) {
+    display: none;
+  }
 </style>

--- a/packages/theme-wizard-website/src/components/TokenStoryMatches.astro
+++ b/packages/theme-wizard-website/src/components/TokenStoryMatches.astro
@@ -6,11 +6,15 @@ interface Props {
 const { groups } = Astro.props;
 ---
 
-<wizard-story-matches groups={groups}></wizard-story-matches>
+<section class="wizard-story-samples">
+  <clippy-heading level="4">Voorbeelden</clippy-heading>
+  <wizard-story-matches groups={groups}></wizard-story-matches>
+</section>
 
 <script>
   import type { WizardStoryMatches } from '@nl-design-system-community/theme-wizard-app/components/wizard-story-matches';
   import { components } from '@/lib/components';
+  import '@nl-design-system-community/clippy-components/clippy-heading';
 
   await import('@nl-design-system-community/theme-wizard-app/components/wizard-story-matches');
 
@@ -18,3 +22,14 @@ const { groups } = Astro.props;
     element.components = components;
   }
 </script>
+
+<style>
+  .wizard-story-samples {
+    padding-inline: var(--basis-space-inline-4xl);
+    padding-block: var(--basis-space-block-3xl);
+    background-color: var(--basis-color-default-bg-subtle);
+    display: flex;
+    flex-direction: column;
+    row-gap: var(--basis-space-row-3xl);
+  }
+</style>

--- a/packages/theme-wizard-website/src/pages/style-guide/border-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/border-system.astro
@@ -9,9 +9,10 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
 ---
 
 <script>
-  import '@nl-design-system-community/clippy-components/clippy-graph-paper';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-border';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
+  import '@nl-design-system-community/clippy-components/clippy-story-preview';
+  import '@nl-design-system-community/clippy-components/clippy-heading';
 </script>
 
 <BaseLayout title="Randen en lijnen systeem - Stijlgids - Theme Wizard">
@@ -32,13 +33,11 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
                 {widths.map((width) => (
                   <wizard-stack size="3xl">
                     <clippy-heading level="3">{capitalize(width)}</clippy-heading>
-                    <clippy-graph-paper>
-                      <clippy-reset-theme>
-                        <wizard-preview-theme>
-                          <clippy-token-sample-border border-width={`var(--basis-border-width-${width})`} border-radius=""></clippy-token-sample-border>
-                        </wizard-preview-theme>
-                      </clippy-reset-theme>
-                    </clippy-graph-paper>
+                    <clippy-reset-theme>
+                      <wizard-preview-theme>
+                        <clippy-token-sample-border border-width={`var(--basis-border-width-${width})`} border-radius=""></clippy-token-sample-border>
+                      </wizard-preview-theme>
+                    </clippy-reset-theme>
                     <TokenStoryMatches groups={`basis.border-width.${width}`} />
                   </wizard-stack>
                 ))}
@@ -54,13 +53,11 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
                 {radii.map((radius) => (
                   <wizard-stack size="3xl">
                     <clippy-heading level="3">{capitalize(radius)}</clippy-heading>
-                    <clippy-graph-paper>
-                      <clippy-reset-theme>
-                        <wizard-preview-theme>
-                          <clippy-token-sample-border border-radius={`var(--basis-border-radius-${radius})`} border-width="var(--basis-border-width-md)"></clippy-token-sample-border>
-                        </wizard-preview-theme>
-                      </clippy-reset-theme>
-                    </clippy-graph-paper>
+                    <clippy-reset-theme>
+                      <wizard-preview-theme>
+                        <clippy-token-sample-border border-radius={`var(--basis-border-radius-${radius})`} border-width="var(--basis-border-width-md)"></clippy-token-sample-border>
+                      </wizard-preview-theme>
+                    </clippy-reset-theme>
                     <TokenStoryMatches groups={`basis.border-width.${radius}`} />
                   </wizard-stack>
                 ))}
@@ -73,10 +70,3 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
     </wizard-layout>
   </theme-wizard-app>
 </BaseLayout>
-
-<style>
-  clippy-graph-paper {
-    padding-block: var(--basis-space-block-4xl);
-    padding-inline: var(--basis-space-inline-3xl);
-  }
-</style>

--- a/packages/theme-wizard-website/src/pages/style-guide/spacing-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/spacing-system.astro
@@ -9,9 +9,10 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
 ---
 
 <script>
-  import '@nl-design-system-community/clippy-components/clippy-graph-paper';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
+  import '@nl-design-system-community/clippy-components/clippy-story-preview';
+  import '@nl-design-system-community/clippy-components/clippy-heading';
 </script>
 
 <BaseLayout title="Witruimte systeem - Stijlgids - Theme Wizard">
@@ -33,13 +34,11 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
                   {scale.map((size) => (
                     <wizard-stack size="3xl">
                       <clippy-heading level="3">{capitalize(size)}</clippy-heading>
-                      <clippy-graph-paper>
-                        <clippy-reset-theme>
-                          <wizard-preview-theme>
-                            <clippy-token-sample-spacing size={`var(--basis-space-${concept}-${size})`} concept={concept}></clippy-token-sample-spacing>
-                          </wizard-preview-theme>
-                        </clippy-reset-theme>
-                      </clippy-graph-paper>
+                      <clippy-reset-theme>
+                        <wizard-preview-theme>
+                          <clippy-token-sample-spacing size={`var(--basis-space-${concept}-${size})`} concept={concept}></clippy-token-sample-spacing>
+                        </wizard-preview-theme>
+                      </clippy-reset-theme>
                       <TokenStoryMatches groups={`basis.space.${concept}.${size}`} />
                     </wizard-stack>
                   ))}
@@ -53,10 +52,3 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
     </wizard-layout>
   </theme-wizard-app>
 </BaseLayout>
-
-<style>
-  clippy-graph-paper {
-    padding-block: var(--basis-space-block-4xl);
-    padding-inline: var(--basis-space-inline-3xl);
-  }
-</style>


### PR DESCRIPTION
Test URL: https://theme-wizard-git-fix-clarify-examples-nl-design-system.vercel.app/style-guide/border-system

- move responsibility for padding and background-color outside of `wizard-story-matches`
- remove empty state for cases where no matching stories are found
- remove `graph-paper` everywhere, except for typography, where we still have placeholders for samples

## before

<img width="1711" height="1277" alt="Screenshot 2026-08-07 at 16 26 05" src="https://github.com/user-attachments/assets/dd708952-c79d-433c-bd59-1c2d655a2421" />

## after

<img width="1712" height="1293" alt="Screenshot 2026-08-07 at 17 21 58" src="https://github.com/user-attachments/assets/ea74bd63-ae8b-4b8e-8f00-215bffd7f2da" />


