### PR TITLE
feat: add basis token documentation to style guide pages

### DIFF
--- a/packages/theme-wizard-app/index.ts
+++ b/packages/theme-wizard-app/index.ts
@@ -36,6 +36,7 @@ export * from './src/components/wizard-style-guide-spacing';
 export * from './src/components/wizard-style-guide-typography';
 export * from './src/components/wizard-table-scroller';
 export * from './src/components/wizard-theme-reset-button';
+export * from './src/components/wizard-token-docs';
 export * from './src/components/wizard-token-field';
 export * from './src/components/wizard-token-input';
 export * from './src/components/wizard-token-navigator';

--- a/packages/theme-wizard-app/src/components/wizard-color-system-preview/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-color-system-preview/index.ts
@@ -10,7 +10,7 @@ import { property, state } from 'lit/decorators.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
-import { getSiblingGroupsWithOnlyRefsTo } from '../../lib/ColorScale/siblings';
+import { filterRedundantGroups } from '../../lib/ColorScale/siblings';
 import { countUsagePerToken, prepareColorGroups } from '../wizard-style-guide/utils';
 
 const tag = 'wizard-color-system-preview';
@@ -53,7 +53,7 @@ export class WizardColorSystemPreview extends LitElement {
     const requestedGroups = this.groups.length > 0 ? this.groups : colorTokenGroups.map((group) => group.key);
     const visibleGroups =
       this.skipRedundantGroups.length > 0
-        ? this.#dropRedundantGroups(requestedGroups, colors, this.skipRedundantGroups)
+        ? filterRedundantGroups(requestedGroups, colors, this.skipRedundantGroups)
         : requestedGroups;
 
     this.#visibleTokenGroups = this.#filterColorGroups(visibleGroups, colorTokenGroups);
@@ -64,22 +64,6 @@ export class WizardColorSystemPreview extends LitElement {
 
     const foundGroups = groups.map((groupKey) => colorTokenGroups.find((group) => group.key === groupKey));
     return foundGroups.filter((group): group is NonNullable<typeof group> => group !== undefined);
-  }
-
-  /** Drops each group matching `prefixes` that is entirely composed of references into an earlier group, e.g. accent-3 re-pointing at accent-1 or accent-2. */
-  #dropRedundantGroups(groupKeys: string[], colors: Record<string, unknown>, prefixes: string[]) {
-    const seenGroupKeys: string[] = [];
-
-    return groupKeys.filter((groupKey) => {
-      const isRedundant =
-        prefixes.some((prefix) => groupKey.startsWith(prefix)) &&
-        seenGroupKeys.some((seenGroupKey) =>
-          getSiblingGroupsWithOnlyRefsTo(`basis.color.${seenGroupKey}`, colors).includes(`basis.color.${groupKey}`),
-        );
-
-      seenGroupKeys.push(groupKey);
-      return !isRedundant;
-    });
   }
 
   override render() {

--- a/packages/theme-wizard-app/src/components/wizard-token-docs/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-docs/index.ts
@@ -12,7 +12,6 @@ import { t } from '../../i18n';
 import { filterRedundantGroups } from '../../lib/ColorScale/siblings';
 import { tokenDocs } from '../../lib/tokenDocs';
 import '../wizard-stack';
-import styles from './styles';
 
 const tag = 'wizard-token-docs';
 
@@ -45,8 +44,6 @@ const parseGroup = (path: string): ParsedGroup => {
 
 @safeCustomElement(tag)
 export class WizardTokenDocs extends LitElement {
-  static override readonly styles = [styles];
-
   @consume({ context: themeContext, subscribe: true })
   @state()
   private readonly theme!: Theme;

--- a/packages/theme-wizard-app/src/components/wizard-token-docs/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-docs/index.ts
@@ -1,0 +1,120 @@
+import { consume } from '@lit/context';
+import '@nl-design-system-community/clippy-components/clippy-heading';
+import { arrayFromCommaList } from '@nl-design-system-community/clippy-components/lib/converters';
+import { safeCustomElement } from '@nl-design-system-community/clippy-components/lib/decorators';
+import '@vanillawc/wc-markdown';
+import dlv from 'dlv';
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import type Theme from '../../lib/Theme';
+import { themeContext } from '../../contexts/theme';
+import { t } from '../../i18n';
+import { filterRedundantGroups } from '../../lib/ColorScale/siblings';
+import { tokenDocs } from '../../lib/tokenDocs';
+import '../wizard-stack';
+import styles from './styles';
+
+const tag = 'wizard-token-docs';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [tag]: WizardTokenDocs;
+  }
+}
+
+interface ParsedGroup {
+  path: string;
+  key: string;
+  baseSegments: string[];
+  docKey: string;
+}
+
+const keyOf = (path: string) => path.split('.').at(-1)!;
+
+/** Splits a full basis token path once and derives everything else (key, base, doc lookup key) from those segments. */
+const parseGroup = (path: string): ParsedGroup => {
+  const segments = path.split('.');
+  return {
+    baseSegments: segments.slice(0, -1),
+    // e.g. "basis.color.accent-1" -> "color-accent-1", matching the doc's filename-derived key in `tokenDocs`.
+    docKey: segments.slice(1).join('-'),
+    key: segments.at(-1)!,
+    path,
+  };
+};
+
+@safeCustomElement(tag)
+export class WizardTokenDocs extends LitElement {
+  static override readonly styles = [styles];
+
+  @consume({ context: themeContext, subscribe: true })
+  @state()
+  private readonly theme!: Theme;
+
+  #visibleGroups: ParsedGroup[] = [];
+
+  /** Full basis token paths to show docs for, e.g. "basis.color.default, basis.color.accent-1". */
+  @property({ converter: arrayFromCommaList })
+  groups: string[] = [];
+
+  /** Full basis token paths (e.g. "basis.color.accent-2") to drop when that group's tokens are only references to an earlier group in `groups`, e.g. accent-2 entirely re-pointing at accent-1. */
+  @property({ attribute: 'skip-redundant-groups', converter: arrayFromCommaList })
+  skipRedundantGroups: string[] = [];
+
+  @property({ attribute: 'heading-level', type: Number })
+  headingLevel = 2;
+
+  protected override willUpdate(changedProperties: PropertyValues) {
+    if (
+      !changedProperties.has('theme') &&
+      !changedProperties.has('groups') &&
+      !changedProperties.has('skipRedundantGroups')
+    ) {
+      return;
+    }
+
+    const parsedGroups = this.groups.map(parseGroup);
+
+    if (this.skipRedundantGroups.length === 0 || parsedGroups.length === 0) {
+      this.#visibleGroups = parsedGroups;
+      return;
+    }
+
+    // All groups in one <wizard-token-docs> share the same base, e.g. ["basis", "color"].
+    const baseSegments = parsedGroups[0].baseSegments;
+    const domain = dlv(this.theme.tokens, baseSegments);
+
+    if (!domain || typeof domain !== 'object') {
+      this.#visibleGroups = parsedGroups;
+      return;
+    }
+
+    // filterRedundantGroups works on bare keys ("accent-1"), keep a way back to the parsed group for lookup after.
+    const groupsByKey = new Map(parsedGroups.map((group) => [group.key, group]));
+    const visibleKeys = filterRedundantGroups(
+      [...groupsByKey.keys()],
+      domain as Record<string, unknown>,
+      this.skipRedundantGroups.map(keyOf),
+      baseSegments.join('.'),
+    );
+    this.#visibleGroups = visibleKeys.map((key) => groupsByKey.get(key)!);
+  }
+
+  override render() {
+    return html`
+      <clippy-stack size="sm">
+        ${this.#visibleGroups.map(({ docKey, path }) => {
+          const docs = tokenDocs[docKey];
+          if (!docs) return nothing;
+
+          return html`
+            <wizard-stack size="none">
+              <clippy-heading level=${this.headingLevel}>${t(`tokens.fieldLabels.${path}.label`)}</clippy-heading>
+              <wc-markdown class="wizard-token-docs__markdown" .textContent=${docs}></wc-markdown>
+            </wizard-stack>
+          `;
+        })}
+      </clippy-stack>
+    `;
+  }
+}

--- a/packages/theme-wizard-app/src/components/wizard-token-docs/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-docs/index.ts
@@ -11,7 +11,7 @@ import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
 import { filterRedundantGroups } from '../../lib/ColorScale/siblings';
 import { tokenDocs } from '../../lib/tokenDocs';
-import '../wizard-stack';
+import '@nl-design-system-community/clippy-components/clippy-stack';
 
 const tag = 'wizard-token-docs';
 
@@ -105,10 +105,10 @@ export class WizardTokenDocs extends LitElement {
           if (!docs) return nothing;
 
           return html`
-            <wizard-stack size="none">
+            <clippy-stack size="none">
               <clippy-heading level=${this.headingLevel}>${t(`tokens.fieldLabels.${path}.label`)}</clippy-heading>
               <wc-markdown class="wizard-token-docs__markdown" .textContent=${docs}></wc-markdown>
-            </wizard-stack>
+            </clippy-stack>
           `;
         })}
       </clippy-stack>

