### PR TITLE
feat: implement `<clippy-token-sample-text>` in typography system style guide page

### DIFF
--- a/packages/clippy-components/src/clippy-token-sample-text/styles.ts
+++ b/packages/clippy-components/src/clippy-token-sample-text/styles.ts
@@ -37,6 +37,7 @@ export default css`
    * When line-height is set, use pseudo elements to simulate the line height
    */
   :host(:where([line-height]:not([line-height='']))) :where(.clippy-token-sample-text__dummy) {
+    isolation: isolate;
     position: relative;
 
     &::before,

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -12,6 +12,7 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
 
 <script>
   import '@nl-design-system-community/clippy-components/clippy-graph-paper';
+  import '@nl-design-system-community/clippy-components/clippy-token-sample-text';
 </script>
 
 <BaseLayout title="Typografie systeem - Stijlgids - Theme Wizard">
@@ -32,7 +33,13 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(family)}</clippy-heading>
                     <clippy-graph-paper>
-                      Placeholder {family}
+                      <clippy-reset-theme>
+                        <wizard-preview-theme>
+                          <clippy-token-sample-text font-family={`var(--basis-text-font-family-${family})`} truncate>
+                            Op brute wijze ving de schooljuf de quasi-kalme lynx.
+                          </clippy-token-sample-text>
+                        </wizard-preview-theme>
+                      </clippy-reset-theme>
                     </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-family.${family}`} />
                   </wizard-stack>
@@ -49,7 +56,13 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(weight)}</clippy-heading>
                     <clippy-graph-paper>
-                      Placeholder {weight}
+                      <clippy-reset-theme>
+                        <wizard-preview-theme>
+                          <clippy-token-sample-text font-weight={`var(--basis-text-font-weight-${weight})`} truncate>
+                            Op brute wijze ving de schooljuf de quasi-kalme lynx.
+                          </clippy-token-sample-text>
+                        </wizard-preview-theme>
+                      </clippy-reset-theme>
                     </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-weight.${weight}`} />
                   </wizard-stack>
@@ -66,7 +79,13 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(size)}</clippy-heading>
                     <clippy-graph-paper>
-                      Placeholder {size}
+                      <clippy-reset-theme>
+                        <wizard-preview-theme>
+                          <clippy-token-sample-text font-size={`var(--basis-text-font-size-${size})`} truncate>
+                            Op brute wijze ving de schooljuf de quasi-kalme lynx.
+                          </clippy-token-sample-text>
+                        </wizard-preview-theme>
+                      </clippy-reset-theme>
                     </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-size.${size}`} />
                   </wizard-stack>
@@ -82,9 +101,13 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(lineHeight)}</clippy-heading>
-                    <clippy-graph-paper>
-                      Placeholder {lineHeight}
-                    </clippy-graph-paper>
+                    <clippy-reset-theme>
+                      <wizard-preview-theme>
+                        <clippy-token-sample-text line-height={`var(--basis-text-line-height-${lineHeight})`} truncate>
+                          Op brute wijze ving de schooljuf de quasi-kalme lynx.
+                        </clippy-token-sample-text>
+                      </wizard-preview-theme>
+                    </clippy-reset-theme>
                     <TokenStoryMatches groups={`basis.text.line-height.${lineHeight}`} />
                   </wizard-stack>
                 </clippy-story-preview>


### PR DESCRIPTION
Test-URL: https://theme-wizard-git-feat-styleguide-typo-samples-nl-design-system.vercel.app/style-guide/typography-system

<img width="1703" height="1300" alt="Screenshot 2026-08-10 at 10 58 16" src="https://github.com/user-attachments/assets/e3061883-0823-45d1-b32b-343d4d3c559d" />
