### PR TITLE
feat: show actual token values in all style guide sections

### DIFF
--- a/packages/clippy-components/src/clippy-code/index.test.ts
+++ b/packages/clippy-components/src/clippy-code/index.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import './index';
+import { ClippyCode } from './index';
+
+const tag = 'clippy-code';
+
+function getComponent() {
+  return document.querySelector(tag) as unknown as ClippyCode;
+}
+
+describe(`<${tag}>`, () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders a code element with translate="no" and dir="ltr"', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    const code = component.shadowRoot?.querySelector('code');
+    expect(code).toBeTruthy();
+    expect(code?.getAttribute('translate')).toBe('no');
+    expect(code?.getAttribute('dir')).toBe('ltr');
+  });
+
+  it('renders the nl-code class on the code element', async () => {
+    document.body.innerHTML = `<${tag}></${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    const code = component.shadowRoot?.querySelector('code');
+    expect(code?.classList.contains('nl-code')).toBe(true);
+  });
+
+  it('reflects slot contents in the rendered result', async () => {
+    document.body.innerHTML = `<${tag}>const x = 1;</${tag}>`;
+    const component = getComponent();
+    await component.updateComplete;
+
+    expect(component.textContent).toBe('const x = 1;');
+  });
+});

--- a/packages/clippy-components/src/clippy-code/index.ts
+++ b/packages/clippy-components/src/clippy-code/index.ts
@@ -9,7 +9,7 @@ export class ClippyCode extends LitElement {
   static override readonly styles = [unsafeCSS(codeCss)];
 
   override render() {
-    return html`<code class="nl-code"><slot></slot></code>`;
+    return html`<code class="nl-code" translate="no" dir="ltr"><slot></slot></code>`;
   }
 }
 

--- a/packages/theme-wizard-app/index.ts
+++ b/packages/theme-wizard-app/index.ts
@@ -43,6 +43,7 @@ export * from './src/components/wizard-token-output';
 export * from './src/components/wizard-token-presets';
 export * from './src/components/wizard-token-upload-form';
 export * from './src/components/wizard-token-validation-form';
+export * from './src/components/wizard-token-value';
 export * from './src/components/wizard-tokens-download';
 export * from './src/components/wizard-tokens-form';
 export * from './src/components/wizard-tokens-reuse-form';

--- a/packages/theme-wizard-app/src/components/wizard-token-value/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-value/index.ts
@@ -1,0 +1,32 @@
+import { consume } from '@lit/context';
+import { resolveRef, stringifyToken, type TokenReference } from '@nl-design-system-community/design-tokens-schema';
+import { html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type Theme from '../../lib/Theme';
+import { themeContext } from '../../contexts/theme';
+
+const tag = 'wizard-token-value';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: WizardTokenValue;
+  }
+}
+
+@customElement(tag)
+export class WizardTokenValue extends LitElement {
+  @consume({ context: themeContext, subscribe: true })
+  @state()
+  private readonly theme!: Theme;
+
+  @property({ type: String }) path = '';
+
+  private get resolved(): string {
+    const token = resolveRef(this.theme.tokens, `{${this.path}}` as TokenReference);
+    return token ? stringifyToken(token) : '';
+  }
+
+  protected override render() {
+    return html`<slot>${this.resolved}</slot>`;
+  }
+}

--- a/packages/theme-wizard-app/src/lib/Theme/index.ts
+++ b/packages/theme-wizard-app/src/lib/Theme/index.ts
@@ -16,7 +16,7 @@ import {
   addBasisContrastExtensions,
   upgradeLegacyTokens,
   resolveConfigRefs,
-  useRefAsValue,
+  useOriginalValue,
 } from '@nl-design-system-community/design-tokens-schema';
 import startTokens from '@nl-design-system-unstable/start-design-tokens/dist/tokens.json';
 import { dequal } from 'dequal';
@@ -113,7 +113,7 @@ export default class Theme {
   }
 
   #runThemeProcessors(tokens: DesignTokens) {
-    useRefAsValue(tokens);
+    useOriginalValue(tokens);
     upgradeLegacyTokens(tokens);
     addComponentContrastExtensions(tokens);
     addBasisContrastExtensions(tokens);

--- a/packages/theme-wizard-website/src/pages/style-guide/border-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/border-system.astro
@@ -9,6 +9,7 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
 ---
 
 <script>
+  import '@nl-design-system-community/clippy-components/clippy-code';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-border';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
   import '@nl-design-system-community/clippy-components/clippy-story-preview';
@@ -33,6 +34,9 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
                 {widths.map((width) => (
                   <wizard-stack size="3xl">
                     <clippy-heading level="3">{capitalize(width)}</clippy-heading>
+                    <clippy-code>
+                      <wizard-token-value path={`basis.border-width.${width}`}></wizard-token-value>
+                    </clippy-code>
                     <clippy-reset-theme>
                       <wizard-preview-theme>
                         <clippy-token-sample-border border-width={`var(--basis-border-width-${width})`} border-radius=""></clippy-token-sample-border>
@@ -53,6 +57,9 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
                 {radii.map((radius) => (
                   <wizard-stack size="3xl">
                     <clippy-heading level="3">{capitalize(radius)}</clippy-heading>
+                    <clippy-code>
+                      <wizard-token-value path={`basis.border-radius.${radius}`}></wizard-token-value>
+                    </clippy-code>
                     <clippy-reset-theme>
                       <wizard-preview-theme>
                         <clippy-token-sample-border border-radius={`var(--basis-border-radius-${radius})`} border-width="var(--basis-border-width-md)"></clippy-token-sample-border>

--- a/packages/theme-wizard-website/src/pages/style-guide/spacing-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/spacing-system.astro
@@ -9,6 +9,7 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
 ---
 
 <script>
+  import '@nl-design-system-community/clippy-components/clippy-code';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
   import '@nl-design-system-community/clippy-components/clippy-story-preview';
@@ -34,6 +35,9 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
                   {scale.map((size) => (
                     <wizard-stack size="3xl">
                       <clippy-heading level="3">{capitalize(size)}</clippy-heading>
+                      <clippy-code>
+                        <wizard-token-value path={`basis.space.${concept}.${size}`}></wizard-token-value>
+                      </clippy-code>
                       <clippy-reset-theme>
                         <wizard-preview-theme>
                           <clippy-token-sample-spacing size={`var(--basis-space-${concept}-${size})`} concept={concept}></clippy-token-sample-spacing>

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -11,6 +11,7 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
 ---
 
 <script>
+  import '@nl-design-system-community/clippy-components/clippy-code';
   import '@nl-design-system-community/clippy-components/clippy-graph-paper';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-text';
 </script>
@@ -32,6 +33,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(family)}</clippy-heading>
+                    <clippy-code>
+                      <wizard-token-value path={`basis.text.font-family.${family}`}></wizard-token-value>
+                    </clippy-code>
                     <clippy-graph-paper>
                       <clippy-reset-theme>
                         <wizard-preview-theme>
@@ -55,6 +59,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(weight)}</clippy-heading>
+                    <clippy-code>
+                      <wizard-token-value path={`basis.text.font-weight.${weight}`}></wizard-token-value>
+                    </clippy-code>
                     <clippy-graph-paper>
                       <clippy-reset-theme>
                         <wizard-preview-theme>
@@ -78,6 +85,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(size)}</clippy-heading>
+                    <clippy-code>
+                      <wizard-token-value path={`basis.text.font-size.${size}`}></wizard-token-value>
+                    </clippy-code>
                     <clippy-graph-paper>
                       <clippy-reset-theme>
                         <wizard-preview-theme>
@@ -101,6 +111,9 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                 <clippy-story-preview>
                   <wizard-stack size="2xl">
                     <clippy-heading level="3">{capitalize(lineHeight)}</clippy-heading>
+                    <clippy-code>
+                      <wizard-token-value path={`basis.text.line-height.${lineHeight}`}></wizard-token-value>
+                    </clippy-code>
                     <clippy-reset-theme>
                       <wizard-preview-theme>
                         <clippy-token-sample-text line-height={`var(--basis-text-line-height-${lineHeight})`} truncate>


### PR DESCRIPTION
- Toon token values in alle relevante stijlgidssecties
- Voeg nieuw `<wizard-token-value path="basis.etc.">` component toe
- Voeg missende attributen en unit tests toe voor `clippy-code`

<img width="1012" height="781" alt="Screenshot 2026-08-10 at 13 52 13" src="https://github.com/user-attachments/assets/eb81b44d-bced-4ba5-98e8-f966ca52b713" />