--- a/packages/theme-wizard-app/src/components/wizard-token-docs/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-docs/styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'lit';
+
+export default css`
+  :host(:not([hidden])) {
+    display: contents;
+  }
+`;

--- a/packages/theme-wizard-app/src/components/wizard-token-docs/styles.ts
+++ b/packages/theme-wizard-app/src/components/wizard-token-docs/styles.ts
@@ -1,7 +1,0 @@
-import { css } from 'lit';
-
-export default css`
-  :host(:not([hidden])) {
-    display: contents;
-  }
-`;

--- a/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-tokens-form/index.ts
@@ -3,19 +3,6 @@ import linkCss from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphCss from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
 import '@nl-design-system-community/clippy-components/clippy-heading';
 import srOnlyStyles from '@nl-design-system-community/clippy-components/lib/sr-only';
-import accent1Docs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-accent-1-intro.md?raw';
-import accent2Docs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-accent-2-intro.md?raw';
-import accent3Docs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-accent-3-intro.md?raw';
-import action1Docs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-action-1-intro.md?raw';
-import action2Docs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-action-2-intro.md?raw';
-import defaultDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-default-intro.md?raw';
-import disabledDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-disabled-intro.md?raw';
-import highlightDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-highlight-intro.md?raw';
-import infoDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-info-intro.md?raw';
-import negativeDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-negative-intro.md?raw';
-import positiveDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-positive-intro.md?raw';
-import selectedDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-selected-intro.md?raw';
-import warningDocs from '@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-color-warning-intro.md?raw';
 import ChevronLeft from '@tabler/icons/outline/chevron-left.svg?raw';
 import ChevronRight from '@tabler/icons/outline/chevron-right.svg?raw';
 import buttonLinkCss from '@utrecht/link-button-css/dist/index.css?inline';
@@ -26,32 +13,19 @@ import '../wizard-font-input';
 import '../wizard-download-confirmation';
 import '../wizard-validation-issues-alert';
 
-const colorDocs: Record<string, string> = {
-  'accent-1': accent1Docs,
-  'accent-2': accent2Docs,
-  'accent-3': accent3Docs,
-  'action-1': action1Docs,
-  'action-2': action2Docs,
-  default: defaultDocs,
-  disabled: disabledDocs,
-  highlight: highlightDocs,
-  info: infoDocs,
-  negative: negativeDocs,
-  positive: positiveDocs,
-  selected: selectedDocs,
-  warning: warningDocs,
-};
 import { LitElement, TemplateResult, html, nothing, unsafeCSS } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
+import { getTokenDocs } from '../../lib/tokenDocs';
 import '@vanillawc/wc-markdown';
 import styles from './styles';
 
 const BODY_FONT_TOKEN_REF = 'basis.text.font-family.default';
 const HEADING_FONT_TOKEN_REF = 'basis.heading.font-family';
+const colorDocs = getTokenDocs('color');
 
 const tag = 'wizard-tokens-form';
 

