### PR TITLE
feat: add `countUsagePerToken` and `addTokenCountExtensions` to design-tokens-schema

### DIFF
--- a/packages/design-tokens-schema/src/index.ts
+++ b/packages/design-tokens-schema/src/index.ts
@@ -14,5 +14,6 @@ export * from './resolve-refs';
 export * from './reuse-tokens';
 export * from './stringify-token';
 export * from './theme';
+export * from './token-usage';
 export * from './upgrade-legacy-tokens';
 export * from './walker';

--- a/packages/design-tokens-schema/src/theme.ts
+++ b/packages/design-tokens-schema/src/theme.ts
@@ -328,6 +328,9 @@ export const ThemeSchema = z.unknown().transform(preprocessTheme).pipe(ThemeShap
 
 export type Theme = z.infer<typeof ThemeShapeSchema>;
 
+/** Like Theme, but less restrictive and less inference based */
+export type ThemeLike = Record<string, unknown>;
+
 const getActualValue = <TValue>(token: { $value: TValue; $extensions?: Record<string, unknown> }): TValue => {
   return (token.$extensions?.[EXTENSION_RESOLVED_AS] as TValue) ?? token.$value;
 };

--- a/packages/design-tokens-schema/src/token-usage.test.ts
+++ b/packages/design-tokens-schema/src/token-usage.test.ts
@@ -138,6 +138,22 @@ describe('addTokenCountExtensions', () => {
 
     const result = addTokenCountExtensions(tokens);
 
-    expect(result).toBe(tokens);
+    expect(result).toEqual(tokens);
+  });
+
+  it('skips usage extension when the tracked usage path does not resolve to a token', () => {
+    // References are resolved with a `brand.` prefix fallback (see isTokenWithRef), so a ref
+    // like `{primary}` resolves to `brand.primary`, but the usage map still stores the
+    // unprefixed path `primary`, which does not exist at the root of `tokens`.
+    const primary: BaseDesignToken = { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } };
+    const tokens = {
+      alias: { $type: 'color', $value: '{primary}' },
+      brand: { primary },
+    };
+
+    const result = addTokenCountExtensions(tokens);
+
+    expect(primary.$extensions).toBeUndefined();
+    expect(result).toEqual(tokens);
   });
 });

--- a/packages/design-tokens-schema/src/token-usage.test.ts
+++ b/packages/design-tokens-schema/src/token-usage.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import type { BaseDesignToken } from './tokens/base-token';
+import {
+  countUsagePerToken,
+  addTokenCountExtensions,
+  EXTENSION_REFERENCED_AT,
+  EXTENSION_REFERENCE_COUNT,
+} from './token-usage';
+
+describe('countUsagePerToken', () => {
+  it('maps a referenced token id to the path of its referencer', () => {
+    const tokens = {
+      alias: { $type: 'color', $value: '{brand.primary}' },
+      brand: {
+        primary: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+      },
+    };
+
+    const usage = countUsagePerToken(tokens);
+
+    expect(usage.get('brand.primary')).toEqual(['alias']);
+  });
+
+  it('collects paths from multiple tokens referencing the same token', () => {
+    const tokens = {
+      brand: {
+        primary: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+      },
+      button: {
+        background: { $type: 'color', $value: '{brand.primary}' },
+      },
+      link: {
+        color: { $type: 'color', $value: '{brand.primary}' },
+      },
+    };
+
+    const usage = countUsagePerToken(tokens);
+
+    expect(usage.get('brand.primary')).toEqual(['button.background', 'link.color']);
+  });
+
+  it('does not include tokens that are never referenced', () => {
+    const tokens = {
+      alias: { $type: 'color', $value: '{brand.primary}' },
+      brand: {
+        primary: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+        secondary: { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 1, 0] } },
+      },
+    };
+
+    const usage = countUsagePerToken(tokens);
+
+    expect(usage.has('brand.secondary')).toBe(false);
+  });
+
+  it('ignores refs that live inside $extensions', () => {
+    const tokens = {
+      alias: {
+        $extensions: {
+          shadow: { $type: 'color', $value: '{brand.primary}' },
+        },
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 0, 0] },
+      },
+      brand: {
+        primary: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+      },
+    };
+
+    const usage = countUsagePerToken(tokens);
+
+    expect(usage.has('brand.primary')).toBe(false);
+  });
+
+  it('returns an empty map when there are no refs', () => {
+    const tokens = {
+      brand: {
+        primary: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+      },
+    };
+
+    const usage = countUsagePerToken(tokens);
+
+    expect(usage.size).toBe(0);
+  });
+});
+
+describe('addTokenCountExtensions', () => {
+  it('adds referenced-in and reference-count extensions to a referenced token', () => {
+    const primary: BaseDesignToken = { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } };
+    const tokens = {
+      alias: { $type: 'color', $value: '{brand.primary}' },
+      brand: { primary },
+    };
+
+    addTokenCountExtensions(tokens);
+
+    expect(primary.$extensions).toEqual({
+      [EXTENSION_REFERENCE_COUNT]: 1,
+      [EXTENSION_REFERENCED_AT]: ['alias'],
+    });
+  });
+
+  it('sums up all referencing paths for reference-count', () => {
+    const primary: BaseDesignToken = { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } };
+    const tokens = {
+      brand: { primary },
+      button: {
+        background: { $type: 'color', $value: '{brand.primary}' },
+      },
+      link: {
+        color: { $type: 'color', $value: '{brand.primary}' },
+      },
+    };
+
+    addTokenCountExtensions(tokens);
+
+    expect(primary.$extensions?.[EXTENSION_REFERENCE_COUNT]).toBe(2);
+    expect(primary.$extensions?.[EXTENSION_REFERENCED_AT]).toEqual(['button.background', 'link.color']);
+  });
+
+  it('leaves unreferenced tokens without extensions', () => {
+    const primary: BaseDesignToken = { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } };
+    const tokens = { brand: { primary } };
+
+    addTokenCountExtensions(tokens);
+
+    expect(primary.$extensions).toBeUndefined();
+  });
+
+  it('mutates and returns the same input object', () => {
+    const tokens = {
+      alias: { $type: 'color', $value: '{brand.primary}' },
+      brand: {
+        primary: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } },
+      },
+    };
+
+    const result = addTokenCountExtensions(tokens);
+
+    expect(result).toBe(tokens);
+  });
+});