--- a/packages/theme-wizard-app/src/i18n/messages.ts
+++ b/packages/theme-wizard-app/src/i18n/messages.ts
@@ -251,6 +251,8 @@ export const en = {
     backToOverview: 'Back to overview',
     fieldLabels: {
       basis: {
+        'border-radius': { label: 'Border radius' },
+        'border-width': { label: 'Border width' },
         color: {
           'accent-1': {
             docs: 'https://nldesignsystem.nl/handboek/huisstijl/basis-tokens/#accent-1-accent-2-en-accent-3',
@@ -306,7 +308,26 @@ export const en = {
           },
         },
         colors: 'Colors',
+        space: {
+          block: { label: 'Block' },
+          column: { label: 'Column' },
+          inline: { label: 'Inline' },
+          row: { label: 'Row' },
+          text: { label: 'Text' },
+        },
         spacing: 'Spacing',
+        text: {
+          'font-family': {
+            default: { label: 'Default' },
+            monospace: { label: 'Monospace' },
+          },
+          'font-size': { label: 'Font size' },
+          'font-weight': {
+            bold: { label: 'Bold' },
+            default: { label: 'Default' },
+          },
+          'line-height': { label: 'Line height' },
+        },
         typography: 'Typography',
       },
       bodyFont: 'Running text',
@@ -725,6 +746,8 @@ export const nl = {
     backToOverview: 'Terug naar overzicht',
     fieldLabels: {
       basis: {
+        'border-radius': { label: 'Afgeronde hoeken' },
+        'border-width': { label: 'Kader- of lijndikte' },
         color: {
           'accent-1': {
             docs: 'https://nldesignsystem.nl/handboek/huisstijl/basis-tokens/#accent-1-accent-2-en-accent-3',
@@ -780,7 +803,26 @@ export const nl = {
           },
         },
         colors: 'Kleuren',
+        space: {
+          block: { label: 'Block' },
+          column: { label: 'Column' },
+          inline: { label: 'Inline' },
+          row: { label: 'Row' },
+          text: { label: 'Text' },
+        },
         spacing: 'Witruimte',
+        text: {
+          'font-family': {
+            default: { label: 'Standaard' },
+            monospace: { label: 'Monospace' },
+          },
+          'font-size': { label: 'Lettergrootte' },
+          'font-weight': {
+            bold: { label: 'Vet' },
+            default: { label: 'Standaard' },
+          },
+          'line-height': { label: 'Regelhoogte' },
+        },
         typography: 'Typografie',
       },
       bodyFont: 'Lopende tekst',

--- a/packages/theme-wizard-app/src/lib/ColorScale/siblings.ts
+++ b/packages/theme-wizard-app/src/lib/ColorScale/siblings.ts
@@ -44,3 +44,27 @@ export function getSiblingGroupsWithOnlyRefsTo(groupPath: string, parentGroup: u
     })
     .map(([siblingKey]) => `${parentPath}.${siblingKey}`);
 }
+
+/**
+ * Drops each group matching `prefixes` that is entirely composed of references into an earlier
+ * group in `groupKeys`, e.g. `accent-2` entirely re-pointing at `accent-1`.
+ */
+export function filterRedundantGroups(
+  groupKeys: string[],
+  colors: Record<string, unknown>,
+  prefixes: string[],
+  basePath = 'basis.color',
+): string[] {
+  const seenGroupKeys: string[] = [];
+
+  return groupKeys.filter((groupKey) => {
+    const isRedundant =
+      prefixes.some((prefix) => groupKey.startsWith(prefix)) &&
+      seenGroupKeys.some((seenGroupKey) =>
+        getSiblingGroupsWithOnlyRefsTo(`${basePath}.${seenGroupKey}`, colors).includes(`${basePath}.${groupKey}`),
+      );
+
+    seenGroupKeys.push(groupKey);
+    return !isRedundant;
+  });
+}

--- a/packages/theme-wizard-app/src/lib/tokenDocs.ts
+++ b/packages/theme-wizard-app/src/lib/tokenDocs.ts
@@ -1,0 +1,27 @@
+const DOC_KEY_PATTERN = /_basis-(.+)-intro\.md$/;
+
+const docModules = import.meta.glob(
+  '../../node_modules/@nl-design-system-unstable/documentation/handboek/huisstijl-vastleggen/basis-tokens/_basis-*-intro.md',
+  { eager: true, exhaustive: true, import: 'default', query: '?raw' },
+);
+
+/** Every basis-token intro doc, keyed by its full dash-joined path (e.g. `color-accent-1`, `space-block`, `border-radius`, `focus`). */
+export const tokenDocs: Record<string, string> = Object.fromEntries(
+  Object.entries(docModules).map(([path, content]) => {
+    const key = DOC_KEY_PATTERN.exec(path)?.[1] ?? path;
+    return [key, content as string];
+  }),
+);
+
+/**
+ * Scopes `tokenDocs` to one domain prefix and strips it, e.g. `getTokenDocs('color')` turns
+ * `color-accent-1` into `accent-1`. Pass `''` (default) to get the full map unprefixed.
+ */
+export function getTokenDocs(prefix = ''): Record<string, string> {
+  const withDash = prefix ? `${prefix}-` : '';
+  return Object.fromEntries(
+    Object.entries(tokenDocs)
+      .filter(([key]) => key.startsWith(withDash))
+      .map(([key, docs]) => [key.slice(withDash.length), docs]),
+  );
+}

--- a/packages/theme-wizard-website/src/pages/style-guide/border-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/border-system.astro
@@ -12,6 +12,7 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
   import '@nl-design-system-community/clippy-components/clippy-code';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-border';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
+  import '@nl-design-system-community/clippy-components/clippy-stack';
   import '@nl-design-system-community/clippy-components/clippy-story-preview';
   import '@nl-design-system-community/clippy-components/clippy-heading';
 </script>
@@ -23,16 +24,15 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
       <StyleGuideNav />
 
       <wizard-container slot="main">
-        <wizard-stack size="5xl">
+        <clippy-stack size="5xl">
           <clippy-heading level="1">Randen en lijnen systeem</clippy-heading>
 
           <clippy-story-preview>
-            <wizard-stack size="5xl">
-              <clippy-heading level="2">Lijndiktes</clippy-heading>
-              {/* TODO: add documentation partials here, from https://nldesignsystem.nl/handboek/huisstijl/basis-tokens/#basis-tokens-voor-kader--of-lijndikte */}
-              <wizard-stack size="5xl">
+            <clippy-stack size="5xl">
+              <wizard-token-docs groups={`basis.border-width`} heading-level="2"></wizard-token-docs>
+              <clippy-stack size="5xl">
                 {widths.map((width) => (
-                  <wizard-stack size="3xl">
+                  <clippy-stack size="3xl">
                     <clippy-heading level="3">{capitalize(width)}</clippy-heading>
                     <clippy-code>
                       <wizard-token-value path={`basis.border-width.${width}`}></wizard-token-value>
@@ -43,19 +43,18 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
                       </wizard-preview-theme>
                     </clippy-reset-theme>
                     <TokenStoryMatches groups={`basis.border-width.${width}`} />
-                  </wizard-stack>
+                  </clippy-stack>
                 ))}
-              </wizard-stack>
-            </wizard-stack>
+              </clippy-stack>
+            </clippy-stack>
           </clippy-story-preview>
 
           <clippy-story-preview>
-            <wizard-stack size="5xl">
-              <clippy-heading level="2">Afgeronde hoeken</clippy-heading>
-              {/* TODO: add documentation partials here, from https://nldesignsystem.nl/handboek/huisstijl/basis-tokens/#basis-tokens-voor-afgeronde-hoeken */}
-              <wizard-stack size="5xl">
+            <clippy-stack size="5xl">
+              <wizard-token-docs groups={`basis.border-radius`} heading-level="2"></wizard-token-docs>
+              <clippy-stack size="5xl">
                 {radii.map((radius) => (
-                  <wizard-stack size="3xl">
+                  <clippy-stack size="3xl">
                     <clippy-heading level="3">{capitalize(radius)}</clippy-heading>
                     <clippy-code>
                       <wizard-token-value path={`basis.border-radius.${radius}`}></wizard-token-value>
@@ -66,13 +65,13 @@ const radii = ['none', 'sm', 'md', 'lg', 'round'] as const
                       </wizard-preview-theme>
                     </clippy-reset-theme>
                     <TokenStoryMatches groups={`basis.border-width.${radius}`} />
-                  </wizard-stack>
+                  </clippy-stack>
                 ))}
-              </wizard-stack>
-            </wizard-stack>
+              </clippy-stack>
+            </clippy-stack>
           </clippy-story-preview>
 
-        </wizard-stack>
+        </clippy-stack>
       </wizard-container>
     </wizard-layout>
   </theme-wizard-app>

--- a/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/color-system.astro
@@ -6,6 +6,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 
 <script>
   import '@nl-design-system-community/clippy-components/clippy-heading';
+  import '@nl-design-system-community/clippy-components/clippy-stack';
   import '@nl-design-system-community/clippy-components/clippy-story-preview';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
 </script>
@@ -17,56 +18,56 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
       <StyleGuideNav />
 
       <wizard-container slot="main">
-        <wizard-stack size="5xl">
+        <clippy-stack size="5xl">
           <clippy-heading level="1">Kleur systeem</clippy-heading>
 
-          <wizard-stack size="3xl">
+          <clippy-stack size="3xl">
             <section>
               <clippy-story-preview>
-                <wizard-stack size="4xl">
+                <clippy-stack size="4xl">
                   <clippy-heading level="2">Huisstijl</clippy-heading>
+                  <wizard-token-docs groups="basis.color.default, basis.color.accent-1, basis.color.accent-2, basis.color.accent-3" skip-redundant-groups="basis.color.accent-2, basis.color.accent-3" heading-level="3"></wizard-token-docs>
                   <wizard-color-system-preview groups="default, accent-1, accent-2, accent-3" skip-redundant-groups="accent-2, accent-3"></wizard-color-system-preview>
-
                   <TokenStoryMatches groups="basis.color.default, basis.color.default-inverse, basis.color.accent-1, basis.color.accent-1-inverse, basis.color.accent-2, basis.color.accent-2-inverse, basis.color.accent-3, basis.color.accent-3-inverse" />
-                </wizard-stack>
+                </clippy-stack>
               </clippy-story-preview>
             </section>
 
             <section>
               <clippy-story-preview>
-                <wizard-stack size="2xl">
+                <clippy-stack size="2xl">
                   <clippy-heading level="2">Interactie</clippy-heading>
+                  <wizard-token-docs groups="basis.color.action-1, basis.color.action-2, basis.color.disabled" skip-redundant-groups="basis.color.action-2" heading-level="3"></wizard-token-docs>
                   <wizard-color-system-preview groups="action-1, action-2, disabled" skip-redundant-groups="action-2"></wizard-color-system-preview>
-
                   <TokenStoryMatches groups="basis.color.action-1, basis.color.action-1-inverse, basis.color.action-2, basis.color.action-2-inverse, basis.color.disabled, basis.color.disabled-inverse" />
-                </wizard-stack>
+                </clippy-stack>
               </clippy-story-preview>
             </section>
 
             <section>
               <clippy-story-preview>
-                <wizard-stack size="2xl">
+                <clippy-stack size="2xl">
                   <clippy-heading level="2">Signaal</clippy-heading>
+                  <wizard-token-docs groups="basis.color.info, basis.color.positive, basis.color.negative, basis.color.warning" heading-level="3"></wizard-token-docs>
                   <wizard-color-system-preview groups="info, positive, negative, warning"></wizard-color-system-preview>
-
                   <TokenStoryMatches groups="basis.color.info, basis.color.info-inverse, basis.color.positive, basis.color.positive-inverse, basis.color.negative, basis.color.negative-inverse, basis.color.warning, basis.color.warning-inverse" />
-                </wizard-stack>
+                </clippy-stack>
               </clippy-story-preview>
             </section>
 
             <section>
               <clippy-story-preview>
-                <wizard-stack size="2xl">
+                <clippy-stack size="2xl">
                   <clippy-heading level="2">Overig</clippy-heading>
+                  <wizard-token-docs groups="basis.color.highlight, basis.color.selected" heading-level="3"></wizard-token-docs>
                   <wizard-color-system-preview groups="highlight, selected"></wizard-color-system-preview>
-
                   <TokenStoryMatches groups="basis.color.highlight, basis.color.highlight-inverse, basis.color.selected, basis.color.selected-inverse" />
-                </wizard-stack>
+                </clippy-stack>
               </clippy-story-preview>
             </section>
 
-          </wizard-stack>
-        </wizard-stack>
+          </clippy-stack>
+        </clippy-stack>
       </wizard-container>
     </wizard-layout>
   </theme-wizard-app>

--- a/packages/theme-wizard-website/src/pages/style-guide/spacing-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/spacing-system.astro
@@ -12,6 +12,7 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
   import '@nl-design-system-community/clippy-components/clippy-code';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-spacing';
   import '@nl-design-system-community/clippy-components/clippy-reset-theme';
+  import '@nl-design-system-community/clippy-components/clippy-stack';
   import '@nl-design-system-community/clippy-components/clippy-story-preview';
   import '@nl-design-system-community/clippy-components/clippy-heading';
 </script>
@@ -23,17 +24,16 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
       <StyleGuideNav />
 
       <wizard-container slot="main">
-        <wizard-stack size="5xl">
+        <clippy-stack size="5xl">
           <clippy-heading level="1">Witruimte systeem</clippy-heading>
 
           {concepts.map(concept => (
             <clippy-story-preview>
-              <wizard-stack size="5xl">
-                <clippy-heading level="2">{capitalize(concept)}</clippy-heading>
-                {/* TODO: add documentation partials here, from https://nldesignsystem.nl/richtlijnen/stijl/ruimte/spacing-concepten/ */}
-                <wizard-stack size="5xl">
+              <clippy-stack size="5xl">
+                <wizard-token-docs groups={`basis.space.${concept}`} heading-level="2"></wizard-token-docs>
+                <clippy-stack size="5xl">
                   {scale.map((size) => (
-                    <wizard-stack size="3xl">
+                    <clippy-stack size="3xl">
                       <clippy-heading level="3">{capitalize(size)}</clippy-heading>
                       <clippy-code>
                         <wizard-token-value path={`basis.space.${concept}.${size}`}></wizard-token-value>
@@ -44,14 +44,14 @@ const concepts = ['inline', 'block', 'text', 'column', 'row']
                         </wizard-preview-theme>
                       </clippy-reset-theme>
                       <TokenStoryMatches groups={`basis.space.${concept}.${size}`} />
-                    </wizard-stack>
+                    </clippy-stack>
                   ))}
-                </wizard-stack>
-              </wizard-stack>
+                </clippy-stack>
+              </clippy-stack>
             </clippy-story-preview>
           ))}
 
-        </wizard-stack>
+        </clippy-stack>
       </wizard-container>
     </wizard-layout>
   </theme-wizard-app>

--- a/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
+++ b/packages/theme-wizard-website/src/pages/style-guide/typography-system.astro
@@ -13,6 +13,7 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
 <script>
   import '@nl-design-system-community/clippy-components/clippy-code';
   import '@nl-design-system-community/clippy-components/clippy-graph-paper';
+  import '@nl-design-system-community/clippy-components/clippy-stack';
   import '@nl-design-system-community/clippy-components/clippy-token-sample-text';
 </script>
 
@@ -23,16 +24,15 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
       <StyleGuideNav />
 
       <wizard-container slot="main">
-        <wizard-stack size="5xl">
+        <clippy-stack size="5xl">
           <clippy-heading level="1">Typografie systeem</clippy-heading>
 
-          <wizard-stack size="4xl">
-            <clippy-heading level="2">Lettertype</clippy-heading>
-            <wizard-stack size="3xl">
-              {fontFamilies.map((family) => (
-                <clippy-story-preview>
-                  <wizard-stack size="2xl">
-                    <clippy-heading level="3">{capitalize(family)}</clippy-heading>
+          <clippy-story-preview>
+            <clippy-stack size="5xl">
+              <clippy-heading level="2">Lettertype</clippy-heading>
+                {fontFamilies.map((family) => (
+                  <clippy-stack size="2xl">
+                    <wizard-token-docs groups={`basis.text.font-family.${family}`} heading-level="3"></wizard-token-docs>
                     <clippy-code>
                       <wizard-token-value path={`basis.text.font-family.${family}`}></wizard-token-value>
                     </clippy-code>
@@ -46,89 +46,82 @@ const lineHeights = ['sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const;
                       </clippy-reset-theme>
                     </clippy-graph-paper>
                     <TokenStoryMatches groups={`basis.text.font-family.${family}`} />
-                  </wizard-stack>
-                </clippy-story-preview>
+                  </clippy-stack>
               ))}
-            </wizard-stack>
-          </wizard-stack>
+          </clippy-stack>
+        </clippy-story-preview>
 
-          <wizard-stack size="4xl">
+        <clippy-story-preview>
+          <clippy-stack size="5xl">
             <clippy-heading level="2">Lettergewicht</clippy-heading>
-            <wizard-stack size="3xl">
               {fontWeights.map((weight) => (
-                <clippy-story-preview>
-                  <wizard-stack size="2xl">
-                    <clippy-heading level="3">{capitalize(weight)}</clippy-heading>
-                    <clippy-code>
-                      <wizard-token-value path={`basis.text.font-weight.${weight}`}></wizard-token-value>
-                    </clippy-code>
-                    <clippy-graph-paper>
-                      <clippy-reset-theme>
-                        <wizard-preview-theme>
-                          <clippy-token-sample-text font-weight={`var(--basis-text-font-weight-${weight})`} truncate>
-                            Op brute wijze ving de schooljuf de quasi-kalme lynx.
-                          </clippy-token-sample-text>
-                        </wizard-preview-theme>
-                      </clippy-reset-theme>
-                    </clippy-graph-paper>
-                    <TokenStoryMatches groups={`basis.text.font-weight.${weight}`} />
-                  </wizard-stack>
-                </clippy-story-preview>
-              ))}
-            </wizard-stack>
-          </wizard-stack>
-
-          <wizard-stack size="4xl">
-            <clippy-heading level="2">Lettergrootte</clippy-heading>
-            <wizard-stack size="3xl">
-              {fontSizes.map((size) => (
-                <clippy-story-preview>
-                  <wizard-stack size="2xl">
-                    <clippy-heading level="3">{capitalize(size)}</clippy-heading>
-                    <clippy-code>
-                      <wizard-token-value path={`basis.text.font-size.${size}`}></wizard-token-value>
-                    </clippy-code>
-                    <clippy-graph-paper>
-                      <clippy-reset-theme>
-                        <wizard-preview-theme>
-                          <clippy-token-sample-text font-size={`var(--basis-text-font-size-${size})`} truncate>
-                            Op brute wijze ving de schooljuf de quasi-kalme lynx.
-                          </clippy-token-sample-text>
-                        </wizard-preview-theme>
-                      </clippy-reset-theme>
-                    </clippy-graph-paper>
-                    <TokenStoryMatches groups={`basis.text.font-size.${size}`} />
-                  </wizard-stack>
-                </clippy-story-preview>
-              ))}
-            </wizard-stack>
-          </wizard-stack>
-
-          <wizard-stack size="4xl">
-            <clippy-heading level="2">Regelhoogte</clippy-heading>
-            <wizard-stack size="3xl">
-              {lineHeights.map((lineHeight) => (
-                <clippy-story-preview>
-                  <wizard-stack size="2xl">
-                    <clippy-heading level="3">{capitalize(lineHeight)}</clippy-heading>
-                    <clippy-code>
-                      <wizard-token-value path={`basis.text.line-height.${lineHeight}`}></wizard-token-value>
-                    </clippy-code>
+                <clippy-stack size="2xl">
+                  <wizard-token-docs groups={`basis.text.font-weight.${weight}`} heading-level="3"></wizard-token-docs>
+                  <clippy-code>
+                    <wizard-token-value path={`basis.text.font-weight.${weight}`}></wizard-token-value>
+                  </clippy-code>
+                  <clippy-graph-paper>
                     <clippy-reset-theme>
                       <wizard-preview-theme>
-                        <clippy-token-sample-text line-height={`var(--basis-text-line-height-${lineHeight})`} truncate>
+                        <clippy-token-sample-text font-weight={`var(--basis-text-font-weight-${weight})`} truncate>
                           Op brute wijze ving de schooljuf de quasi-kalme lynx.
                         </clippy-token-sample-text>
                       </wizard-preview-theme>
                     </clippy-reset-theme>
-                    <TokenStoryMatches groups={`basis.text.line-height.${lineHeight}`} />
-                  </wizard-stack>
-                </clippy-story-preview>
+                  </clippy-graph-paper>
+                  <TokenStoryMatches groups={`basis.text.font-weight.${weight}`} />
+                </clippy-stack>
               ))}
-            </wizard-stack>
-          </wizard-stack>
+          </clippy-stack>
+        </clippy-story-preview>
 
-        </wizard-stack>
+        <clippy-story-preview>
+          <clippy-stack size="5xl">
+            <wizard-token-docs groups="basis.text.font-size" heading-level="2"></wizard-token-docs>
+              {fontSizes.map((size) => (
+                <clippy-stack size="2xl">
+                  <clippy-heading level="3">{capitalize(size)}</clippy-heading>
+                  <clippy-code>
+                    <wizard-token-value path={`basis.text.font-size.${size}`}></wizard-token-value>
+                  </clippy-code>
+                  <clippy-graph-paper>
+                    <clippy-reset-theme>
+                      <wizard-preview-theme>
+                        <clippy-token-sample-text font-size={`var(--basis-text-font-size-${size})`} truncate>
+                          Op brute wijze ving de schooljuf de quasi-kalme lynx.
+                        </clippy-token-sample-text>
+                      </wizard-preview-theme>
+                    </clippy-reset-theme>
+                  </clippy-graph-paper>
+                  <TokenStoryMatches groups={`basis.text.font-size.${size}`} />
+                </clippy-stack>
+              ))}
+          </clippy-stack>
+        </clippy-story-preview>
+
+        <clippy-story-preview>
+          <clippy-stack size="5xl">
+            <wizard-token-docs groups="basis.text.line-height" heading-level="2"></wizard-token-docs>
+              {lineHeights.map((lineHeight) => (
+                <clippy-stack size="2xl">
+                  <clippy-heading level="3">{capitalize(lineHeight)}</clippy-heading>
+                  <clippy-code>
+                    <wizard-token-value path={`basis.text.line-height.${lineHeight}`}></wizard-token-value>
+                  </clippy-code>
+                  <clippy-reset-theme>
+                    <wizard-preview-theme>
+                      <clippy-token-sample-text line-height={`var(--basis-text-line-height-${lineHeight})`} truncate>
+                        Op brute wijze ving de schooljuf de quasi-kalme lynx.
+                      </clippy-token-sample-text>
+                    </wizard-preview-theme>
+                  </clippy-reset-theme>
+                  <TokenStoryMatches groups={`basis.text.line-height.${lineHeight}`} />
+                </clippy-stack>
+              ))}
+            </clippy-stack>
+          </clippy-story-preview>
+
+        </clippy-stack>
       </wizard-container>
     </wizard-layout>
   </theme-wizard-app>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,10 +952,10 @@ importers:
     dependencies:
       '@astrojs/react':
         specifier: 6.0.2
-        version: 6.0.2(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(tsx@4.21.0)(yaml@2.9.0)
+        version: 6.0.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@astrojs/vercel':
         specifier: 11.0.4
-        version: 11.0.4(astro@7.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(@vercel/blob@2.4.0)(@vercel/functions@3.7.7(ws@8.21.2))(tsx@4.21.0)(yaml@2.9.0))(react@19.2.8)(supports-color@10.2.2)(ws@8.21.2)
+        version: 11.0.4(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@vercel/functions@3.7.7))(react@19.2.8)
       '@fontsource/fira-sans':
         specifier: 5.3.0
         version: 5.3.0
@@ -970,7 +970,7 @@ importers:
         version: 1.1.0
       '@nl-design-system-candidate/button-react':
         specifier: 1.1.0
-        version: 1.1.0(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.1.0(react@19.2.8)
       '@nl-design-system-candidate/button-tokens':
         specifier: 1.0.0
         version: 1.0.0
@@ -979,7 +979,7 @@ importers:
         version: 1.2.0
       '@nl-design-system-candidate/code-block-react':
         specifier: 1.4.0
-        version: 1.4.0(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.4.0(react@19.2.8)
       '@nl-design-system-candidate/code-block-tokens':
         specifier: 2.0.3
         version: 2.0.3
@@ -991,7 +991,7 @@ importers:
         version: 1.1.2
       '@nl-design-system-candidate/code-react':
         specifier: 2.0.0
-        version: 2.0.0(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 2.0.0(react@19.2.8)
       '@nl-design-system-candidate/code-tokens':
         specifier: 3.0.0
         version: 3.0.0
@@ -1003,7 +1003,7 @@ importers:
         version: 1.2.2
       '@nl-design-system-candidate/color-sample-react':
         specifier: 1.2.2
-        version: 1.2.2(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.2.2(react@19.2.8)
       '@nl-design-system-candidate/color-sample-tokens':
         specifier: 2.0.3
         version: 2.0.3
@@ -1012,7 +1012,7 @@ importers:
         version: 1.0.5
       '@nl-design-system-candidate/data-badge-react':
         specifier: 1.1.7
-        version: 1.1.7(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.1.7(react@19.2.8)
       '@nl-design-system-candidate/data-badge-tokens':
         specifier: 2.0.3
         version: 2.0.3
@@ -1021,7 +1021,7 @@ importers:
         version: 1.1.3
       '@nl-design-system-candidate/heading-react':
         specifier: 1.1.7
-        version: 1.1.7(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.1.7(react@19.2.8)
       '@nl-design-system-candidate/heading-tokens':
         specifier: 1.1.2
         version: 1.1.2
@@ -1033,7 +1033,7 @@ importers:
         version: 1.2.1
       '@nl-design-system-candidate/link-react':
         specifier: 1.1.8
-        version: 1.1.8(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.1.8(react@19.2.8)
       '@nl-design-system-candidate/link-tokens':
         specifier: 3.0.3
         version: 3.0.3
@@ -1045,7 +1045,7 @@ importers:
         version: 1.2.1
       '@nl-design-system-candidate/mark-react':
         specifier: 1.1.7
-        version: 1.1.7(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.1.7(react@19.2.8)
       '@nl-design-system-candidate/mark-tokens':
         specifier: 2.0.3
         version: 2.0.3
@@ -1054,7 +1054,7 @@ importers:
         version: 1.1.5
       '@nl-design-system-candidate/number-badge-react':
         specifier: 1.3.2
-        version: 1.3.2(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.3.2(react@19.2.8)
       '@nl-design-system-candidate/number-badge-tokens':
         specifier: 2.0.3
         version: 2.0.3
@@ -1063,7 +1063,7 @@ importers:
         version: 2.1.3
       '@nl-design-system-candidate/paragraph-react':
         specifier: 2.2.2
-        version: 2.2.2(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 2.2.2(react@19.2.8)
       '@nl-design-system-candidate/paragraph-tokens':
         specifier: 1.1.3
         version: 1.1.3
@@ -1072,7 +1072,7 @@ importers:
         version: 1.0.5
       '@nl-design-system-candidate/skip-link-react':
         specifier: 1.1.7
-        version: 1.1.7(@babel/runtime@7.29.7)(react@19.2.8)
+        version: 1.1.7(react@19.2.8)
       '@nl-design-system-candidate/skip-link-tokens':
         specifier: 1.0.4
         version: 1.0.4
@@ -1096,7 +1096,7 @@ importers:
         version: 1.4.7
       '@storybook/react-vite':
         specifier: 10.5.6
-        version: 10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.6(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0))
+        version: 10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.0(esbuild@0.28.1))
       '@tabler/icons-react':
         specifier: 3.46.0
         version: 3.46.0(react@19.2.8)
@@ -1111,7 +1111,7 @@ importers:
         version: 1.1.1
       astro:
         specifier: 7.1.6
-        version: 7.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(@vercel/blob@2.4.0)(@vercel/functions@3.7.7(ws@8.21.2))(tsx@4.21.0)(yaml@2.9.0)
+        version: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@vercel/functions@3.7.7)
       dequal:
         specifier: 2.0.3
         version: 2.0.3
@@ -9259,6 +9259,14 @@ snapshots:
   '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
     optional: true
 
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
   '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
@@ -9273,6 +9281,21 @@ snapshots:
   '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
     optional: true
 
+  '@astrojs/compiler-binding@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    optionalDependencies:
+      '@astrojs/compiler-binding-darwin-arm64': 0.3.2
+      '@astrojs/compiler-binding-darwin-x64': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-musl': 0.3.2
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.2
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.3.2
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   '@astrojs/compiler-binding@0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)':
     optionalDependencies:
       '@astrojs/compiler-binding-darwin-arm64': 0.3.2
@@ -9284,6 +9307,13 @@ snapshots:
       '@astrojs/compiler-binding-wasm32-wasi': 0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
       '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.2
       '@astrojs/compiler-binding-win32-x64-msvc': 0.3.2
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/compiler-rs@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@astrojs/compiler-binding': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -9371,6 +9401,32 @@ snapshots:
       - tsx
       - yaml
 
+  '@astrojs/react@6.0.2(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.2
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+      '@vitejs/plugin-react': 5.2.0(vite@8.2.0(esbuild@0.28.1))
+      devalue: 5.9.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      ultrahtml: 1.7.0
+      vite: 8.2.0(esbuild@0.28.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@astrojs/telemetry@3.3.3':
     dependencies:
       ci-info: 4.4.0
@@ -9378,14 +9434,14 @@ snapshots:
       is-docker: 4.0.0
       package-manager-detector: 1.8.0
 
-  '@astrojs/vercel@11.0.4(astro@7.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(@vercel/blob@2.4.0)(@vercel/functions@3.7.7(ws@8.21.2))(tsx@4.21.0)(yaml@2.9.0))(react@19.2.8)(supports-color@10.2.2)(ws@8.21.2)':
+  '@astrojs/vercel@11.0.4(astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@vercel/functions@3.7.7))(react@19.2.8)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@vercel/analytics': 1.6.1(react@19.2.8)
-      '@vercel/functions': 3.7.7(ws@8.21.2)
-      '@vercel/nft': 1.10.2(supports-color@10.2.2)
+      '@vercel/functions': 3.7.7
+      '@vercel/nft': 1.10.2
       '@vercel/routing-utils': 5.3.3
-      astro: 7.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(@vercel/blob@2.4.0)(@vercel/functions@3.7.7(ws@8.21.2))(tsx@4.21.0)(yaml@2.9.0)
+      astro: 7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@vercel/functions@3.7.7)
       esbuild: 0.28.1
       tinyglobby: 0.2.17
     transitivePeerDependencies:
@@ -9413,6 +9469,26 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
@@ -9460,6 +9536,13 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
@@ -9473,6 +9556,15 @@ snapshots:
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -9502,9 +9594,19 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
   '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.24.8':
@@ -9528,6 +9630,18 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -10467,6 +10581,12 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(vite@8.2.0(esbuild@0.28.1))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0
+      vite: 8.2.0(esbuild@0.28.1)
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10647,6 +10767,19 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.5
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@mapbox/node-pre-gyp@2.0.3(supports-color@10.2.2)':
     dependencies:
       consola: 3.4.2
@@ -10731,6 +10864,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
@@ -10760,13 +10900,17 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.8
 
+  '@nl-design-system-candidate/button-react@1.1.0(react@19.2.8)':
+    dependencies:
+      clsx: 2.1.1
+      react: 19.2.8
+
   '@nl-design-system-candidate/button-tokens@1.0.0': {}
 
   '@nl-design-system-candidate/code-block-css@1.2.0': {}
 
-  '@nl-design-system-candidate/code-block-react@1.4.0(@babel/runtime@7.29.7)(react@19.2.8)':
+  '@nl-design-system-candidate/code-block-react@1.4.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
       '@nl-design-system-candidate/code-block-css': 1.2.0
       clsx: 2.1.1
       react: 19.2.8
@@ -10777,9 +10921,8 @@ snapshots:
 
   '@nl-design-system-candidate/code-docs@1.1.2': {}
 
-  '@nl-design-system-candidate/code-react@2.0.0(@babel/runtime@7.29.7)(react@19.2.8)':
+  '@nl-design-system-candidate/code-react@2.0.0(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
       '@nl-design-system-candidate/code-css': 3.0.0
       react: 19.2.8
 
@@ -10789,18 +10932,16 @@ snapshots:
 
   '@nl-design-system-candidate/color-sample-docs@1.2.2': {}
 
-  '@nl-design-system-candidate/color-sample-react@1.2.2(@babel/runtime@7.29.7)(react@19.2.8)':
+  '@nl-design-system-candidate/color-sample-react@1.2.2(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@nl-design-system-candidate/color-sample-tokens@2.0.3': {}
 
   '@nl-design-system-candidate/data-badge-css@1.0.5': {}
 
-  '@nl-design-system-candidate/data-badge-react@1.1.7(@babel/runtime@7.29.7)(react@19.2.8)':
+  '@nl-design-system-candidate/data-badge-react@1.1.7(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@nl-design-system-candidate/data-badge-tokens@2.0.3': {}
@@ -10810,6 +10951,10 @@ snapshots:
   '@nl-design-system-candidate/heading-react@1.1.7(@babel/runtime@7.29.7)(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
+      react: 19.2.8
+
+  '@nl-design-system-candidate/heading-react@1.1.7(react@19.2.8)':
+    dependencies:
       react: 19.2.8
 
   '@nl-design-system-candidate/heading-tokens@1.1.2': {}
@@ -10824,15 +10969,19 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.8
 
+  '@nl-design-system-candidate/link-react@1.1.8(react@19.2.8)':
+    dependencies:
+      clsx: 2.1.1
+      react: 19.2.8
+
   '@nl-design-system-candidate/link-tokens@3.0.3': {}
 
   '@nl-design-system-candidate/mark-css@1.0.5': {}
 
   '@nl-design-system-candidate/mark-docs@1.2.1': {}
 
-  '@nl-design-system-candidate/mark-react@1.1.7(@babel/runtime@7.29.7)(react@19.2.8)':
+  '@nl-design-system-candidate/mark-react@1.1.7(react@19.2.8)':
     dependencies:
-      '@babel/runtime': 7.29.7
       react: 19.2.8
 
   '@nl-design-system-candidate/mark-tokens@2.0.3': {}
@@ -10842,6 +10991,10 @@ snapshots:
   '@nl-design-system-candidate/number-badge-react@1.3.2(@babel/runtime@7.29.7)(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
+      react: 19.2.8
+
+  '@nl-design-system-candidate/number-badge-react@1.3.2(react@19.2.8)':
+    dependencies:
       react: 19.2.8
 
   '@nl-design-system-candidate/number-badge-tokens@2.0.3': {}
@@ -10854,6 +11007,11 @@ snapshots:
       clsx: 2.1.1
       react: 19.2.8
 
+  '@nl-design-system-candidate/paragraph-react@2.2.2(react@19.2.8)':
+    dependencies:
+      clsx: 2.1.1
+      react: 19.2.8
+
   '@nl-design-system-candidate/paragraph-tokens@1.1.3': {}
 
   '@nl-design-system-candidate/skip-link-css@1.0.5': {}
@@ -10861,6 +11019,11 @@ snapshots:
   '@nl-design-system-candidate/skip-link-react@1.1.7(@babel/runtime@7.29.7)(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.29.7
+      clsx: 2.1.1
+      react: 19.2.8
+
+  '@nl-design-system-candidate/skip-link-react@1.1.7(react@19.2.8)':
+    dependencies:
       clsx: 2.1.1
       react: 19.2.8
 
@@ -11331,6 +11494,16 @@ snapshots:
       - rollup
       - webpack
 
+  '@storybook/builder-vite@10.5.6(esbuild@0.28.1)(vite@8.2.0(esbuild@0.28.1))':
+    dependencies:
+      '@storybook/csf-plugin': 10.5.6(esbuild@0.28.1)(vite@8.2.0(esbuild@0.28.1))
+      ts-dedent: 2.3.0
+      vite: 8.2.0(esbuild@0.28.1)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
   '@storybook/csf-plugin@10.5.6(esbuild@0.28.1)(storybook@10.5.6(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       storybook: 10.5.6(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
@@ -11339,11 +11512,26 @@ snapshots:
       esbuild: 0.28.1
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@storybook/csf-plugin@10.5.6(esbuild@0.28.1)(vite@8.2.0(esbuild@0.28.1))':
+    dependencies:
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.1
+      vite: 8.2.0(esbuild@0.28.1)
+
   '@storybook/global@5.0.0': {}
 
   '@storybook/icons@2.1.0(react@19.2.8)':
     dependencies:
       react: 19.2.8
+
+  '@storybook/react-dom-shim@10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@storybook/react-dom-shim@10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.6(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
     dependencies:
@@ -11378,6 +11566,42 @@ snapshots:
       - rollup
       - supports-color
       - webpack
+
+  '@storybook/react-vite@10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.0(esbuild@0.28.1))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(vite@8.2.0(esbuild@0.28.1))
+      '@rollup/pluginutils': 5.4.0
+      '@storybook/builder-vite': 10.5.6(esbuild@0.28.1)(vite@8.2.0(esbuild@0.28.1))
+      '@storybook/react': 10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      empathic: 2.0.1
+      magic-string: 0.30.21
+      react: 19.2.8
+      react-docgen: 8.0.3
+      react-dom: 19.2.8(react@19.2.8)
+      resolve: 1.22.12
+      tsconfig-paths: 4.2.0
+      vite: 8.2.0(esbuild@0.28.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - supports-color
+      - webpack
+
+  '@storybook/react@10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
+      react-docgen: 8.0.3
+      react-docgen-typescript: 2.4.0
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+    transitivePeerDependencies:
+      - supports-color
 
   '@storybook/react@10.5.6(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.6(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
@@ -12575,11 +12799,16 @@ snapshots:
       - encoding
       - supports-color
 
+  '@vercel/functions@3.7.7':
+    dependencies:
+      '@vercel/oidc': 3.8.2
+
   '@vercel/functions@3.7.7(ws@8.21.2)':
     dependencies:
       '@vercel/oidc': 3.8.2
     optionalDependencies:
       ws: 8.21.2
+    optional: true
 
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     dependencies:
@@ -12668,9 +12897,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/nft@1.10.2(supports-color@10.2.2)':
+  '@vercel/nft@1.10.2':
     dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3(supports-color@10.2.2)
+      '@mapbox/node-pre-gyp': 2.0.3
       '@rollup/pluginutils': 5.4.0
       acorn: 8.18.0
       acorn-import-attributes: 1.9.5(acorn@8.18.0)
@@ -12822,6 +13051,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@5.2.0(vite@8.2.0(esbuild@0.28.1))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 8.2.0(esbuild@0.28.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13196,6 +13437,98 @@ snapshots:
       js-tokens: 10.0.0
 
   astral-regex@2.0.0: {}
+
+  astro@7.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@vercel/functions@3.7.7):
+    dependencies:
+      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+      '@astrojs/internal-helpers': 0.10.2
+      '@astrojs/markdown-satteri': 0.3.5
+      '@astrojs/telemetry': 3.3.3
+      '@capsizecss/unpack': 4.0.1
+      '@clack/prompts': 1.7.0
+      '@oslojs/encoding': 1.1.0
+      '@rollup/pluginutils': 5.4.0
+      am-i-vibing: 0.4.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 2.0.0
+      cookie: 2.0.1
+      devalue: 5.9.0
+      diff: 8.0.4
+      dset: 3.1.4
+      es-module-lexer: 2.3.1
+      esbuild: 0.28.1
+      flattie: 1.1.1
+      fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      js-yaml: 4.3.1
+      jsonc-parser: 3.3.1
+      magic-string: 1.1.0
+      magicast: 0.5.4
+      mrmime: 2.0.1
+      neotraverse: 1.0.1
+      obug: 2.1.4
+      p-limit: 7.3.1
+      p-queue: 9.3.3
+      package-manager-detector: 1.8.0
+      piccolore: 0.1.3
+      picomatch: 4.0.5
+      semver: 7.8.5
+      shiki: 4.4.2
+      smol-toml: 1.7.1
+      svgo: 4.0.2
+      tinyclip: 0.1.15
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      ultrahtml: 1.7.0
+      unifont: 0.7.4
+      unstorage: 1.17.5(@vercel/functions@3.7.7)
+      vite: 8.2.0(esbuild@0.28.1)
+      vitefu: 1.1.3(vite@8.2.0(esbuild@0.28.1))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 22.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      sharp: 0.35.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - rollup
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - uploadthing
+      - yaml
 
   astro@7.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@24.13.3)(@vercel/blob@2.4.0)(@vercel/functions@3.7.7(ws@8.21.2))(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
@@ -13681,6 +14014,10 @@ snapshots:
       ms: 2.1.2
     optionalDependencies:
       supports-color: 10.2.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -14734,6 +15071,13 @@ snapshots:
       url-join: 4.0.1
     transitivePeerDependencies:
       - debug
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.2.2):
@@ -16262,9 +16606,26 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  react-docgen-typescript@2.4.0: {}
+
   react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  react-docgen@8.0.3:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.12
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   react-docgen@8.0.3(supports-color@10.2.2):
     dependencies:
@@ -16623,6 +16984,39 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setprototypeof@1.1.1: {}
+
+  sharp@0.35.3:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+    optional: true
 
   sharp@0.35.3(@types/node@24.13.3):
     dependencies:
@@ -17399,6 +17793,19 @@ snapshots:
       '@vercel/blob': 2.4.0
       '@vercel/functions': 3.7.7(ws@8.21.2)
 
+  unstorage@1.17.5(@vercel/functions@3.7.7):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      '@vercel/functions': 3.7.7
+
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
       browserslist: 4.28.7
@@ -17532,9 +17939,24 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
+  vite@8.2.0(esbuild@0.28.1):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+
   vitefu@1.1.3(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0)
+
+  vitefu@1.1.3(vite@8.2.0(esbuild@0.28.1)):
+    optionalDependencies:
+      vite: 8.2.0(esbuild@0.28.1)
 
   vitest@4.1.10(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(esbuild@0.28.1)(tsx@4.21.0)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
- New `<wizard-token-docs groups="basis.color.default, basis.color.accent-1, basis.color.accent-2, basis.color.accent-3" skip-redundant-groups="basis.color.accent-2, basis.color.accent-3" heading-level="3">` element
  - shows intro docs for all tokens in `groups`
  - except for the redundant ones listed in `skip-redundant-groups`
- Updates `/basis-tokens` to use this component instead of it's own outdated solution
- Convert style guide pages from `<wizard-stack>` to `<clippy-stack>`
- Makes style guide pages more consistent in layout by wrapping each _section_ in its own `clippy-story-preview` instead of each separate _value_.

Reviewing with whitespace disabled is recommended because of element reshuffling.