--- a/packages/design-tokens-schema/src/token-usage.ts
+++ b/packages/design-tokens-schema/src/token-usage.ts
@@ -1,0 +1,41 @@
+import dlv from 'dlv';
+import { setExtension } from './extensions';
+import { ThemeLike } from './theme';
+import { extractRef, isTokenLike } from './tokens/token-reference';
+import { walkTokensWithRef } from './walker';
+
+/**
+ * Create a Map of which other tokens reference each token, keyed by referenced token id,
+ * with values being the dot-joined paths of tokens that reference it.
+ */
+export const countUsagePerToken = (tokens: ThemeLike): Map<string, string[]> => {
+  const tokenUsage = new Map<string, string[]>();
+  walkTokensWithRef(tokens, tokens, (token, path) => {
+    const tokenId = extractRef(token.$value);
+    if (path.includes('$extensions')) {
+      return;
+    }
+    const stored = tokenUsage.get(tokenId) || [];
+    stored.push(path.join('.'));
+    tokenUsage.set(tokenId, stored);
+  });
+  return tokenUsage;
+};
+
+export const EXTENSION_REFERENCED_AT = 'nl.nldesignsystem.referenced-at';
+export const EXTENSION_REFERENCE_COUNT = 'nl.nldesignsystem.reference-count';
+
+export const addTokenCountExtensions = (tokens: ThemeLike): ThemeLike => {
+  const usage = countUsagePerToken(tokens);
+
+  for (const [tokenId, usages] of usage) {
+    const token = dlv(tokens, tokenId);
+    if (!isTokenLike(token)) {
+      continue;
+    }
+    setExtension(token, EXTENSION_REFERENCED_AT, usages);
+    setExtension(token, EXTENSION_REFERENCE_COUNT, usages.length);
+  }
+
+  return tokens;
+};

--- a/packages/design-tokens-schema/src/tokens/token-reference.ts
+++ b/packages/design-tokens-schema/src/tokens/token-reference.ts
@@ -1,6 +1,6 @@
 import dlv from 'dlv';
 import * as z from 'zod';
-import { BaseDesignTokenIdentifierSchema, TokenPath, type BaseDesignToken } from './base-token';
+import { BaseDesignTokenIdentifierSchema, TokenPath, type BaseDesignToken, type Extensions } from './base-token';
 
 // A Design Token ref:
 // - Starts with {
@@ -40,7 +40,13 @@ export const isTokenLike = (obj: unknown): obj is BaseDesignToken => {
   return Object.hasOwn(obj, '$value');
 };
 
-export const isTokenGroup = (obj: unknown): obj is Record<string, BaseDesignToken> => {
+export type TokenGroup = {
+  [key: string]: BaseDesignToken | string | Extensions | undefined;
+  $type?: string;
+  $extensions?: Extensions;
+};
+
+export const isTokenGroup = (obj: unknown): obj is TokenGroup => {
   if (!isValueObject(obj)) return false;
   if (Object.hasOwn(obj, '$value')) return false;
   if (Object.hasOwn(obj, '$type') && typeof obj['$type'] !== 'string') return false;

--- a/packages/theme-wizard-app/src/components/wizard-color-system-preview/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-color-system-preview/index.ts
@@ -5,13 +5,14 @@ import '../wizard-table-scroller';
 
 import { arrayFromCommaList } from '@nl-design-system-community/clippy-components/lib/converters';
 import { safeCustomElement } from '@nl-design-system-community/clippy-components/lib/decorators';
+import { countUsagePerToken } from '@nl-design-system-community/design-tokens-schema';
 import { LitElement, html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type Theme from '../../lib/Theme';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
 import { filterRedundantGroups } from '../../lib/ColorScale/siblings';
-import { countUsagePerToken, prepareColorGroups } from '../wizard-style-guide/utils';
+import { prepareColorGroups } from '../wizard-style-guide/utils';
 
 const tag = 'wizard-color-system-preview';
 

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-colors/index.ts
@@ -7,6 +7,7 @@ import '@nl-design-system-community/clippy-components/clippy-toggletip';
 import linkCss from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphCss from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
 import '@nl-design-system-community/clippy-components/clippy-color-sample';
+import { countUsagePerToken } from '@nl-design-system-community/design-tokens-schema';
 import ClipboardCopyIcon from '@tabler/icons/outline/clipboard-copy.svg?raw';
 import buttonLinkStyles from '@utrecht/link-button-css?inline';
 import tableCss from '@utrecht/table-css/dist/index.css?inline';
@@ -19,12 +20,7 @@ import type { DisplayToken } from '../wizard-style-guide/types';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
 import styles from '../wizard-style-guide/styles';
-import {
-  countUsagePerToken,
-  openTokenDialog,
-  prepareColorGroups,
-  renderTokenDialog,
-} from '../wizard-style-guide/utils';
+import { openTokenDialog, prepareColorGroups, renderTokenDialog } from '../wizard-style-guide/utils';
 
 const tag = 'wizard-style-guide-colors';
 

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-spacing/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-spacing/index.ts
@@ -5,7 +5,7 @@ import '@nl-design-system-community/clippy-components/clippy-heading';
 import '@nl-design-system-community/clippy-components/clippy-toggletip';
 import linkCss from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphCss from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
-import { type DimensionToken } from '@nl-design-system-community/design-tokens-schema';
+import { type DimensionToken, countUsagePerToken } from '@nl-design-system-community/design-tokens-schema';
 import ClipboardCopyIcon from '@tabler/icons/outline/clipboard-copy.svg?raw';
 import buttonLinkStyles from '@utrecht/link-button-css?inline';
 import tableCss from '@utrecht/table-css/dist/index.css?inline';
@@ -17,12 +17,7 @@ import type { DisplayToken, SpaceToken } from '../wizard-style-guide/types';
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
 import styles from '../wizard-style-guide/styles';
-import {
-  countUsagePerToken,
-  openTokenDialog,
-  renderSpacingExample,
-  renderTokenDialog,
-} from '../wizard-style-guide/utils';
+import { openTokenDialog, renderSpacingExample, renderTokenDialog } from '../wizard-style-guide/utils';
 
 const tag = 'wizard-style-guide-spacing';
 

--- a/packages/theme-wizard-app/src/components/wizard-style-guide-typography/index.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide-typography/index.ts
@@ -8,7 +8,7 @@ import '@nl-design-system-community/clippy-components/clippy-toggletip';
 import linkCss from '@nl-design-system-candidate/link-css/link.css?inline';
 import paragraphCss from '@nl-design-system-candidate/paragraph-css/paragraph.css?inline';
 import googleFonts from '@nl-design-system-community/clippy-components/assets/google-fonts.json' with { type: 'json' };
-import { type ModernDimensionToken } from '@nl-design-system-community/design-tokens-schema';
+import { type ModernDimensionToken, countUsagePerToken } from '@nl-design-system-community/design-tokens-schema';
 import ClipboardCopyIcon from '@tabler/icons/outline/clipboard-copy.svg?raw';
 import buttonLinkStyles from '@utrecht/link-button-css?inline';
 import tableCss from '@utrecht/table-css/dist/index.css?inline';
@@ -21,7 +21,7 @@ import type { DisplayToken, FontFamilyToken, FontSizeToken } from '../wizard-sty
 import { themeContext } from '../../contexts/theme';
 import { t } from '../../i18n';
 import styles from '../wizard-style-guide/styles';
-import { countUsagePerToken, openTokenDialog, renderTokenDialog } from '../wizard-style-guide/utils';
+import { openTokenDialog, renderTokenDialog } from '../wizard-style-guide/utils';
 
 const tag = 'wizard-style-guide-typography';
 

--- a/packages/theme-wizard-app/src/components/wizard-style-guide/utils.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide/utils.ts
@@ -36,6 +36,7 @@ export function prepareColorGroups(colors: Record<string, unknown>, tokenUsage: 
     });
 }
 
+/** @deprecated use `@nl-design-system-community/design-tokens-schema`'s `countUsagePerToken()` instead */
 export function countUsagePerToken(tokens: DesignTokens): Map<string, string[]> {
   const tokenUsage = new Map<string, string[]>();
   walkTokensWithRef(tokens, tokens, (token, path) => {

--- a/packages/theme-wizard-app/src/components/wizard-style-guide/utils.ts
+++ b/packages/theme-wizard-app/src/components/wizard-style-guide/utils.ts
@@ -2,14 +2,11 @@ import type { ClippyModal } from '@nl-design-system-community/clippy-components/
 import '@nl-design-system-community/clippy-components/clippy-color-sample';
 import '@nl-design-system-community/clippy-components/clippy-modal';
 import '@nl-design-system-community/clippy-components/clippy-heading';
-import type { DesignTokens } from 'style-dictionary/types';
 import {
   type ColorValue,
   type ColorToken as ColorTokenType,
-  extractRef,
   isValueObject,
   stringifyColor,
-  walkTokensWithRef,
 } from '@nl-design-system-community/design-tokens-schema';
 import { html, nothing } from 'lit';
 import type { ColorGroup, DisplayToken } from './types';
@@ -34,19 +31,6 @@ export function prepareColorGroups(colors: Record<string, unknown>, tokenUsage: 
         .filter(({ displayValue }) => displayValue !== null);
       return { colorEntries, key };
     });
-}
-
-/** @deprecated use `@nl-design-system-community/design-tokens-schema`'s `countUsagePerToken()` instead */
-export function countUsagePerToken(tokens: DesignTokens): Map<string, string[]> {
-  const tokenUsage = new Map<string, string[]>();
-  walkTokensWithRef(tokens, tokens, (token, path) => {
-    const tokenId = extractRef(token.$value);
-    if (path.includes('$extensions')) return;
-    const stored = tokenUsage.get(tokenId) || [];
-    stored.push(path.join('.'));
-    tokenUsage.set(tokenId, stored);
-  });
-  return tokenUsage;
 }
 
 export function stringifyTokenValue(token: unknown): string {

--- a/packages/theme-wizard-app/src/lib/ColorScale/siblings.ts
+++ b/packages/theme-wizard-app/src/lib/ColorScale/siblings.ts
@@ -1,4 +1,4 @@
-import { extractRef, isRef, isTokenGroup } from '@nl-design-system-community/design-tokens-schema';
+import { extractRef, isRef, isTokenGroup, isTokenLike } from '@nl-design-system-community/design-tokens-schema';
 
 /**
  * Given a color scale group path (e.g. 'basis.color.accent-1') and its parent group object
@@ -28,8 +28,9 @@ import { extractRef, isRef, isTokenGroup } from '@nl-design-system-community/des
 export function getSiblingGroupsWithOnlyRefsTo(groupPath: string, parentGroup: unknown): string[] {
   if (!parentGroup || typeof parentGroup !== 'object') return [];
 
-  const selfKey = groupPath.split('.').at(-1);
-  const parentPath = groupPath.split('.').slice(0, -1).join('.');
+  const path = groupPath.split('.');
+  const selfKey = path.at(-1);
+  const parentPath = path.slice(0, -1).join('.');
 
   return Object.entries(parentGroup)
     .filter(([siblingKey, siblingGroup]) => {
@@ -39,7 +40,9 @@ export function getSiblingGroupsWithOnlyRefsTo(groupPath: string, parentGroup: u
         Object.entries(siblingGroup)
           .filter(([k]) => !k.startsWith('$')) // skip group-level $type, $extensions, etc.
           // Check that every token's value is a ref starting with groupPath
-          .every(([, token]) => isRef(token.$value) && extractRef(token.$value).startsWith(groupPath))
+          .every(
+            ([, token]) => isTokenLike(token) && isRef(token.$value) && extractRef(token.$value).startsWith(groupPath),
+          )
       );
     })
     .map(([siblingKey]) => `${parentPath}.${siblingKey}`);


### PR DESCRIPTION
Enkele verbeteringen om wat clippy-components te kunnen unblocken om te kunnen laten zien hoe vaak een waar components gebruikt worden.

- 🆕 `type TokenGroup` expliciet exported nu, naast de `isTokenGroup` functie
- 🆕 `type ThemeLike` om de oneindige herhaling van `Record<string, unknown>` te voorkomen en op sommige plekken wat explicieter te zijn
- 🆕 `countUsagePerToken(tokens: ThemeLike)` om een `Map()` te maken van `token.path` de plekken waar de token gebruikt wordt
- 🆕  `addTokenCountExtensions(tokens: ThemeLike)` om `$extensions` toe te voegen met _waar_ de token gebruikt wordt en _hoe vaak_.
- ✅ vervang `theme-wizard-app`'s `countUsagePerToken()` met de design-tokens-schema variant